### PR TITLE
refactor: delegate Lua script error handling to lua-redis-wasm 1.3.0

### DIFF
--- a/docs/lua-runtime-refactor-plan.md
+++ b/docs/lua-runtime-refactor-plan.md
@@ -133,3 +133,42 @@ the reply; `normalizeLuaReplyError`, `luaRuntimeError`, `normalizeRedisNoArgsErr
   `, on @user_script:1.`; cover with a lib test, not just here.
 - Existing behavior (obs 459) — call/pcall zero-arg messages already matched
   Redis via the regex hack; the lib fix must preserve that exact output.
+
+---
+
+## Implementation status (done)
+
+Shipped against `lua-redis-wasm` `1.3.0` (local source at
+`../redis-lua-wasm`, npm-linked into this repo; **not yet published**).
+
+Design refinement vs the plan: H1 decoration is driven by a new wire tag rather
+than threaded sha. The C abort paths (`luaL_loadbuffer` / `lua_pcall` failures in
+`eval` and `eval_with_args`) emit `REPLY_SCRIPT_ERROR = 0x06`; the engine
+decorates *only* that tag, so call-aborts get `script: <sha>, on @user_script:N.`
+while pcall error *values* the script returns stay clean. The script sha is the
+engine's own `computeSha1Hex` — the project passes none.
+
+- **H1 (done)** — lib owns all error decoration. `eval()` lost its `sha`
+  argument; no sha threading remains in the project.
+- **H2 (done)** — `ReplyValue` error is `{ err: Buffer; code?: Buffer }`.
+  `codec.ts` splits the leading code on decode and re-joins it on encode. The
+  project reads `code` directly; both `/^([A-Z][A-Z0-9]*) (.+)$/` regexes are
+  gone.
+- **H3 (done)** — zero-arg `redis.call()/pcall()` no longer short-circuits in C;
+  it is dispatched to the host with `[]`, so `ScriptCallNoCommandError` and the
+  call/pcall distinction come for free. `firstZeroArgRedisCallKind` /
+  `normalizeRedisNoArgsError` (source-regex hack) deleted.
+- **H4 (kept)** — `normalizeScriptCommandValue` (MOVED→generic) stays at the host
+  dispatch in `lua-runtime.ts`, which is already the right layer (the pure
+  translator no longer touches it); it no longer carries sha.
+- **H5 (no-op)** — error wire-formatting (code-prefix join + CRLF sanitize) is
+  already owned by `src/core/resp-encoder.ts`; the duplicate was simply removed
+  from `lua-runtime.ts`.
+
+Tests: lib 138/138 (incl. new zero-arg-delegation + decoration/code-split
+cases); project 89 unit + 152 mock integration green, including the exact
+contract in `tests-integration/ioredis/scripts.test.ts`.
+
+**Follow-up required:** publish `lua-redis-wasm@1.3.0` to the registry. Until
+then this repo only builds/tests via the local `npm link`; a fresh `npm install`
+resolves `^1.3.0` against a registry that still has `1.2.2`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "async-mutex": "^0.5.0",
         "cluster-key-slot": "^1.1.2",
         "ioredis-mock": "^8.9.0",
-        "lua-redis-wasm": "^1.2.2",
+        "lua-redis-wasm": "^1.3.0",
         "respjs": "^4.2.0"
       },
       "bin": {
@@ -2530,9 +2530,9 @@
       }
     },
     "node_modules/lua-redis-wasm": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/lua-redis-wasm/-/lua-redis-wasm-1.2.2.tgz",
-      "integrity": "sha512-+Pyd/3TrgUJi2fbkYiAVdbcyCkEe9VocOmLBzFCdTig3jiDvgcZW7QPwkujYCbs+DUBxeEW1FJ7+rby7cT3zHQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/lua-redis-wasm/-/lua-redis-wasm-1.3.0.tgz",
+      "integrity": "sha512-pK++51kAGRAOHSXmmYwhblMsTOkDMpIdM+OprYNv52fq76il4cAZQhLiBgv+Fro8wmxW8h1PQPpSeKEv4zIOSA==",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "async-mutex": "^0.5.0",
     "cluster-key-slot": "^1.1.2",
     "ioredis-mock": "^8.9.0",
-    "lua-redis-wasm": "^1.2.2",
+    "lua-redis-wasm": "^1.3.0",
     "respjs": "^4.2.0"
   },
   "devDependencies": {

--- a/src/commands/scripts.ts
+++ b/src/commands/scripts.ts
@@ -2,6 +2,7 @@ import { defineCommand } from '../core/command-definition'
 import { t } from '../core/command-schema'
 import {
   NoScriptError,
+  RedisCommandError,
   ScriptDebugModeError,
   ScriptFlushOptionError,
   UnknownScriptSubcommandError,
@@ -104,8 +105,9 @@ export const evalCommand = defineCommand<EvalArgs>({
   keys: evalKeys,
   execute: async (args, ctx) => {
     const { keys, argv } = splitEvalArgs(args)
-    const sha = ctx.server.scriptCache.load(args.script)
-    return runLuaScript(args.script, keys, argv, ctx, sha)
+    // Cache the script so a later EVALSHA can find it by digest.
+    ctx.server.scriptCache.load(args.script)
+    return runLuaScript(args.script, keys, argv, ctx)
   },
 })
 
@@ -126,7 +128,7 @@ export const evalshaCommand = defineCommand<EvalShaArgs>({
     }
 
     const { keys, argv } = splitEvalArgs(args)
-    return runLuaScript(script, keys, argv, ctx, args.sha)
+    return runLuaScript(script, keys, argv, ctx)
   },
 })
 
@@ -243,89 +245,18 @@ async function runLuaScript(
   keys: readonly Buffer[],
   argv: readonly Buffer[],
   ctx: RedisExecutionContext,
-  sha: string,
 ): Promise<RedisResult> {
   const runtime = await getDefaultRedisLuaRuntime()
 
   try {
-    const reply = runtime.eval(script, keys, argv, ctx, sha)
-    const normalized = normalizeLuaReplyError(reply, script, sha)
-    if (normalized) {
-      return normalized
-    }
-
+    const reply = runtime.eval(script, keys, argv, ctx)
     return RedisResult.create(luaReplyToRedisValue(reply))
   } catch (err) {
+    if (err instanceof RedisCommandError) {
+      return RedisResult.error(err.message, err.code)
+    }
+
     const message = err instanceof Error ? err.message : String(err)
-    return luaRuntimeError(message, script, sha)
-  }
-}
-
-function normalizeLuaReplyError(
-  reply: unknown,
-  script: Buffer,
-  sha: string,
-): RedisResult | null {
-  if (!reply || typeof reply !== 'object' || !('err' in reply)) {
-    return null
-  }
-
-  const rawMessage = (reply as { err: unknown }).err
-  const message = Buffer.isBuffer(rawMessage)
-    ? rawMessage.toString()
-    : String(rawMessage)
-  return normalizeRedisNoArgsError(message, script, sha)
-}
-
-function luaRuntimeError(
-  message: string,
-  script?: Buffer,
-  sha?: string,
-): RedisResult {
-  const normalized = normalizeRedisNoArgsError(message, script, sha)
-  if (normalized) {
-    return normalized
-  }
-
-  const match = /^([A-Z][A-Z0-9]*) (.+)$/.exec(message)
-  if (!match) {
     return RedisResult.error(message, 'ERR')
   }
-
-  return RedisResult.error(match[2], match[1])
-}
-
-function normalizeRedisNoArgsError(
-  message: string,
-  script?: Buffer,
-  sha?: string,
-): RedisResult | null {
-  if (!message.includes('ERR redis.call requires arguments') || !script) {
-    return null
-  }
-
-  const kind = firstZeroArgRedisCallKind(script.toString())
-  if (!kind) {
-    return null
-  }
-
-  const baseMessage =
-    'Please specify at least one argument for this redis lib call'
-  if (kind === 'pcall') {
-    return RedisResult.error(baseMessage, 'ERR')
-  }
-
-  return RedisResult.error(
-    `${baseMessage} script: ${sha}, on @user_script:1.`,
-    'ERR',
-  )
-}
-
-function firstZeroArgRedisCallKind(script: string): 'call' | 'pcall' | null {
-  const match = /\bredis\s*\.\s*(p?call)\s*\(\s*\)/.exec(script)
-  if (!match) {
-    return null
-  }
-
-  return match[1] === 'pcall' ? 'pcall' : 'call'
 }

--- a/src/core/lua-runtime.ts
+++ b/src/core/lua-runtime.ts
@@ -16,19 +16,18 @@ import { RedisValue } from './redis-value'
 
 type LuaHostState = {
   ctx: RedisExecutionContext | null
-  sha: string
 }
 
 export type LuaReplyValue = ReplyValue
 
 export class RedisLuaRuntime {
-  private readonly hostState: LuaHostState = { ctx: null, sha: '' }
+  private readonly hostState: LuaHostState = { ctx: null }
   private readonly engine: LuaEngine
 
   constructor(module: LuaWasmModule) {
     this.engine = module.create({
-      redisCall: args => this.runRedisCommand(args, 'call'),
-      redisPcall: args => this.runRedisCommand(args, 'pcall'),
+      redisCall: args => this.runRedisCommand(args),
+      redisPcall: args => this.runRedisCommand(args),
       log: () => {},
     })
   }
@@ -38,32 +37,31 @@ export class RedisLuaRuntime {
     keys: readonly Buffer[],
     args: readonly Buffer[],
     ctx: RedisExecutionContext,
-    sha: string,
   ): ReplyValue {
     if (this.hostState.ctx) {
       throw new RedisCommandError('Lua runtime is already executing a script')
     }
 
     this.hostState.ctx = ctx
-    this.hostState.sha = sha
 
     try {
       return this.engine.evalWithArgs(script, [...keys], [...args])
     } finally {
       this.hostState.ctx = null
-      this.hostState.sha = ''
     }
   }
 
-  private runRedisCommand(args: Buffer[], mode: 'call' | 'pcall'): ReplyValue {
+  // Host callback for redis.call()/redis.pcall(). Both modes share the same
+  // dispatch: the engine decides whether an error aborts the script (call) or is
+  // returned as a value (pcall) and decorates it with the script sha accordingly.
+  private runRedisCommand(args: Buffer[]): ReplyValue {
     const ctx = this.hostState.ctx
     if (!ctx) {
       throw new Error('ERR Lua runtime is not initialized')
     }
-    const scriptSha = mode === 'call' ? this.hostState.sha : undefined
 
     if (args.length === 0) {
-      return redisErrorToLuaReply(new ScriptCallNoCommandError(), scriptSha)
+      return redisErrorToLuaReply(new ScriptCallNoCommandError())
     }
 
     let plan: CommandPlan
@@ -71,25 +69,22 @@ export class RedisLuaRuntime {
       plan = ctx.executor.plan(args[0], args.slice(1))
     } catch (err) {
       if (err instanceof UnknownRedisCommandError) {
-        return redisErrorToLuaReply(new ScriptUnknownCommandError(), scriptSha)
+        return redisErrorToLuaReply(new ScriptUnknownCommandError())
       }
 
       if (err instanceof RedisCommandError) {
-        return redisErrorToLuaReply(err, scriptSha)
+        return redisErrorToLuaReply(err)
       }
 
       throw err
     }
 
     if (plan.flags.includes('noscript')) {
-      return redisErrorToLuaReply(new ScriptUnknownCommandError(), scriptSha)
+      return redisErrorToLuaReply(new ScriptUnknownCommandError())
     }
 
     const result = ctx.executor.executePlanSync(plan, ctx)
-    return redisValueToLuaReply(
-      normalizeScriptCommandValue(result.value),
-      scriptSha,
-    )
+    return redisValueToLuaReply(normalizeScriptCommandValue(result.value))
   }
 }
 
@@ -127,16 +122,16 @@ export function luaReplyToRedisValue(value: ReplyValue): RedisValue {
   }
 
   if ('err' in value) {
-    return luaErrorToRedisValue(value.err.toString())
+    return RedisValue.error(
+      value.err.toString(),
+      value.code?.toString() ?? 'ERR',
+    )
   }
 
   return RedisValue.bulkString(Buffer.from(String(value)))
 }
 
-function redisValueToLuaReply(
-  value: RedisValue,
-  scriptSha?: string,
-): ReplyValue {
+function redisValueToLuaReply(value: RedisValue): ReplyValue {
   switch (value.kind) {
     case 'simple-string':
       return { ok: Buffer.from(value.value) }
@@ -153,29 +148,29 @@ function redisValueToLuaReply(
     case 'verbatim':
       return value.value
     case 'array':
-      return value.items.map(item => redisValueToLuaReply(item, scriptSha))
+      return value.items.map(redisValueToLuaReply)
     case 'set':
-      return value.items.map(item => redisValueToLuaReply(item, scriptSha))
+      return value.items.map(redisValueToLuaReply)
     case 'map':
       return value.entries.flatMap(([key, entryValue]) => [
-        redisValueToLuaReply(key, scriptSha),
-        redisValueToLuaReply(entryValue, scriptSha),
+        redisValueToLuaReply(key),
+        redisValueToLuaReply(entryValue),
       ])
     case 'push':
-      return [
-        Buffer.from(value.name),
-        ...value.items.map(item => redisValueToLuaReply(item, scriptSha)),
-      ]
+      return [Buffer.from(value.name), ...value.items.map(redisValueToLuaReply)]
     case 'null':
     case 'null-array':
       return null
     case 'error':
       return {
-        err: Buffer.from(formatRedisErrorValue(value, scriptSha)),
+        err: Buffer.from(value.message),
+        code: value.code ? Buffer.from(value.code) : undefined,
       }
   }
 }
 
+// A command run from a script cannot redirect the client, so a MOVED reply is
+// surfaced to the script as a generic error instead of a cluster redirect.
 function normalizeScriptCommandValue(value: RedisValue): RedisValue {
   if (value.kind === 'error' && value.code === 'MOVED') {
     return RedisValue.error(
@@ -187,56 +182,11 @@ function normalizeScriptCommandValue(value: RedisValue): RedisValue {
   return value
 }
 
-function redisErrorToLuaReply(
-  err: RedisCommandError,
-  scriptSha?: string,
-): ReplyValue {
+function redisErrorToLuaReply(err: RedisCommandError): ReplyValue {
   return {
-    err: Buffer.from(
-      formatRedisError(scriptErrorMessage(err.message, scriptSha), err.code),
-    ),
+    err: Buffer.from(err.message),
+    code: Buffer.from(err.code),
   }
-}
-
-function luaErrorToRedisValue(message: string): RedisValue {
-  const match = /^([A-Z][A-Z0-9]*) (.+)$/.exec(message)
-  if (!match) {
-    return RedisValue.error(message, 'ERR')
-  }
-
-  return RedisValue.error(match[2], match[1])
-}
-
-function formatRedisErrorValue(
-  value: Extract<RedisValue, { kind: 'error' }>,
-  scriptSha?: string,
-): string {
-  return formatRedisError(
-    scriptErrorMessage(value.message, scriptSha),
-    value.code,
-  )
-}
-
-function scriptErrorMessage(message: string, scriptSha?: string): string {
-  if (!scriptSha) {
-    return message
-  }
-
-  return `${message} script: ${scriptSha}, on @user_script:1.`
-}
-
-function formatRedisError(message: string, code?: string): string {
-  const sanitizedMessage = sanitizeErrorText(message)
-  if (!code) {
-    return sanitizedMessage
-  }
-
-  const sanitizedCode = sanitizeErrorText(code)
-  if (sanitizedMessage.startsWith(`${sanitizedCode} `)) {
-    return sanitizedMessage
-  }
-
-  return `${sanitizedCode} ${sanitizedMessage}`
 }
 
 function formatNumber(value: number): string {
@@ -257,8 +207,4 @@ function formatNumber(value: number): string {
   }
 
   return value.toString()
-}
-
-function sanitizeErrorText(value: string): string {
-  return value.replace(/[\r\n]+/g, ' ')
 }


### PR DESCRIPTION
## Summary

Removes the JS-side hacks that reconstructed Redis Lua error semantics, now that [lua-redis-wasm@1.3.0](https://github.com/fatal10110/lua-redis-wasm/releases/tag/v1.3.0) owns them. The Lua bridge becomes a thin `RedisValue ⇄ ReplyValue` translator.

## Changes

- **Bump `lua-redis-wasm` to `^1.3.0`** (published to npm).
- **`src/core/lua-runtime.ts`**
  - Drop script-sha threading — `eval()` no longer takes a `sha`; the engine computes the sha and decorates script-aborting errors itself.
  - Drop the manual RESP error formatting / CRLF sanitizing (already owned by `resp-encoder.ts`) and the `luaErrorToRedisValue` regex. Errors arrive as structured `{ err, code }`; read `code` directly.
  - Keep the `MOVED`→generic rewrite at the host dispatch and the RESP2 reply flattening — genuine server semantics, not adapter hacks.
- **`src/commands/scripts.ts`** — delete `normalizeLuaReplyError`, `luaRuntimeError`, `normalizeRedisNoArgsError`, and the raw-source-scanning `firstZeroArgRedisCallKind`. `runLuaScript` is now eval + map, with a small catch that maps thrown `RedisCommandError`s to RESP errors.
- **docs** — record the implemented design in `docs/lua-runtime-refactor-plan.md`.

Net: roughly −160 lines across the two source files.

## Testing

Against the published 1.3.0 (local npm link removed, installed from registry):
- `tsc --noEmit` clean
- **89** unit tests pass
- **152** mock integration tests pass

The script error contract (`tests-integration/ioredis/scripts.test.ts`) — call vs pcall decoration, `WRONGTYPE`/`NOSCRIPT`, zero-arg messages, `MOVED`→generic — is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)