### PR TITLE
[codex] Fix XRANGE COUNT integer error

### DIFF
--- a/src/commands/streams.ts
+++ b/src/commands/streams.ts
@@ -5,6 +5,7 @@ import {
   type ParseContext,
 } from '../core/command-schema'
 import {
+  ExpectedIntegerError,
   InvalidStreamIdError,
   RedisSyntaxError,
   StreamIdEqualOrSmallerError,
@@ -597,7 +598,7 @@ function createCountSchema() {
       }
       const value = Number(raw.toString())
       if (!Number.isInteger(value)) {
-        throw new InvalidStreamIdError()
+        throw new ExpectedIntegerError()
       }
       return { value, nextIndex: index + 2 }
     },

--- a/tests-integration/ioredis/stream-integration.test.ts
+++ b/tests-integration/ioredis/stream-integration.test.ts
@@ -112,6 +112,28 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
     )
   })
 
+  test('XRANGE and XREVRANGE reject non-integer COUNT values', async () => {
+    const key = randomKey()
+    const node = await connectToSlotOwner(redisClient!, key)
+    try {
+      await node.xadd(key, '1-1', 'a', '1')
+
+      const invalidCount = errorWithMessage(
+        'ERR value is not an integer or out of range',
+      )
+      await assert.rejects(
+        () => node.call('XRANGE', key, '-', '+', 'COUNT', 'abc'),
+        invalidCount,
+      )
+      await assert.rejects(
+        () => node.call('XREVRANGE', key, '+', '-', 'COUNT', 'abc'),
+        invalidCount,
+      )
+    } finally {
+      node.disconnect()
+    }
+  })
+
   test('XREVRANGE returns entries in descending order', async () => {
     const key = randomKey()
     await redisClient?.xadd(key, '1-1', 'a', '1')


### PR DESCRIPTION
## Summary

Fixes #9.

- Return the standard Redis integer error when `XRANGE` or `XREVRANGE` receives a non-integer `COUNT` value.
- Add ioredis integration coverage for both commands through the existing integration backend harness.

## Root Cause

`createCountSchema` parsed `COUNT` with `Number(...)`, but non-integer values threw `InvalidStreamIdError`, producing `ERR Invalid stream ID specified as stream command argument` instead of the Redis integer validation error.

## Validation

- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/stream-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/stream-integration.test.ts`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint` (passes with one existing warning in `src/types/respjs.d.ts`)
