### PR TITLE
fix: EXEC with wrong arity discards transaction with EXECABORT (#73)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -223,7 +223,7 @@ sequenceDiagram
 
     Cl->>CS: EXEC
     CS->>CE: executeRaw(EXEC, [], ctx)
-    Note over CE,CS: WATCH dirty → discard, reply *-1<br/>queue dirty (e.g. unknown cmd) → discard, EXECABORT
+    Note over CE,CS: WATCH dirty → discard, reply *-1<br/>queue dirty (e.g. unknown cmd) → discard, EXECABORT<br/>EXEC itself malformed (e.g. `EXEC foo`) → discard immediately,<br/>EXECABORT "Transaction discarded because of: &lt;reason&gt;"
     CE->>CS: drainTransaction() → plans[]
     CS->>CS: executeTransaction(plans)<br/>runs each plan through the executor, in order
     CS-->>Cl: array of per-command replies

--- a/src/core/command-executor.ts
+++ b/src/core/command-executor.ts
@@ -2,7 +2,12 @@ import { CommandDefinition, CommandPlan } from './command-definition'
 import { CommandRegistry } from './command-registry'
 import { parseCommandArgs } from './command-schema'
 import type { ExecutionPolicy } from './execution-policies'
-import { RedisCommandError, UnknownRedisCommandError } from './redis-error'
+import {
+  ExecCommandAbortError,
+  RedisCommandError,
+  UnknownRedisCommandError,
+  WrongNumberOfArgumentsError,
+} from './redis-error'
 import type { RedisExecutionContext } from './redis-context'
 import { RedisResult } from './redis-result'
 import { isResponseStream, ResponseStream } from './response-stream'
@@ -64,10 +69,7 @@ export class CommandExecutor {
    * @throws {UnknownRedisCommandError} if no command is registered under the name.
    */
   plan(rawCommand: Buffer | string, rawArgs: readonly Buffer[]): CommandPlan {
-    const commandName =
-      typeof rawCommand === 'string'
-        ? rawCommand.toLowerCase()
-        : rawCommand.toString().toLowerCase()
+    const commandName = CommandExecutor.normalizeCommandName(rawCommand)
     const definition = this.registry.get(commandName)
 
     if (!definition) {
@@ -96,12 +98,32 @@ export class CommandExecutor {
       return await this.executePlan(this.plan(rawCommand, rawArgs), ctx)
     } catch (err) {
       if (err instanceof RedisCommandError) {
+        // EXEC itself with bad arity (e.g. `EXEC foo`) discards the
+        // transaction immediately and replies EXECABORT, matching Redis'
+        // execCommandAbort — distinct from a *queued* command's arity error,
+        // which only dirties the transaction for a later, well-formed EXEC.
+        if (
+          err instanceof WrongNumberOfArgumentsError &&
+          ctx.session.mode === 'transaction' &&
+          CommandExecutor.normalizeCommandName(rawCommand) === 'exec'
+        ) {
+          ctx.session.discardTransaction()
+          const abortError = new ExecCommandAbortError(err.message)
+          return RedisResult.error(abortError.message, abortError.code)
+        }
+
         ctx.session.markTransactionDirty()
         return RedisResult.error(err.message, err.code)
       }
 
       throw err
     }
+  }
+
+  private static normalizeCommandName(rawCommand: Buffer | string): string {
+    return typeof rawCommand === 'string'
+      ? rawCommand.toLowerCase()
+      : rawCommand.toString().toLowerCase()
   }
 
   /**

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -155,6 +155,13 @@ export class TransactionDiscardedError extends RedisCommandError {
   }
 }
 
+/** EXEC itself is malformed (e.g. wrong arity) — discards the transaction immediately. */
+export class ExecCommandAbortError extends RedisCommandError {
+  constructor(reason: string) {
+    super(`Transaction discarded because of: ${reason}`, 'EXECABORT')
+  }
+}
+
 export class IndexOutOfRangeError extends RedisCommandError {
   constructor() {
     super('index out of range')

--- a/tests-integration/ioredis/multi.test.ts
+++ b/tests-integration/ioredis/multi.test.ts
@@ -109,6 +109,30 @@ describe('multi', () => {
     }
   })
 
+  test('EXEC with wrong arity aborts the transaction with EXECABORT', async () => {
+    const key = `{exec-arity:${randomKey()}}:key`
+    const directClient = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      assert.strictEqual(await directClient.call('MULTI'), 'OK')
+      assert.strictEqual(await directClient.call('SET', key, 'value'), 'QUEUED')
+      await assert.rejects(
+        () => directClient.call('EXEC', 'foo'),
+        errorWithMessage(
+          "EXECABORT Transaction discarded because of: wrong number of arguments for 'exec' command",
+        ),
+      )
+
+      // Session must be back in normal mode: this SET runs immediately
+      // instead of being queued, and the queued SET above never ran.
+      assert.strictEqual(await directClient.call('SET', key, 'value2'), 'OK')
+      assert.strictEqual(await directClient.get(key), 'value2')
+    } finally {
+      await directClient.del(key)
+      directClient.disconnect()
+    }
+  })
+
   test('UNWATCH is queued in MULTI and returns OK from EXEC', async () => {
     const key = `{unwatch:${randomKey()}}:key`
     const directClient = await connectToSlotOwner(redisClient!, key)


### PR DESCRIPTION
## Summary
- `EXEC foo` (wrong arity) inside `MULTI` threw a plain "wrong number of arguments for 'exec' command" error and left the session stuck in transaction mode — every subsequent command kept being queued instead of executing.
- Real Redis (verified against 7.2.14) discards the transaction immediately and replies `EXECABORT Transaction discarded because of: wrong number of arguments for 'exec' command` (Redis' `execCommandAbort` path — distinct from the generic `Transaction discarded because of previous errors.` used when a *queued* command was malformed).
- `executeRaw` now special-cases `WrongNumberOfArgumentsError` on `EXEC` while `session.mode === 'transaction'`: discards the transaction and returns the new `ExecCommandAbortError`.
- Updated the MULTI/EXEC sequence diagram in `docs/ARCHITECTURE.md` to document this second EXECABORT path.

Closes #73

## Test plan
- [x] New test in `tests-integration/ioredis/multi.test.ts` reproduces the bug (red on mock before the fix)
- [x] Test passes against real Redis 7.2.14 (confirmed exact EXECABORT message)
- [x] Fix makes the test pass on mock too
- [x] `npm run test:all` passes (123 unit + 194 mock + 194 real)