### PR TITLE
[codex] Register SUBSTR alias for GETRANGE

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -82,6 +82,7 @@ export {
   msetCommand,
   msetnxCommand,
   getrangeCommand,
+  substrCommand,
   setrangeCommand,
   getexCommand,
   stringsCommands,

--- a/src/commands/strings.ts
+++ b/src/commands/strings.ts
@@ -381,6 +381,11 @@ export const getrangeCommand = defineCommand({
   },
 })
 
+export const substrCommand = defineCommand({
+  ...getrangeCommand,
+  name: 'substr',
+})
+
 export const setrangeCommand = defineCommand({
   name: 'setrange',
   schema: t.object({
@@ -452,6 +457,7 @@ export const stringsCommands = [
   msetCommand,
   msetnxCommand,
   getrangeCommand,
+  substrCommand,
   setrangeCommand,
   getexCommand,
 ]

--- a/tests-integration/ioredis/string-integration.test.ts
+++ b/tests-integration/ioredis/string-integration.test.ts
@@ -155,6 +155,33 @@ describe(`String Commands Integration (${testRunner.getBackendName()})`, () => {
     assert.strictEqual(nullValue, null)
   })
 
+  test('SUBSTR aliases GETRANGE', async () => {
+    const tag = `{substr:${randomKey()}}`
+    const key = `${tag}:key`
+    const missingKey = `${tag}:missing`
+    const directClient = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      await directClient.set(key, 'abcdef')
+
+      assert.strictEqual(
+        await directClient.call('SUBSTR', key, '1', '3'),
+        'bcd',
+      )
+      assert.strictEqual(
+        await directClient.call('SUBSTR', key, '-3', '-1'),
+        'def',
+      )
+      assert.strictEqual(
+        await directClient.call('SUBSTR', missingKey, '0', '1'),
+        '',
+      )
+    } finally {
+      await directClient.del(key, missingKey)
+      directClient.disconnect()
+    }
+  })
+
   test('String commands workflow', async () => {
     // Create a session counter with user data
     await redisClient?.set('{user1001}name', 'Alice')


### PR DESCRIPTION
## Summary
- register `SUBSTR` as a Redis-compatible alias for the existing `GETRANGE` command implementation
- add ioredis integration coverage for normal ranges, negative indexes, and missing keys

## Root cause
The command registry exposed `GETRANGE` but did not register Redis' legacy `SUBSTR` alias, so clients received `ERR unknown command` for a valid Redis command name.

## Validation
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/string-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/string-integration.test.ts`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint` (passes with the existing `src/types/respjs.d.ts` warning)

Fixes #70
