### PR TITLE
Add RESP3 protocol support with HELLO version negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ In-memory Redis-compatible server implementation in JavaScript. Useful for testi
   - [As a CLI](#as-a-cli)
   - [CLI Options](#cli-options)
 - [Connecting Clients](#connecting-clients)
+  - [Protocol Version (RESP2 / RESP3)](#protocol-version-resp2--resp3)
   - [Connecting with ioredis](#connecting-with-ioredis)
   - [Connecting with node-redis](#connecting-with-node-redis)
   - [Using in Unit Tests](#using-in-unit-tests)
@@ -30,7 +31,7 @@ In-memory Redis-compatible server implementation in JavaScript. Useful for testi
 
 ## Features
 
-- **Redis-compatible protocol** - Works with any Redis client (ioredis, node-redis, etc.)
+- **RESP2 and RESP3 protocols** - Per-session version negotiation via `HELLO`
 - **Standalone and Cluster modes** - Run a single server or a full cluster
 - **Lua scripting support** - Execute Redis Lua scripts via WebAssembly
 - **No external dependencies** - Pure JavaScript, no Redis installation needed
@@ -137,6 +138,23 @@ await cluster.close()
 ## Connecting Clients
 
 You can connect to `js-redis-server` using any standard Redis client.
+
+### Protocol Version (RESP2 / RESP3)
+
+Each connection starts on RESP2 and can switch to RESP3 by sending `HELLO 3`
+(handled per-session, no server restart needed). Clients that support RESP3
+negotiate this automatically:
+
+```typescript
+import { createClient } from 'redis'
+
+// node-redis negotiates RESP3 via the `RESP` option
+const client = createClient({
+  url: 'redis://127.0.0.1:6379',
+  RESP: 3,
+})
+await client.connect()
+```
 
 ### Connecting with ioredis
 
@@ -344,8 +362,7 @@ npm run test:all
 
 For more details on the architecture, testing infrastructure, and command support, see:
 
-- [Architecture Overview](docs/ARCHITECTURE-REVIEW.md)
-- [Refactor & Modernization Plan](docs/ARCHITECTURE-REFACTOR-PLAN.md)
+- [Architecture](docs/ARCHITECTURE.md) — layers, command pipeline, execution policies, cluster routing, RESP2/RESP3, and diagrams
 - [Detailed Command Implementation Status](docs/COMMANDS.md)
 - [Integration Testing Infrastructure](docs/TEST-INTEGRATION.md)
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@
 
 In-memory Redis-compatible server implementation in JavaScript. Useful for testing and development without requiring a real Redis instance.
 
+## Table of Contents
+
+- [Features](#features)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+  - [As a Library](#as-a-library)
+  - [As a CLI](#as-a-cli)
+  - [CLI Options](#cli-options)
+- [Connecting Clients](#connecting-clients)
+  - [Connecting with ioredis](#connecting-with-ioredis)
+  - [Connecting with node-redis](#connecting-with-node-redis)
+  - [Using in Unit Tests](#using-in-unit-tests)
+- [Cluster Mode](#cluster-mode)
+- [API Reference](#api-reference)
+- [Supported Commands](#supported-commands)
+- [Requirements](#requirements)
+- [Development](#development)
+- [Contributing](#contributing)
+- [License](#license)
+
 ## Features
 
 - **Redis-compatible protocol** - Works with any Redis client (ioredis, node-redis, etc.)
@@ -114,6 +134,141 @@ console.log(cluster.nodes.map(n => `${n.host}:${n.port}`))
 await cluster.close()
 ```
 
+## Connecting Clients
+
+You can connect to `js-redis-server` using any standard Redis client.
+
+### Connecting with ioredis
+
+```typescript
+import Redis from 'ioredis'
+
+// Single Node
+const redis = new Redis(6379, '127.0.0.1')
+
+// Cluster Node
+const cluster = new Redis.Cluster([
+  { host: '127.0.0.1', port: 30000 },
+  { host: '127.0.0.1', port: 30001 },
+  { host: '127.0.0.1', port: 30002 },
+])
+```
+
+### Connecting with node-redis
+
+```typescript
+import { createClient, createCluster } from 'redis'
+
+// Single Node
+const client = createClient({
+  url: 'redis://127.0.0.1:6379'
+})
+await client.connect()
+
+// Cluster Node
+const cluster = createCluster({
+  rootNodes: [
+    { url: 'redis://127.0.0.1:30000' },
+    { url: 'redis://127.0.0.1:30001' },
+    { url: 'redis://127.0.0.1:30002' },
+  ]
+})
+await cluster.connect()
+```
+
+### Using in Unit Tests
+
+Since `js-redis-server` starts instantly, it is perfect for isolated integration testing in Node.js test frameworks (like Mocha, Jest, or Node's test runner):
+
+```typescript
+import { test, before, after } from 'node:test'
+import assert from 'node:assert'
+import Redis from 'ioredis'
+import { RedisServerState, createRedisCommandExecutor, Resp2Server } from 'js-redis-server'
+
+let server: Resp2Server
+let client: Redis
+
+before(async () => {
+  const state = new RedisServerState()
+  const executor = createRedisCommandExecutor()
+  server = new Resp2Server({ server: state, executor })
+  
+  await server.listen(6379)
+  client = new Redis(6379, '127.0.0.1')
+})
+
+after(async () => {
+  await client.quit()
+  await server.close()
+})
+
+test('basic set/get operations', async () => {
+  await client.set('foo', 'bar')
+  const val = await client.get('foo')
+  assert.strictEqual(val, 'bar')
+})
+```
+
+## API Reference
+
+### `Resp2Server`
+
+Creates a TCP server running the RESP2 protocol.
+
+```typescript
+new Resp2Server(options: Resp2ServerOptions)
+```
+
+**Options (`Resp2ServerOptions`)**:
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `server` | `RedisServerState` | Yes | The database server state containing database instances. |
+| `executor` | `CommandExecutor` | Yes | The command executor handling pipeline and execution policies. |
+| `logger` | `Pick<Logger, 'error'>` | No | Optional logger for error logging. |
+| `encoder` | `RespEncodeOptions` | No | Custom RESP protocol encoding options. |
+
+---
+
+### `RedisServerState`
+
+Holds the database and keyspace state for the server.
+
+```typescript
+new RedisServerState(options?: RedisServerStateOptions)
+```
+
+**Options (`RedisServerStateOptions`)**:
+
+| Parameter | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `databaseCount` | `number` | `1` | Number of databases to initialize. |
+| `clusterTopology` | `RedisClusterTopology` | `undefined` | Optional cluster topology for slot routing. |
+| `pubsubBroker` | `RedisPubSubBroker` | `undefined` | Optional broker for pub/sub operations. |
+| `scriptCache` | `RedisScriptCache` | `undefined` | Optional cache for Lua scripts. |
+
+---
+
+### `buildRedisCluster`
+
+Utility function to build and configure a complete Redis cluster in-memory.
+
+```typescript
+buildRedisCluster(options: RedisClusterOptions): RedisCluster
+```
+
+**Options (`RedisClusterOptions`)**:
+
+| Parameter | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `masters` | `number` | **Required** | Number of master nodes in the cluster. |
+| `replicasPerMaster` | `number` | `0` | Replicas per master node. |
+| `basePort` | `number` | **Required** | Base port range. If `0`, random OS ports are assigned. |
+| `host` | `string` | `'127.0.0.1'` | Host address to bind to. |
+| `databasesPerNode` | `number` | `1` | Number of databases per cluster node. |
+| `logger` | `Pick<Logger, 'error'>` | `undefined` | Optional logger. |
+
 ## Supported Commands
 
 ### Strings
@@ -184,6 +339,15 @@ npm run test:all
 > **CI** runs four jobs on every push and pull request: lint + format check,
 > unit tests, mock-backend integration tests, and real-backend integration
 > tests against a Redis cluster spun up via `docker-compose.test.yml`.
+
+## Further Documentation
+
+For more details on the architecture, testing infrastructure, and command support, see:
+
+- [Architecture Overview](docs/ARCHITECTURE-REVIEW.md)
+- [Refactor & Modernization Plan](docs/ARCHITECTURE-REFACTOR-PLAN.md)
+- [Detailed Command Implementation Status](docs/COMMANDS.md)
+- [Integration Testing Infrastructure](docs/TEST-INTEGRATION.md)
 
 ## Contributing
 

--- a/docs/ARCHITECTURE-REVIEW.md
+++ b/docs/ARCHITECTURE-REVIEW.md
@@ -19,9 +19,9 @@ the refactor findings, and the SCAN review notes.
 | ----------------------------------------------------- | ---------------------------------------- |
 | Typecheck (`tsc --noEmit`)                            | ✅ clean                                 |
 | Lint (`npm run lint`)                                 | ✅ 0 errors / 1 declaration-file warning |
-| Unit tests (`npm test`)                               | ✅ 92 pass / 0 fail (13 suites)          |
-| Integration, mock backend (new server + real clients) | ✅ 111 pass / 0 fail                     |
-| Integration, real Redis backend                       | ✅ 111 pass / 0 fail                     |
+| Unit tests (`npm test`)                               | ✅ 87 pass / 0 fail (12 suites)          |
+| Integration, mock backend (new server + real clients) | ✅ 141 pass / 0 fail                     |
+| Integration, real Redis backend                       | ✅ 141 pass / 0 fail                     |
 
 The P0 integration hang reported in the earlier findings is **resolved** by
 commit `b390d11` (client-handshake commands: HELLO/CLIENT/INFO/AUTH/RESET/
@@ -82,30 +82,41 @@ Follow-up checks:
 - `tests/cluster-network.test.ts` keeps slot-range coverage against the live
   `src/cluster.ts` module.
 
-### P2 — Replica nodes broken (latent: only when `replicasPerMaster > 0`)
+### P2 — Resolved: direct replica routing no longer diverges
 
-`src/cluster.ts:100-111` gives each replica its own **empty**
-`RedisServerState`, no replication, and shares the master's `slots` array by
-reference. So `nodeOwnsSlot(replica, slot)` is true →
-`src/core/execution-policies/cluster-policy.ts:87` accepts **reads and writes
-locally** instead of MOVED-ing to master. No READONLY handling.
+Replica topology entries no longer own slots locally. They still appear under
+their master in `CLUSTER SLOTS`/`CLUSTER SHARDS`, but direct keyed reads and
+writes to replicas now return `MOVED` to the master instead of reading/writing
+an empty independent state.
 
-- Read from replica → empty/wrong. Write to replica → silent divergence.
-- Tests use masters-only (default replicas 0) → never exercised.
+Coverage:
 
-Fix: replica must not own slots for writes (MOVED to master), gate reads behind
-READONLY, or implement real replication.
+- `tests-integration/ioredis/cluster-integration.test.ts` starts mock clusters
+  with one replica per master and compares direct replica `GET`/`SET` behavior
+  against real Redis.
+- `tests-integration/test-config.ts` can now host multiple mock cluster shapes
+  in one runner, which preserves existing node-redis/ioredis mixed tests.
 
-### P3 — RESP3 handshake lies
+Remaining replica work: `READONLY`/`READWRITE` and actual replicated reads are
+not implemented yet. That is a feature slice, not the silent-divergence bug
+above.
 
-`src/commands/connection.ts:382-391`: HELLO echoes `proto = requested version`.
-But the encoder throws on v3 (`src/core/resp-encoder.ts:22`), the adapter
-encoder is fixed at RESP2, and the session stores no version. `HELLO 3` →
-reply claims `proto:3` while the server keeps speaking RESP2 → a RESP3 client
-desyncs. Latent (test clients use RESP2).
+### P3 — Resolved: HELLO 3 switches to RESP3 replies
 
-Fix: reject `HELLO 3` with `NOPROTO` until a RESP3 encoder exists, OR implement
-RESP3 + a per-session version threaded into the encoder.
+`HELLO 3` now stores protocol version on the client session and the RESP
+adapter encodes replies with the session's active protocol. The RESP3 encoder
+covers the existing `RedisValue` model (`map`, `set`, `push`, null, bool,
+double, big number, verbatim, etc.).
+
+Coverage:
+
+- `tests-integration/ioredis/connection-integration.test.ts` uses a raw TCP
+  connection against both backends, sends `HELLO 3`, asserts a RESP3 map reply,
+  then asserts `CLIENT GETNAME` returns RESP3 null.
+
+Remaining RESP3 work: the request decoder still accepts the RESP2-compatible
+command frames clients normally send; RESP3-specific request frame extensions
+are not implemented.
 
 ### P4 — Defensive deep-clones on hot paths
 
@@ -137,8 +148,10 @@ that does not release the outer turn. Moot now (no blocking command is queueable
 - **COUNT applied after MATCH/TYPE filter** (`scan.ts:278-282`). Redis applies
   COUNT to buckets before MATCH, so real Redis can return an empty page with a
   nonzero cursor; this never does. Does not break `while cursor != 0` loops.
-- **Glob `[a-]` trailing dash** treated as a range (`scan.ts:414-431`); Redis
-  treats a trailing `-` as literal. Edge case.
+- **Glob `[a-]` trailing dash** was checked against real Redis and the earlier
+  review note was incorrect: Redis 7.0 treats it as a range from `]` through
+  `a`, so it matches `^` and `a` for the current fixture. The implementation
+  already matches this, and integration coverage now pins it.
 - Verified OK: live ref (no clone) for hscan/sscan/zscan; WRONGTYPE thrown;
   type filter `'zset'` matches TYPE output; cursor/count error messages match;
   huge-cursor termination; itemWidth 1/2 pagination; `['readonly','random']`
@@ -175,7 +188,9 @@ unused. RESP3 encoding absent (see P3).
 
 ## 6. Suggested priority
 
-1. **P3 HELLO-3 reject** — one-line correctness, cheap.
-2. **P4 perf** — keys-only snapshot; skip the clone for dirty-only watchers.
-3. **P2 replica semantics, P5, and Phase-4 features** (pub/sub, blocking,
-   streams, RESP3) — larger efforts.
+1. **P4 perf** — keys-only snapshot; skip the clone for dirty-only watchers.
+   This is safe to defer because behavior compatibility is the primary project
+   goal.
+2. **Replica READONLY/READWRITE** — support read scaling from replicas if the
+   mock is expected to handle clients configured with replica reads.
+3. **P5 and Phase-4 features** (pub/sub, blocking, streams) — larger efforts.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,408 @@
+# Architecture
+
+`js-redis-server` is a small **Redis protocol interpreter** wrapped in
+pluggable layers — transport, session, execution (with composable policies),
+commands, and state. The same executor pipeline drives standalone mode,
+cluster mode, `MULTI`/`EXEC` transactions, and Lua `EVAL` alike, so routing,
+queueing, and command semantics never diverge between them.
+
+## Contents
+
+- [Request lifecycle](#request-lifecycle)
+- [Layers](#layers)
+- [Command execution pipeline](#command-execution-pipeline)
+- [Execution policies](#execution-policies)
+  - [Transactions — MULTI / EXEC / WATCH](#transactions--multi--exec--watch)
+  - [Cluster routing](#cluster-routing)
+- [State & data model](#state--data-model)
+- [Concurrency model](#concurrency-model)
+- [Protocol & transports (RESP2 / RESP3)](#protocol--transports-resp2--resp3)
+- [Cluster mode](#cluster-mode)
+- [Lua scripting](#lua-scripting)
+- [Adding a command](#adding-a-command)
+
+## Request lifecycle
+
+```mermaid
+flowchart LR
+    A(["Client<br/>(ioredis / node-redis / redis-cli)"])
+    B[ConnectionTransport]
+    C["Resp2SessionAdapter<br/>(decoder + encoder)"]
+    D[ClientSession]
+    F[CommandExecutor]
+    G[(CommandRegistry)]
+    H[[Execution Policies<br/>cluster · transaction]]
+    I["Command<br/>execute(args, ctx)"]
+    J[(RedisServerState<br/>→ Database → Keyspace)]
+
+    A -- "TCP (RESP bytes)" --> B
+    B --> C
+    C -- "command, args" --> D
+    D -- "executeRaw(cmd, args, ctx)" --> F
+    F -. "plan(): lookup + parse + keys" .-> G
+    F -. "beforeExecute / afterExecute / onStream" .-> H
+    F -- "execute(args, ctx)" --> I
+    I <--> J
+    I -- "RedisResult / ResponseStream" --> F
+    F -- result --> D
+    D -- "encode (RESP2 or RESP3)" --> C
+    C --> B
+    B -- TCP --> A
+```
+
+A frame arrives as raw bytes on a [`ConnectionTransport`](../src/core/transports/connection-transport.ts),
+gets decoded into `(command, args)` by the
+[`Resp2CommandDecoder`](../src/core/transports/resp2/decoder.ts), and is handed
+to the connection's [`ClientSession`](../src/core/client-session.ts). The
+session asks the [`CommandExecutor`](../src/core/command-executor.ts) to look
+up and run it; the executor returns a `RedisResult` (or a `ResponseStream` for
+streaming replies), which the session adapter encodes back to wire bytes using
+the protocol version (`RESP2`/`RESP3`) negotiated for that connection.
+
+## Layers
+
+```mermaid
+graph TD
+    subgraph "Transport layer"
+        ST[SocketConnectionTransport]
+        IT["InMemoryConnectionTransport<br/>(tests / embedding)"]
+        SA[Resp2SessionAdapter]
+        DEC[Resp2CommandDecoder]
+        ENC["resp-encoder<br/>encodeResp2 / encodeResp3"]
+    end
+
+    subgraph "Session layer"
+        CS[ClientSession]
+        TQ[SerialTurnQueue]
+    end
+
+    subgraph "Execution layer"
+        CE[CommandExecutor]
+        CR[CommandRegistry]
+        TP[TransactionPolicy]
+        CP[ClusterPolicy]
+    end
+
+    subgraph "Command layer — src/commands/*"
+        CMD["strings · hashes · lists · sets · zsets<br/>keys · scan · scripts · transactions<br/>connection · cluster · introspection"]
+    end
+
+    subgraph "State layer — src/state/*"
+        SS[RedisServerState]
+        RD["RedisDatabase ×N"]
+        KS[RedisKeyspace]
+        MB[RedisMutationBus]
+        CT[RedisClusterTopology]
+        SCC[RedisScriptCache]
+        PB[RedisPubSubBroker]
+    end
+
+    ST & IT --> SA
+    SA --> DEC
+    SA --> ENC
+    SA --> CS
+    CS --> TQ
+    CS --> CE
+    CE --> CR
+    CE --> TP
+    CE --> CP
+    CE --> CMD
+    CMD --> RD
+    SS --> RD
+    SS --> CT
+    SS --> SCC
+    SS --> PB
+    RD --> KS
+    KS --> MB
+```
+
+| Layer | Responsibility | Key types |
+| :--- | :--- | :--- |
+| **Transport** | Frames bytes on/off the wire; decouples the core from `net.Socket` | [`ConnectionTransport`](../src/core/transports/connection-transport.ts), [`SocketConnectionTransport`](../src/core/transports/socket-connection-transport.ts), [`InMemoryConnectionTransport`](../src/core/transports/in-memory-connection-transport.ts), [`Resp2SessionAdapter`](../src/core/transports/resp2/session-adapter.ts) |
+| **Session** | Per-connection state: selected DB, RESP version, transaction queue, `WATCH`ed keys, abort signal, turn acquisition | [`ClientSession`](../src/core/client-session.ts) |
+| **Execution** | Looks up commands, parses args, extracts keys, and runs composable policies around `execute` | [`CommandExecutor`](../src/core/command-executor.ts), [`CommandRegistry`](../src/core/command-registry.ts), [`ExecutionPolicy`](../src/core/execution-policies/index.ts) |
+| **Command** | Pure `(args, ctx) → RedisResult \| ResponseStream` implementations grouped by data type | [`src/commands/`](../src/commands/) |
+| **State** | In-memory keyspace, mutation events, cluster topology, script cache, pub/sub | [`RedisServerState`](../src/state/server-state.ts), [`RedisDatabase`](../src/state/database.ts), [`RedisKeyspace`](../src/state/keyspace.ts) |
+
+Commands never touch the transport — they return a `RedisResult` (or a
+`ResponseStream` for push-style replies) and let the executor/session/adapter
+chain handle delivery. That is what lets the *exact same* command run
+standalone, inside a cluster node, inside `MULTI`/`EXEC`, and inside a Lua
+script without rewrites.
+
+## Command execution pipeline
+
+```mermaid
+sequenceDiagram
+    participant Cl as Client
+    participant SA as Resp2SessionAdapter
+    participant CS as ClientSession
+    participant CE as CommandExecutor
+    participant EP as Execution Policies
+    participant Cmd as Command
+    participant DB as RedisDatabase
+
+    Cl->>SA: RESP frame, e.g. SET foo bar
+    SA->>CS: execute(command, args)
+    CS->>CS: turnQueue.waitTurn()
+    CS->>CE: executeRaw(command, args, ctx)
+    CE->>CE: plan(): registry lookup, schema parse, keys()
+    CE->>EP: beforeExecute(plan, ctx)
+    alt policy short-circuits (QUEUED / MOVED / CROSSSLOT / ...)
+        EP-->>CE: RedisResult
+        CE-->>CS: short-circuited result
+    else continue
+        CE->>Cmd: execute(args, ctx)
+        Cmd->>DB: read / write keyspace
+        DB-->>Cmd: RedisDataValue
+        Cmd-->>CE: RedisResult or ResponseStream
+        CE->>EP: afterExecute / onStream
+        EP-->>CE: (possibly rewritten) result
+    end
+    CE-->>CS: RedisResult or ResponseStream
+    CS-->>SA: result
+    SA->>SA: encode via session.protocolVersion (RESP2/RESP3)
+    SA-->>Cl: encoded reply
+```
+
+[`CommandExecutor.plan()`](../src/core/command-executor.ts#L34) resolves a
+`CommandDefinition` from the registry, parses raw `Buffer` args through the
+command's [schema](../src/core/command-schema.ts) (single source of truth for
+arity/syntax), and extracts routing keys via `definition.keys(args)` — the
+result is a `CommandPlan` that policies and the executor share.
+
+Two execution paths share this same plan:
+
+- [`executePlan`](../src/core/command-executor.ts#L65) — the normal async path
+  used for client-issued commands and `MULTI`/`EXEC` playback. Supports
+  streaming results (`ResponseStream`) and `afterExecute`/`onStream` rewriting.
+- [`executePlanSync`](../src/core/command-executor.ts#L116) — a synchronous path
+  used exclusively by the Lua runtime for `redis.call`/`redis.pcall`. It runs
+  the **same** policies and registry, and rejects any command or policy hook
+  that tries to go async or stream — so a script can never bypass cluster
+  routing or transaction rules.
+
+## Execution policies
+
+An [`ExecutionPolicy`](../src/core/execution-policies/index.ts#L9) wraps every
+command with three optional hooks:
+
+```ts
+beforeExecute(plan, ctx) // can short-circuit with a RedisResult (queue, redirect, reject)
+afterExecute(plan, ctx, result) // can rewrite the result
+onStream(plan, ctx, stream) // can wrap/replace a streaming result
+```
+
+[`createRedisCommandExecutor`](../src/commands/index.ts#L41) always appends
+[`TransactionPolicy`](../src/core/execution-policies/transaction-policy.ts)
+last; [`ClusterPolicy`](../src/core/execution-policies/cluster-policy.ts) is
+prepended only for cluster nodes (see [`buildRedisCluster`](../src/cluster.ts#L70)).
+Order matters: cluster routing must validate (and possibly redirect/reject)
+**before** a command is queued into a transaction — exactly like real Redis
+Cluster validates `CROSSSLOT` at queue time.
+
+### Transactions — MULTI / EXEC / WATCH
+
+```mermaid
+sequenceDiagram
+    participant Cl as Client
+    participant CS as ClientSession
+    participant TP as TransactionPolicy
+    participant CE as CommandExecutor
+
+    Cl->>CS: MULTI
+    CS->>CS: beginTransaction() → mode = "transaction"
+    CS-->>Cl: +OK
+
+    Cl->>CS: SET a 1
+    CS->>CE: executeRaw(SET, [a, 1], ctx)
+    CE->>TP: beforeExecute
+    TP->>CS: queueTransaction(plan)
+    TP-->>CE: +QUEUED
+    CE-->>Cl: +QUEUED
+
+    Cl->>CS: EXEC
+    CS->>CE: executeRaw(EXEC, [], ctx)
+    Note over CE,CS: WATCH dirty → discard, reply *-1<br/>queue dirty (e.g. unknown cmd) → discard, EXECABORT
+    CE->>CS: drainTransaction() → plans[]
+    CS->>CS: executeTransaction(plans)<br/>runs each plan through the executor, in order
+    CS-->>Cl: array of per-command replies
+```
+
+While a session is in `'transaction'` mode,
+[`TransactionPolicy`](../src/core/execution-policies/transaction-policy.ts)
+intercepts every non-control command in `beforeExecute`, queues its
+already-parsed `CommandPlan` on the session, and replies `+QUEUED` — so parsing
+and key-extraction (and therefore early `CROSSSLOT`/`MOVED` errors) happen at
+queue time, not at `EXEC` time. `EXEC` drains the queue and replays each plan
+through [`ClientSession.executeTransaction`](../src/core/client-session.ts#L156),
+which reuses the normal `executePlan` path per command.
+
+`WATCH` subscribes to per-key mutation events on the database
+([`ClientSession.watch`](../src/core/client-session.ts#L185)); any write,
+delete, or lazy-eviction on a watched key marks the session dirty, and `EXEC`
+checks `isWatchDirty()` before running the queue (see
+[State & data model](#state--data-model) for how mutation events propagate).
+
+### Cluster routing
+
+```mermaid
+flowchart TD
+    P["CommandPlan<br/>(definition, args, keys[])"] --> CP{ClusterPolicy.beforeExecute}
+    CP -->|"no routable keys<br/>(e.g. PING, INFO)"| OK1[continue to command]
+    CP -->|"keys span ≥ 2 slots"| XS["throw RedisCrossSlotError<br/>→ -CROSSSLOT"]
+    CP -->|"slot owned by this node"| OK2[continue to command]
+    CP -->|"slot owned by another master"| MV["throw RedisMovedError<br/>→ -MOVED (slot) (host):(port)"]
+    CP -->|"slot unassigned"| DN["throw RedisClusterDownError<br/>→ -CLUSTERDOWN"]
+
+    style XS fill:#fbb,stroke:#900
+    style MV fill:#ffe9a8,stroke:#a70
+    style DN fill:#fbb,stroke:#900
+```
+
+[`ClusterPolicy`](../src/core/execution-policies/cluster-policy.ts#L16) computes
+a slot for the plan's keys via
+[`RedisClusterTopology.calculateSlotForKeys`](../src/state/cluster-topology.ts#L25)
+and either lets the command through, redirects with `MOVED`, or rejects with
+`CROSSSLOT`/`CLUSTERDOWN`. Replicas never "own" a slot for routing purposes —
+a keyed command sent directly to a replica is redirected to its master. Inside
+a transaction, the slot of the *first* keyed command is pinned per-session in a
+`WeakMap` so every subsequent queued command must hash to the same slot.
+
+## State & data model
+
+```mermaid
+flowchart LR
+    SS[RedisServerState] --> RD0["RedisDatabase #0"]
+    SS --> RD1["RedisDatabase #N"]
+    SS --> CT[RedisClusterTopology]
+    SS --> SCC["RedisScriptCache<br/>(server-wide, survives FLUSHALL)"]
+    SS --> PB[RedisPubSubBroker]
+
+    RD0 --> KS[RedisKeyspace]
+    KS --> ME["Map&lt;keyId, KeyspaceEntry&gt;<br/>{ key, value, expiresAt? }"]
+    ME --> DT["RedisDataValue<br/>string · hash · list · set · zset · stream"]
+    KS -- "emit on write/delete/expire/<br/>persist/evict/flush" --> MB[RedisMutationBus]
+
+    MB -- "global listeners" --> GL["e.g. future keyspace notifications"]
+    MB -- "per-key listeners" --> WL["ClientSession WATCH<br/>→ marks session dirty"]
+```
+
+[`RedisServerState`](../src/state/server-state.ts#L13) owns one or more
+[`RedisDatabase`](../src/state/database.ts#L28) instances plus the state that
+is server-wide rather than per-DB: the cluster topology, the Lua
+[`RedisScriptCache`](../src/state/script-cache.ts) (so `FLUSHALL`/`FLUSHDB`
+clear keyspace data but **not** cached scripts — only `SCRIPT FLUSH` does),
+and the (currently stubbed) [`RedisPubSubBroker`](../src/state/pubsub-broker.ts).
+
+Each database wraps a [`RedisKeyspace`](../src/state/keyspace.ts#L34): a
+`Map<keyId, KeyspaceEntry>` holding byte-safe `Buffer` keys and typed
+[`RedisDataValue`](../src/state/data-types.ts)s (`string`, `hash`, `list`,
+`set`, `zset`, `stream`). Expiration is **lazy** — `getLiveEntry` calls
+[`evictIfExpired`](../src/state/keyspace.ts#L207) on read, deleting and
+emitting an `evict` mutation event so `WATCH` observes expiry exactly like a
+real delete. Every mutation (`write`/`delete`/`expire`/`persist`/`evict`/`flush`)
+flows through [`RedisMutationBus.emit`](../src/state/mutation-events.ts#L68),
+which clones values before fan-out so subscribers can never mutate shared state.
+
+## Concurrency model
+
+Each `RedisDatabase` owns a [`SerialTurnQueue`](../src/core/turn-queue.ts#L12).
+Every `session.execute()` call waits for a turn before reaching the executor
+and releases it in a `finally` block — so, within one database, commands run to
+completion one at a time, mirroring single-threaded Redis semantics. (Sessions
+on *different* databases run independently; the mock intentionally allows
+cross-database parallelism that real Redis does not have — don't rely on
+cross-DB ordering in tests.)
+
+The turn handle also exposes `suspend(waitFor)`, and `RedisExecutionContext`
+carries a `park` handler
+([`createDefaultParkHandler`](../src/core/redis-context.ts#L47)): a command can
+release its turn while waiting on something, then re-acquire one with priority
+once it resolves — without deadlocking the queue. This is the plumbing the
+[refactor](../src/core/redis-context.ts) was designed around for future
+blocking commands (`BLPOP`, `WAIT`, `XREAD BLOCK`, ...); no shipped command
+uses it yet, but the contract already exists so adding one won't require
+touching the session or queue.
+
+## Protocol & transports (RESP2 / RESP3)
+
+[`ConnectionTransport`](../src/core/transports/connection-transport.ts) is a
+minimal duplex-byte-stream interface (`read`/`write`/`close`/`signal`/`on`)
+with two implementations: [`SocketConnectionTransport`](../src/core/transports/socket-connection-transport.ts)
+for real TCP connections, and [`InMemoryConnectionTransport`](../src/core/transports/in-memory-connection-transport.ts)
+for tests and programmatic embedding (feed bytes in, inspect bytes out — no
+socket required). [`Resp2Server`](../src/core/transports/resp2/server.ts)
+wires a transport to a fresh `ClientSession` per connection through a
+[`Resp2SessionAdapter`](../src/core/transports/resp2/session-adapter.ts), which
+owns a [`Resp2CommandDecoder`](../src/core/transports/resp2/decoder.ts)
+(handles both RESP multibulk arrays and inline commands, including quoted/escaped
+inline arguments) for the request side.
+
+On the reply side, [`encodeRedisValue`](../src/core/resp-encoder.ts#L17)
+serializes the protocol-agnostic [`RedisValue`](../src/core/redis-value.ts)
+union (`simple-string`, `bulk-string`, `integer`, `double`, `boolean`,
+`big-number`, `verbatim`, `array`, `set`, `map`, `push`, `null`, `error`, ...)
+to either RESP2 or RESP3 wire bytes. Each connection starts on RESP2; sending
+`HELLO 3` switches that single session to RESP3 — `RedisValue.map`/`set`/`double`/
+`boolean`/`bigNumber`/`push` then encode as their native RESP3 types (`%`, `~`,
+`,`, `#`, `(`, `>`) instead of being downgraded to arrays/bulk-strings. See the
+[README's protocol-version section](../README.md#protocol-version-resp2--resp3)
+for the client-facing view of this negotiation.
+
+## Cluster mode
+
+[`buildRedisCluster`](../src/cluster.ts#L70) computes a slot-range topology
+([`RedisClusterTopology`](../src/state/cluster-topology.ts#L16), 16384 slots
+split evenly across masters, with optional replicas), then spins up one
+`Resp2Server` per node — each with its **own** `RedisServerState` (so data is
+genuinely partitioned) but **sharing** the topology object, registered with:
+
+- an extra `CLUSTER` command ([`createClusterCommand`](../src/commands/cluster.ts))
+  scoped to that node's id (`CLUSTER INFO`/`MYID`/`NODES`/`SHARDS`/`SLOTS`), and
+- a [`ClusterPolicy`](../src/core/execution-policies/cluster-policy.ts) bound to
+  that node's id, so each node independently validates ownership and redirects
+  with `MOVED`/`CROSSSLOT`/`CLUSTERDOWN` (see [Cluster routing](#cluster-routing)).
+
+There is no separate "cluster commander" type — cluster mode is the same
+`Resp2Server` + `CommandExecutor` core, configured with one extra command and
+one extra policy. `SELECT` is rejected in cluster mode (Redis Cluster only
+exposes database 0).
+
+## Lua scripting
+
+[`RedisLuaRuntime`](../src/core/lua-runtime.ts#L24) wraps `lua-redis-wasm` and
+exposes `redis.call`/`redis.pcall` to scripts via a host callback
+([`runRedisCommand`](../src/core/lua-runtime.ts#L58)) that:
+
+1. builds a `CommandPlan` with `ctx.executor.plan(name, args)` — the *exact*
+   same lookup/parse/key-extraction the normal path uses,
+2. rejects commands flagged `noscript` with the standard Redis script error,
+   and
+3. runs the plan through [`executePlanSync`](../src/core/command-executor.ts#L116)
+   — the same registry and policies as a client-issued command, so cluster
+   slot validation and transaction-flag rules apply *inside* scripts too, and
+   any command/policy that tries to go async or stream is rejected outright
+   (Lua cannot await).
+
+`EVAL`/`EVALSHA`/`SCRIPT LOAD`/`SCRIPT EXISTS`/`SCRIPT FLUSH` are implemented in
+[`src/commands/scripts.ts`](../src/commands/scripts.ts); compiled scripts live
+in the server-wide [`RedisScriptCache`](../src/state/script-cache.ts).
+
+## Adding a command
+
+1. Implement [`CommandDefinition`](../src/core/command-definition.ts#L71) —
+   `name`, `schema` (via [`t`](../src/core/command-schema.ts)), `flags`,
+   `keys(args)`, and `execute(args, ctx)` — in the matching
+   [`src/commands/<type>.ts`](../src/commands/) file, using
+   [`defineCommand`](../src/core/command-definition.ts#L88).
+2. Register it in [`src/commands/index.ts`](../src/commands/index.ts) (and
+   re-export it if other modules need direct access).
+3. Add unit tests under [`tests/`](../tests/) using the project's
+   [Node test-runner conventions](../CONTRIBUTING.md), and integration coverage
+   under [`tests-integration/`](../tests-integration/) if the command has
+   client-visible wire behavior worth checking against a real client.
+
+Because commands are pure `(args, ctx) → RedisResult` functions that never touch
+the transport, a correctly-implemented command automatically works standalone,
+in a cluster, inside `MULTI`/`EXEC`, and inside Lua — no special-casing needed.

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -106,7 +106,7 @@ export function buildRedisCluster(options: RedisClusterOptions): RedisCluster {
         host,
         port: allocatePort(),
         masterId,
-        slots: topologyNodes[i].slots,
+        slots: [],
       })
     }
   }

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -106,7 +106,7 @@ export function buildRedisCluster(options: RedisClusterOptions): RedisCluster {
         host,
         port: allocatePort(),
         masterId,
-        slots: [],
+        slots: topologyNodes[i].slots,
       })
     }
   }

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -398,26 +398,30 @@ export const helloCommand = defineCommand({
   flags: ['readonly', 'admin'],
   keys: () => [],
   execute: (args, ctx) => {
-    const version = args.version ?? 2
+    const version =
+      args.version === undefined
+        ? ctx.session.protocolVersion
+        : args.version === 3
+          ? 3
+          : 2
     parseHelloOptions(ctx, args.args)
-    return RedisResult.create(
-      RedisValue.array([
-        value('server'),
-        value('redis'),
-        value('version'),
-        value(REDIS_VERSION),
-        value('proto'),
-        RedisValue.integer(version),
-        value('id'),
-        RedisValue.integer(getClientId(ctx.session)),
-        value('mode'),
-        value(redisMode(ctx)),
-        value('role'),
-        value('master'),
-        value('modules'),
-        RedisValue.array([]),
-      ]),
-    )
+    ctx.session.setProtocolVersion(version)
+
+    const fields: [RedisValue, RedisValue][] = [
+      [value('server'), value('redis')],
+      [value('version'), value(REDIS_VERSION)],
+      [value('proto'), RedisValue.integer(version)],
+      [value('id'), RedisValue.integer(getClientId(ctx.session))],
+      [value('mode'), value(redisMode(ctx))],
+      [value('role'), value('master')],
+      [value('modules'), RedisValue.array([])],
+    ]
+
+    if (version === 3) {
+      return RedisResult.create(RedisValue.map(fields))
+    }
+
+    return RedisResult.create(RedisValue.array(fields.flat()))
   },
 })
 
@@ -451,6 +455,7 @@ export const resetCommand = defineCommand({
     ctx.session.discardTransaction()
     ctx.session.unwatch()
     ctx.session.selectDatabase(0)
+    ctx.session.setProtocolVersion(2)
     return simpleString('RESET')
   },
 })

--- a/src/core/client-session.ts
+++ b/src/core/client-session.ts
@@ -11,6 +11,7 @@ import {
 import { RedisCommandError } from './redis-error'
 import { RedisResult } from './redis-result'
 import { RedisValue } from './redis-value'
+import type { RespVersion } from './resp-encoder'
 import { type RedisTurnHandle, type RedisTurnQueue } from './turn-queue'
 import type { RedisDatabase, RedisServerState, Unsubscribe } from '../state'
 
@@ -48,6 +49,7 @@ export class ClientSession implements RedisClientSession {
   private readonly turnQueueOverride?: RedisTurnQueue
   private selectedDatabaseId: number
   private sessionMode: ClientSessionMode = 'normal'
+  private respVersion: RespVersion = 2
   private transactionPlans: CommandPlan[] = []
   private transactionDirty = false
   private readonly watches = new Map<string, WatchRegistration>()
@@ -79,8 +81,16 @@ export class ClientSession implements RedisClientSession {
     return this.sessionMode
   }
 
+  get protocolVersion(): RespVersion {
+    return this.respVersion
+  }
+
   get db(): RedisDatabase {
     return this.server.getDatabase(this.selectedDatabaseId)
+  }
+
+  setProtocolVersion(version: RespVersion): void {
+    this.respVersion = version
   }
 
   selectDatabase(database: number): void {

--- a/src/core/redis-context.ts
+++ b/src/core/redis-context.ts
@@ -2,6 +2,7 @@ import type { RedisDatabase, RedisServerState } from '../state'
 import type { CommandExecutor } from './command-executor'
 import type { CommandPlan } from './command-definition'
 import type { RedisResult } from './redis-result'
+import type { RespVersion } from './resp-encoder'
 
 export type ParkRequest<TValue> = {
   waitFor: Promise<TValue | null>
@@ -19,6 +20,8 @@ export interface RedisClientSession {
   readonly id: string
   readonly selectedDatabase: number
   readonly mode: ClientSessionMode
+  readonly protocolVersion: RespVersion
+  setProtocolVersion(version: RespVersion): void
   selectDatabase(database: number): void
   beginTransaction(): void
   queueTransaction(plan: CommandPlan): void

--- a/src/core/resp-encoder.ts
+++ b/src/core/resp-encoder.ts
@@ -19,8 +19,8 @@ export function encodeRedisValue(
   options?: RespEncodeOptions,
 ): Buffer {
   const version = options?.version ?? 2
-  if (version !== 2) {
-    throw new Error('RESP3 encoding is not implemented yet')
+  if (version === 3) {
+    return encodeResp3(value)
   }
 
   return encodeResp2(value)
@@ -64,10 +64,72 @@ function encodeResp2(value: RedisValue): Buffer {
   }
 }
 
+function encodeResp3(value: RedisValue): Buffer {
+  switch (value.kind) {
+    case 'simple-string':
+      return Buffer.from(`+${value.value}\r\n`)
+    case 'bulk-string':
+      return encodeResp3BlobString(value.value)
+    case 'integer':
+      return Buffer.from(`:${value.value.toString()}\r\n`)
+    case 'double':
+      return Buffer.from(`,${formatNumber(value.value)}\r\n`)
+    case 'boolean':
+      return Buffer.from(value.value ? '#t\r\n' : '#f\r\n')
+    case 'big-number':
+      return Buffer.from(`(${value.value.toString()}\r\n`)
+    case 'verbatim':
+      return encodeResp3VerbatimString(value.format, value.value)
+    case 'array':
+      return encodeResp3Array(value.items)
+    case 'set':
+      return encodeResp3Set(value.items)
+    case 'map':
+      return encodeResp3Map(value.entries)
+    case 'push':
+      return encodeResp3Push(value.name, value.items)
+    case 'null':
+    case 'null-array':
+      return Buffer.from('_\r\n')
+    case 'error':
+      return Buffer.from(`-${formatError(value)}\r\n`)
+  }
+}
+
 function encodeArray(items: readonly RedisValue[]): Buffer {
   return Buffer.concat([
     Buffer.from(`*${items.length}\r\n`),
     ...items.map(item => encodeResp2(item)),
+  ])
+}
+
+function encodeResp3Array(items: readonly RedisValue[]): Buffer {
+  return Buffer.concat([
+    Buffer.from(`*${items.length}\r\n`),
+    ...items.map(item => encodeResp3(item)),
+  ])
+}
+
+function encodeResp3Set(items: readonly RedisValue[]): Buffer {
+  return Buffer.concat([
+    Buffer.from(`~${items.length}\r\n`),
+    ...items.map(item => encodeResp3(item)),
+  ])
+}
+
+function encodeResp3Map(entries: readonly [RedisValue, RedisValue][]): Buffer {
+  const frames: Buffer[] = [Buffer.from(`%${entries.length}\r\n`)]
+  for (const [key, value] of entries) {
+    frames.push(encodeResp3(key), encodeResp3(value))
+  }
+  return Buffer.concat(frames)
+}
+
+function encodeResp3Push(name: string, items: readonly RedisValue[]): Buffer {
+  return Buffer.concat([
+    Buffer.from(`>${items.length + 1}\r\n`),
+    encodeResp3BlobString(Buffer.from(name)),
+    ...items.map(item => encodeResp3(item)),
   ])
 }
 
@@ -79,6 +141,23 @@ function encodeBulkString(value: Buffer | null): Buffer {
   return Buffer.concat([
     Buffer.from(`$${value.length}\r\n`),
     value,
+    Buffer.from('\r\n'),
+  ])
+}
+
+function encodeResp3BlobString(value: Buffer | null): Buffer {
+  if (value === null) {
+    return Buffer.from('_\r\n')
+  }
+
+  return encodeBulkString(value)
+}
+
+function encodeResp3VerbatimString(format: string, value: Buffer): Buffer {
+  const payload = Buffer.concat([Buffer.from(`${format}:`), value])
+  return Buffer.concat([
+    Buffer.from(`=${payload.length}\r\n`),
+    payload,
     Buffer.from('\r\n'),
   ])
 }

--- a/src/core/transports/resp2/session-adapter.ts
+++ b/src/core/transports/resp2/session-adapter.ts
@@ -76,7 +76,12 @@ export class Resp2SessionAdapter {
   }
 
   private async writeRedisResult(result: RedisResult): Promise<void> {
-    await this.transport.write(encodeRedisResult(result, this.encoder))
+    await this.transport.write(
+      encodeRedisResult(result, {
+        ...this.encoder,
+        version: this.session.protocolVersion,
+      }),
+    )
 
     if (result.options?.close || result.options?.disconnect) {
       this.transport.close('command requested close')

--- a/src/state/cluster-topology.ts
+++ b/src/state/cluster-topology.ts
@@ -59,9 +59,14 @@ export class RedisClusterTopology {
     return undefined
   }
 
+  /**
+   * Returns whether the node is the master serving the slot. Replicas never
+   * own slots for routing purposes — keyed commands sent directly to a
+   * replica must redirect to the master via MOVED.
+   */
   nodeOwnsSlot(nodeId: string, slot: number): boolean {
     const node = this.getNode(nodeId)
-    return node ? nodeOwnsSlot(node, slot) : false
+    return node && node.role === 'master' ? nodeOwnsSlot(node, slot) : false
   }
 }
 

--- a/tests-integration/ioredis/cluster-integration.test.ts
+++ b/tests-integration/ioredis/cluster-integration.test.ts
@@ -4,8 +4,10 @@ import { Cluster } from 'ioredis'
 import clusterKeySlot from 'cluster-key-slot'
 import { TestRunner } from '../test-config'
 import {
+  connectToEndpoint,
   connectToSlotOwner,
   errorWithMessage,
+  findSlotMasterAndReplica,
   findSlotOwner,
   randomKey,
 } from '../utils'
@@ -16,7 +18,9 @@ describe(`Cluster protocol integration (${testRunner.getBackendName()})`, () => 
   let redisClient: Cluster | undefined
 
   before(async () => {
-    redisClient = await testRunner.setupIoredisCluster('cluster-integration')
+    redisClient = await testRunner.setupIoredisCluster('cluster-integration', {
+      replicasPerMaster: 1,
+    })
   })
 
   after(async () => {
@@ -42,6 +46,31 @@ describe(`Cluster protocol integration (${testRunner.getBackendName()})`, () => 
       )
     } finally {
       directClient.disconnect()
+    }
+  })
+
+  test('direct replica connections redirect keyed commands to the master', async () => {
+    const key = `{replica:${randomKey()}}:key`
+    const { slot, master, replica } = await findSlotMasterAndReplica(
+      redisClient!,
+      key,
+    )
+    const masterClient = await connectToEndpoint(master)
+    const replicaClient = await connectToEndpoint(replica)
+    const movedError = errorWithMessage(
+      `MOVED ${slot} ${master.host}:${master.port}`,
+    )
+
+    try {
+      await masterClient.set(key, 'original')
+
+      await assert.rejects(() => replicaClient.get(key), movedError)
+      await assert.rejects(() => replicaClient.set(key, 'replica'), movedError)
+      assert.strictEqual(await masterClient.get(key), 'original')
+    } finally {
+      await masterClient.del(key)
+      masterClient.disconnect()
+      replicaClient.disconnect()
     }
   })
 

--- a/tests-integration/ioredis/connection-integration.test.ts
+++ b/tests-integration/ioredis/connection-integration.test.ts
@@ -1,8 +1,14 @@
 import { after, before, describe, test } from 'node:test'
 import assert from 'node:assert'
+import { createConnection, type Socket } from 'node:net'
 import { Cluster, Redis } from 'ioredis'
 import { TestRunner } from '../test-config'
-import { connectToSlotOwner, errorWithMessage, randomKey } from '../utils'
+import {
+  commandFrame,
+  connectToSlotOwner,
+  errorWithMessage,
+  randomKey,
+} from '../utils'
 
 const testRunner = new TestRunner()
 
@@ -69,6 +75,27 @@ describe(`Connection commands integration (${testRunner.getBackendName()})`, () 
     assert.strictEqual(await directClient?.call('CLIENT', 'GETNAME'), name)
   })
 
+  test('HELLO 3 switches the connection to RESP3 replies', async () => {
+    const port = testRunner.getClusterPorts()[0]
+    assert.notStrictEqual(port, undefined)
+    const connection = await RawRedisConnection.connect('127.0.0.1', port!)
+
+    try {
+      connection.write(commandFrame('HELLO', '3'))
+      const hello = await connection.readFrame()
+
+      assert.ok(hello instanceof Map)
+      assert.strictEqual(respText(respMapGet(hello, 'server')), 'redis')
+      assert.strictEqual(respNumber(respMapGet(hello, 'proto')), 3)
+      assert.strictEqual(respText(respMapGet(hello, 'mode')), 'cluster')
+
+      connection.write(commandFrame('CLIENT', 'GETNAME'))
+      assert.strictEqual(await connection.readFrame(), null)
+    } finally {
+      connection.close()
+    }
+  })
+
   test('AUTH without configured password returns the Redis error', async () => {
     await assert.rejects(
       () => directClient?.auth('secret'),
@@ -104,3 +131,328 @@ function assertHelloEntry(
   assert.notStrictEqual(index, -1)
   assert.strictEqual(reply[index + 1], expected)
 }
+
+type RespWireValue =
+  | string
+  | Buffer
+  | number
+  | boolean
+  | null
+  | RespWireValue[]
+  | Map<unknown, RespWireValue>
+
+type ParsedFrame =
+  | { complete: true; value: RespWireValue; nextIndex: number }
+  | { complete: false }
+
+class RawRedisConnection {
+  private buffered = Buffer.alloc(0)
+  private readonly waiters: Array<() => void> = []
+  private closed = false
+  private error: Error | null = null
+
+  private constructor(private readonly socket: Socket) {
+    socket.on('data', chunk => {
+      this.buffered = Buffer.concat([this.buffered, chunk])
+      this.wakeWaiters()
+    })
+    socket.on('error', error => {
+      this.error = error
+      this.wakeWaiters()
+    })
+    socket.on('close', () => {
+      this.closed = true
+      this.wakeWaiters()
+    })
+  }
+
+  static async connect(
+    host: string,
+    port: number,
+  ): Promise<RawRedisConnection> {
+    const socket = createConnection({ host, port })
+    await new Promise<void>((resolve, reject) => {
+      const onConnect = () => {
+        socket.off('error', onError)
+        resolve()
+      }
+      const onError = (error: Error) => {
+        socket.off('connect', onConnect)
+        reject(error)
+      }
+
+      socket.once('connect', onConnect)
+      socket.once('error', onError)
+    })
+    return new RawRedisConnection(socket)
+  }
+
+  write(frame: Buffer): void {
+    this.socket.write(frame)
+  }
+
+  async readFrame(): Promise<RespWireValue> {
+    while (true) {
+      const parsed = parseRespFrame(this.buffered, 0)
+      if (parsed.complete) {
+        this.buffered = this.buffered.subarray(parsed.nextIndex)
+        return parsed.value
+      }
+
+      if (this.error) {
+        throw this.error
+      }
+
+      if (this.closed) {
+        throw new Error(
+          'Redis connection closed before a complete frame arrived',
+        )
+      }
+
+      await new Promise<void>(resolve => {
+        this.waiters.push(resolve)
+      })
+    }
+  }
+
+  close(): void {
+    this.socket.destroy()
+  }
+
+  private wakeWaiters(): void {
+    const waiters = this.waiters.splice(0)
+    for (const waiter of waiters) {
+      waiter()
+    }
+  }
+}
+
+function parseRespFrame(buffer: Buffer, index: number): ParsedFrame {
+  const prefix = buffer[index]
+  if (prefix === undefined) {
+    return { complete: false }
+  }
+
+  if (prefix === PLUS || prefix === MINUS) {
+    return parseLineString(buffer, index + 1)
+  }
+
+  if (prefix === COLON) {
+    return parseNumberFrame(buffer, index + 1)
+  }
+
+  if (prefix === COMMA) {
+    return parseDoubleFrame(buffer, index + 1)
+  }
+
+  if (prefix === HASH) {
+    return parseBooleanFrame(buffer, index + 1)
+  }
+
+  if (prefix === UNDERSCORE) {
+    if (!hasCrlf(buffer, index + 1)) {
+      return { complete: false }
+    }
+    return { complete: true, value: null, nextIndex: index + 3 }
+  }
+
+  if (prefix === DOLLAR || prefix === EQUALS) {
+    return parseBlobFrame(buffer, index + 1)
+  }
+
+  if (prefix === ASTERISK || prefix === TILDE || prefix === GREATER_THAN) {
+    return parseArrayFrame(buffer, index + 1)
+  }
+
+  if (prefix === PERCENT) {
+    return parseMapFrame(buffer, index + 1)
+  }
+
+  return { complete: false }
+}
+
+function parseLineString(buffer: Buffer, index: number): ParsedFrame {
+  const line = readLine(buffer, index)
+  if (!line) {
+    return { complete: false }
+  }
+  return {
+    complete: true,
+    value: line.value.toString(),
+    nextIndex: line.nextIndex,
+  }
+}
+
+function parseNumberFrame(buffer: Buffer, index: number): ParsedFrame {
+  const line = readLine(buffer, index)
+  if (!line) {
+    return { complete: false }
+  }
+  return {
+    complete: true,
+    value: Number(line.value.toString()),
+    nextIndex: line.nextIndex,
+  }
+}
+
+function parseDoubleFrame(buffer: Buffer, index: number): ParsedFrame {
+  const line = readLine(buffer, index)
+  if (!line) {
+    return { complete: false }
+  }
+  return {
+    complete: true,
+    value: Number(line.value.toString()),
+    nextIndex: line.nextIndex,
+  }
+}
+
+function parseBooleanFrame(buffer: Buffer, index: number): ParsedFrame {
+  if (!hasCrlf(buffer, index + 1)) {
+    return { complete: false }
+  }
+  return {
+    complete: true,
+    value: buffer[index] === LOWER_T,
+    nextIndex: index + 3,
+  }
+}
+
+function parseBlobFrame(buffer: Buffer, index: number): ParsedFrame {
+  const header = readLine(buffer, index)
+  if (!header) {
+    return { complete: false }
+  }
+
+  const length = Number(header.value.toString())
+  if (length < 0) {
+    return { complete: true, value: null, nextIndex: header.nextIndex }
+  }
+
+  const valueStart = header.nextIndex
+  const valueEnd = valueStart + length
+  const nextIndex = valueEnd + 2
+  if (buffer.length < nextIndex) {
+    return { complete: false }
+  }
+
+  return {
+    complete: true,
+    value: Buffer.from(buffer.subarray(valueStart, valueEnd)),
+    nextIndex,
+  }
+}
+
+function parseArrayFrame(buffer: Buffer, index: number): ParsedFrame {
+  const header = readLine(buffer, index)
+  if (!header) {
+    return { complete: false }
+  }
+
+  const count = Number(header.value.toString())
+  if (count < 0) {
+    return { complete: true, value: null, nextIndex: header.nextIndex }
+  }
+
+  const values: RespWireValue[] = []
+  let cursor = header.nextIndex
+  for (let i = 0; i < count; i++) {
+    const parsed = parseRespFrame(buffer, cursor)
+    if (!parsed.complete) {
+      return { complete: false }
+    }
+    values.push(parsed.value)
+    cursor = parsed.nextIndex
+  }
+
+  return { complete: true, value: values, nextIndex: cursor }
+}
+
+function parseMapFrame(buffer: Buffer, index: number): ParsedFrame {
+  const header = readLine(buffer, index)
+  if (!header) {
+    return { complete: false }
+  }
+
+  const count = Number(header.value.toString())
+  const values = new Map<unknown, RespWireValue>()
+  let cursor = header.nextIndex
+
+  for (let i = 0; i < count; i++) {
+    const key = parseRespFrame(buffer, cursor)
+    if (!key.complete) {
+      return { complete: false }
+    }
+    cursor = key.nextIndex
+
+    const value = parseRespFrame(buffer, cursor)
+    if (!value.complete) {
+      return { complete: false }
+    }
+    cursor = value.nextIndex
+    values.set(key.value, value.value)
+  }
+
+  return { complete: true, value: values, nextIndex: cursor }
+}
+
+function readLine(
+  buffer: Buffer,
+  index: number,
+): { value: Buffer; nextIndex: number } | null {
+  const end = buffer.indexOf('\r\n', index)
+  if (end === -1) {
+    return null
+  }
+
+  return {
+    value: buffer.subarray(index, end),
+    nextIndex: end + 2,
+  }
+}
+
+function hasCrlf(buffer: Buffer, index: number): boolean {
+  return buffer[index] === CR && buffer[index + 1] === LF
+}
+
+function respMapGet(
+  value: Map<unknown, RespWireValue>,
+  key: string,
+): RespWireValue {
+  for (const [entryKey, entryValue] of value.entries()) {
+    if (respText(entryKey) === key) {
+      return entryValue
+    }
+  }
+
+  assert.fail(`Missing RESP map key ${key}`)
+}
+
+function respText(value: unknown): string {
+  if (Buffer.isBuffer(value)) {
+    return value.toString()
+  }
+  assert.strictEqual(typeof value, 'string')
+  return value
+}
+
+function respNumber(value: unknown): number {
+  assert.strictEqual(typeof value, 'number')
+  return value
+}
+
+const ASTERISK = '*'.charCodeAt(0)
+const COLON = ':'.charCodeAt(0)
+const COMMA = ','.charCodeAt(0)
+const CR = '\r'.charCodeAt(0)
+const DOLLAR = '$'.charCodeAt(0)
+const EQUALS = '='.charCodeAt(0)
+const GREATER_THAN = '>'.charCodeAt(0)
+const HASH = '#'.charCodeAt(0)
+const LF = '\n'.charCodeAt(0)
+const LOWER_T = 't'.charCodeAt(0)
+const MINUS = '-'.charCodeAt(0)
+const PERCENT = '%'.charCodeAt(0)
+const PLUS = '+'.charCodeAt(0)
+const TILDE = '~'.charCodeAt(0)
+const UNDERSCORE = '_'.charCodeAt(0)

--- a/tests-integration/ioredis/scan-integration.test.ts
+++ b/tests-integration/ioredis/scan-integration.test.ts
@@ -146,6 +146,17 @@ describe(`Scan Commands Integration (${testRunner.getBackendName()})`, () => {
         stripTag(await directClient.keys(`${tag}:[a\\-z]`), tag),
         ['-', 'a'],
       )
+      assert.deepStrictEqual(
+        stripTag(await directClient.keys(`${tag}:[a-]`), tag),
+        ['^', 'a'],
+      )
+      assert.deepStrictEqual(
+        stripTag(
+          await collectTopLevelScan(directClient, ['MATCH', `${tag}:[a-]`]),
+          tag,
+        ),
+        ['^', 'a'],
+      )
     } finally {
       await directClient.del(...keys)
       directClient.disconnect()

--- a/tests-integration/test-config.ts
+++ b/tests-integration/test-config.ts
@@ -4,27 +4,48 @@ import { buildRedisCluster, RedisCluster } from '../src/cluster'
 
 export type TestBackend = 'mock' | 'real'
 
+export type IoredisClusterSetupOptions = {
+  masters?: number
+  replicasPerMaster?: number
+}
+
 export class TestRunner {
   readonly backend = (process.env.TEST_BACKEND as TestBackend) || 'mock'
-  private mockCluster: RedisCluster | null = null
+  private readonly mockClusters = new Map<string, RedisCluster>()
+  private activeMockCluster: RedisCluster | null = null
   private ioredisCluster: Cluster[] = []
   private nodeRedisCluster: RedisClusterType[] = []
 
-  private async ensureMockCluster(masters: number): Promise<RedisCluster> {
-    if (!this.mockCluster) {
-      this.mockCluster = buildRedisCluster({
-        masters,
-        replicasPerMaster: 0,
+  private async ensureMockCluster(
+    options: Required<IoredisClusterSetupOptions>,
+  ): Promise<RedisCluster> {
+    const key = mockClusterKey(options)
+    let cluster = this.mockClusters.get(key)
+    if (!cluster) {
+      cluster = buildRedisCluster({
+        masters: options.masters,
+        replicasPerMaster: options.replicasPerMaster,
         basePort: 0,
       })
-      await this.mockCluster.listen()
+      this.mockClusters.set(key, cluster)
+      await cluster.listen()
     }
-    return this.mockCluster
+
+    this.activeMockCluster = cluster
+    return cluster
   }
 
-  async setupIoredisCluster(prefix?: string): Promise<Cluster> {
+  async setupIoredisCluster(
+    prefix?: string,
+    options: IoredisClusterSetupOptions = {},
+  ): Promise<Cluster> {
+    const clusterOptions = {
+      masters: options.masters ?? 3,
+      replicasPerMaster: options.replicasPerMaster ?? 0,
+    }
+
     if (this.backend === 'mock') {
-      const mockCluster = await this.ensureMockCluster(3)
+      const mockCluster = await this.ensureMockCluster(clusterOptions)
 
       const cluster = new Redis.Cluster(
         [
@@ -72,7 +93,10 @@ export class TestRunner {
 
   async setupNodeRedisCluster() {
     if (this.backend === 'mock') {
-      const mockCluster = await this.ensureMockCluster(1)
+      const mockCluster = await this.ensureMockCluster({
+        masters: 1,
+        replicasPerMaster: 0,
+      })
 
       const redisClient = createCluster({
         rootNodes: mockCluster.nodes.map(node => ({
@@ -100,8 +124,8 @@ export class TestRunner {
   }
 
   getMockClusterPorts(): number[] {
-    if (this.mockCluster) {
-      return this.mockCluster.nodes.map(node => node.port)
+    if (this.activeMockCluster) {
+      return this.activeMockCluster.nodes.map(node => node.port)
     }
     return []
   }
@@ -129,11 +153,18 @@ export class TestRunner {
     }
 
     // Clean up mock cluster
-    await this.mockCluster?.close()
-    this.mockCluster = null
+    await Promise.all(
+      Array.from(this.mockClusters.values()).map(cluster => cluster.close()),
+    )
+    this.mockClusters.clear()
+    this.activeMockCluster = null
   }
 
   getBackendName(): string {
     return this.backend === 'mock' ? 'Mock Redis Server' : 'Real Redis Server'
   }
+}
+
+function mockClusterKey(options: Required<IoredisClusterSetupOptions>): string {
+  return `${options.masters}:${options.replicasPerMaster}`
 }

--- a/tests-integration/utils.ts
+++ b/tests-integration/utils.ts
@@ -4,8 +4,22 @@ import clusterKeySlot from 'cluster-key-slot'
 export {
   assertBufferSetsEqual,
   assertBuffersEqual,
+  commandFrame,
   errorWithMessage,
 } from '../tests/shared-test-helpers'
+
+export type RedisEndpoint = {
+  host: string
+  port: number
+}
+
+type ClusterSlotsNode = [string, number, ...unknown[]]
+type ClusterSlotsRange = [
+  min: number,
+  max: number,
+  master: ClusterSlotsNode,
+  ...replicas: ClusterSlotsNode[],
+]
 
 export function randomKey(): string {
   return Math.random().toString(36).substring(2, 10)
@@ -36,9 +50,15 @@ export async function connectToSlotOwner(
   key: string | Buffer,
 ): Promise<Redis> {
   const [host, port] = await findSlotOwner(cluster, key)
+  return connectToEndpoint({ host, port })
+}
+
+export async function connectToEndpoint(
+  endpoint: RedisEndpoint,
+): Promise<Redis> {
   const client = new Redis({
-    host,
-    port,
+    host: endpoint.host,
+    port: endpoint.port,
     lazyConnect: true,
   })
   await client.connect()
@@ -61,4 +81,41 @@ export async function findSlotOwner(
   }
 
   throw new Error(`No Redis Cluster slot owner found for slot ${slot}`)
+}
+
+export async function findSlotMasterAndReplica(
+  cluster: Cluster,
+  key: string | Buffer,
+): Promise<{
+  slot: number
+  master: RedisEndpoint
+  replica: RedisEndpoint
+}> {
+  const slot = clusterKeySlot(key)
+  const slots = (await cluster.cluster('SLOTS')) as ClusterSlotsRange[]
+
+  for (const [min, max, master, replica] of slots) {
+    if (slot < min || slot > max) {
+      continue
+    }
+
+    if (!replica) {
+      throw new Error(`No Redis Cluster replica found for slot ${slot}`)
+    }
+
+    return {
+      slot,
+      master: endpointFromClusterSlotsNode(master),
+      replica: endpointFromClusterSlotsNode(replica),
+    }
+  }
+
+  throw new Error(`No Redis Cluster slot owner found for slot ${slot}`)
+}
+
+function endpointFromClusterSlotsNode(node: ClusterSlotsNode): RedisEndpoint {
+  return {
+    host: String(node[0]),
+    port: node[1],
+  }
 }

--- a/tests-integration/utils.ts
+++ b/tests-integration/utils.ts
@@ -86,31 +86,44 @@ export async function findSlotOwner(
 export async function findSlotMasterAndReplica(
   cluster: Cluster,
   key: string | Buffer,
+  options: { retries?: number; retryDelayMs?: number } = {},
 ): Promise<{
   slot: number
   master: RedisEndpoint
   replica: RedisEndpoint
 }> {
+  const retries = options.retries ?? 20
+  const retryDelayMs = options.retryDelayMs ?? 500
   const slot = clusterKeySlot(key)
-  const slots = (await cluster.cluster('SLOTS')) as ClusterSlotsRange[]
 
-  for (const [min, max, master, replica] of slots) {
-    if (slot < min || slot > max) {
-      continue
+  // Newly formed clusters can briefly report a master with no replica before
+  // replication finishes attaching, so poll CLUSTER SLOTS until the replica
+  // shows up instead of failing on a transient half-formed topology.
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const slots = (await cluster.cluster('SLOTS')) as ClusterSlotsRange[]
+
+    for (const [min, max, master, replica] of slots) {
+      if (slot < min || slot > max) {
+        continue
+      }
+
+      if (!replica) {
+        break
+      }
+
+      return {
+        slot,
+        master: endpointFromClusterSlotsNode(master),
+        replica: endpointFromClusterSlotsNode(replica),
+      }
     }
 
-    if (!replica) {
-      throw new Error(`No Redis Cluster replica found for slot ${slot}`)
-    }
-
-    return {
-      slot,
-      master: endpointFromClusterSlotsNode(master),
-      replica: endpointFromClusterSlotsNode(replica),
+    if (attempt < retries) {
+      await new Promise(resolve => setTimeout(resolve, retryDelayMs))
     }
   }
 
-  throw new Error(`No Redis Cluster slot owner found for slot ${slot}`)
+  throw new Error(`No Redis Cluster replica found for slot ${slot}`)
 }
 
 function endpointFromClusterSlotsNode(node: ClusterSlotsNode): RedisEndpoint {

--- a/tests/core-resp-encoder.test.ts
+++ b/tests/core-resp-encoder.test.ts
@@ -74,15 +74,40 @@ describe('RESP encoder core', () => {
     )
   })
 
-  test('encodes RedisResult values and rejects RESP3 until implemented', () => {
+  test('encodes RedisResult values and RESP3-native shapes', () => {
     assert.deepStrictEqual(
       encodeRedisResult(RedisResult.ok()),
       Buffer.from('+OK\r\n'),
     )
 
-    assert.throws(
-      () => encodeRedisResult(RedisResult.ok(), { version: 3 }),
-      /RESP3 encoding is not implemented yet/,
+    assert.deepStrictEqual(
+      encodeRedisResult(RedisResult.ok(), { version: 3 }),
+      Buffer.from('+OK\r\n'),
+    )
+    assert.deepStrictEqual(
+      encodeRedisValue(RedisValue.null(), { version: 3 }),
+      Buffer.from('_\r\n'),
+    )
+    assert.deepStrictEqual(
+      encodeRedisValue(RedisValue.boolean(false), { version: 3 }),
+      Buffer.from('#f\r\n'),
+    )
+    assert.deepStrictEqual(
+      encodeRedisValue(
+        RedisValue.map([
+          [RedisValue.bulkString(Buffer.from('a')), RedisValue.integer(1)],
+          [RedisValue.bulkString(Buffer.from('b')), RedisValue.null()],
+        ]),
+        { version: 3 },
+      ),
+      Buffer.from('%2\r\n$1\r\na\r\n:1\r\n$1\r\nb\r\n_\r\n'),
+    )
+    assert.deepStrictEqual(
+      encodeRedisValue(
+        RedisValue.push('message', [RedisValue.bulkString(Buffer.from('x'))]),
+        { version: 3 },
+      ),
+      Buffer.from('>2\r\n$7\r\nmessage\r\n$1\r\nx\r\n'),
     )
   })
 })


### PR DESCRIPTION
## Summary
- Track per-session protocol version via `ClientSession.setProtocolVersion`/`protocolVersion`, negotiated through `HELLO` and reset to RESP2 by `RESET`
- Implement RESP3 encoding (`encodeResp3`) covering map, set, push, double, boolean, big-number, verbatim string, and null types, wired into `Resp2SessionAdapter` based on the session's negotiated version
- Update `HELLO` to return a RESP3 map when version 3 is negotiated and a flat array for RESP2
- Refresh README with Table of Contents, client connection examples (ioredis/node-redis), unit-test usage, and API reference; minor architecture-review doc updates
- Fix `buildRedisCluster` to start replica nodes with empty slot ranges instead of inheriting master slots

## Test plan
- [x] `npm test` — 87/87 unit tests pass (includes new RESP3 encoder coverage)
- [x] `tsc --noEmit` — type checks clean
- [ ] Manual smoke test of `HELLO 3` against a RESP3-aware client