### PR TITLE
fix: trap non-RedisCommandError during EXEC into result slot (#83)

### DIFF
--- a/src/core/client-session.ts
+++ b/src/core/client-session.ts
@@ -242,7 +242,21 @@ export class ClientSession implements RedisClientSession {
         currentDbId = this.selectedDatabaseId
       }
 
-      const result = await this.executor.executePlan(plan, noBlockCtx)
+      // executePlan converts RedisCommandErrors into error results, but a
+      // command whose execute() throws an unexpected runtime error (TypeError,
+      // etc.) would otherwise propagate out and abandon the partial results
+      // array. Real Redis always replies with an N-element EXEC array, so trap
+      // the failure into this command's slot and keep running the rest (#83).
+      let result: Awaited<ReturnType<typeof this.executor.executePlan>>
+      try {
+        result = await this.executor.executePlan(plan, noBlockCtx)
+      } catch (err) {
+        if (this.signal.aborted) {
+          throw err
+        }
+        values.push(RedisValue.error((err as Error).message))
+        continue
+      }
 
       if (result instanceof RedisResult) {
         values.push(result.value)

--- a/tests/commands-transactions.test.ts
+++ b/tests/commands-transactions.test.ts
@@ -166,6 +166,48 @@ describe('new transaction commands', () => {
     )
   })
 
+  test('keeps non-RedisCommandError runtime failures as EXEC array elements', async () => {
+    const crashCommand = defineCommand({
+      name: 'crash',
+      schema: t.object({}),
+      flags: ['write'],
+      keys: () => [],
+      execute: () => {
+        throw new TypeError('boom')
+      },
+    })
+    const server = new RedisServerState()
+    const executor = createRedisCommandExecutor({
+      extraCommands: [crashCommand],
+    })
+    const session = new ClientSession({ server, executor })
+
+    assert.deepStrictEqual(await session.execute('multi', []), RedisResult.ok())
+    assert.deepStrictEqual(
+      await session.execute('set', [Buffer.from('key'), Buffer.from('value')]),
+      queued(),
+    )
+    assert.deepStrictEqual(await session.execute('crash', []), queued())
+    assert.deepStrictEqual(
+      await session.execute('get', [Buffer.from('key')]),
+      queued(),
+    )
+
+    // The crashing command must not abandon the partial results array — EXEC
+    // always returns exactly N elements, the failing slot becomes an error, and
+    // later queued commands still run.
+    assert.deepStrictEqual(
+      await session.execute('exec', []),
+      RedisResult.create(
+        RedisValue.array([
+          RedisValue.simpleString('OK'),
+          RedisValue.error('boom'),
+          RedisValue.bulkString(Buffer.from('value')),
+        ]),
+      ),
+    )
+  })
+
   test('SELECT inside MULTI switches the DB for later queued commands', async () => {
     const { session, server } = createSession({ databaseCount: 2 })
 


### PR DESCRIPTION
## Summary
- A command whose `execute()` threw an unexpected runtime error (e.g. `TypeError`) — not a `RedisCommandError` — propagated out of `executeTransaction`'s per-command loop, abandoning the partial results array. The client got a transport-level error instead of a well-formed `EXEC` array reply.
- Root cause: `CommandExecutor.executePlan` only converts `RedisCommandError` into an error result; anything else rethrows, and the loop in `client-session.ts` had no catch.
- Fix: wrap each `executePlan` call in `executeTransaction` so an unexpected error becomes a `RedisValue.error` in that command's slot. Remaining queued commands still run, and `EXEC` always returns an N-element array. Abort errors still propagate (session teardown).

Closes #83

## Test plan
- [x] New unit test in tests/commands-transactions.test.ts reproduces the bug (red before fix: TypeError propagated out of EXEC)
- [x] Fix makes the test pass — EXEC returns `[OK, error('boom'), value]`
- [x] `npm run build` + `npm run lint` clean
- [x] `npm run test:all` passes (194/194: unit + mock + real Redis)

> Note: tested as a unit test because a non-`RedisCommandError` is an internal defect path not reachable by a well-formed wire command, so the integration harness against real Redis can't naturally trigger it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)