### PR TITLE
[codex] Fix CLIENT INFO RESP version reporting

### DIFF
--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -210,7 +210,7 @@ function formatClientLine(
     'cmd=client',
     'user=default',
     'redir=-1',
-    'resp=2',
+    `resp=${session.protocolVersion}`,
   ]
 
   if (libName !== undefined) {

--- a/tests-integration/ioredis/connection-integration.test.ts
+++ b/tests-integration/ioredis/connection-integration.test.ts
@@ -97,6 +97,18 @@ describe(`Connection commands integration (${testRunner.getBackendName()})`, () 
       assert.ok(repeatedHello instanceof Map)
       assert.strictEqual(respNumber(respMapGet(repeatedHello, 'proto')), 3)
 
+      connection.write(commandFrame('CLIENT', 'INFO'))
+      assert.match(
+        respText(await connection.readFrame()),
+        /(?:^| )resp=3(?: |\n)/,
+      )
+
+      connection.write(commandFrame('CLIENT', 'LIST'))
+      assert.match(
+        respText(await connection.readFrame()),
+        /(?:^| )resp=3(?: |\n)/,
+      )
+
       connection.write(commandFrame('RESET'))
       assert.deepStrictEqual(
         await connection.readRawFrame(),


### PR DESCRIPTION
## Summary

Fixes #11.

- Report the active session protocol version in `CLIENT INFO` and `CLIENT LIST` instead of hardcoding `resp=2`.
- Add RESP3 integration coverage that verifies both commands report `resp=3` after `HELLO 3`.

## Root Cause

`formatClientLine` always emitted `resp=2`, even after `HELLO 3` updated `session.protocolVersion`. Clients reading `CLIENT INFO` could therefore see stale protocol metadata.

## Validation

- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/connection-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/connection-integration.test.ts`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint` (passes with one existing warning in `src/types/respjs.d.ts`)
