### PR TITLE
feat: implement CONFIG GET/SET (#116)

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ buildRedisCluster(options: RedisClusterOptions): RedisCluster
 `DEL`, `EXISTS`, `EXPIRE`, `EXPIREAT`, `KEYS`, `PERSIST`, `PEXPIRE`, `PEXPIREAT`, `PTTL`, `RENAME`, `RENAMENX`, `SCAN`, `TTL`, `TYPE`
 
 ### Server
-`DBSIZE`, `FLUSHALL`, `FLUSHDB`, `INFO`, `PING`, `QUIT`
+`CONFIG GET`, `CONFIG SET`, `DBSIZE`, `FLUSHALL`, `FLUSHDB`, `INFO`, `PING`, `QUIT`
 
 ### Transactions
 `MULTI`, `EXEC`, `DISCARD`, `WATCH`, `UNWATCH`

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -59,10 +59,17 @@ surface.
 
 #### CONFIG
 
-- [ ] `CONFIG GET parameter` - Get the value of a configuration parameter
-- [ ] `CONFIG SET parameter value` - Set a configuration parameter
+- [x] `CONFIG GET parameter [parameter ...]` - Get the value of one or more configuration parameters (glob patterns supported)
+- [x] `CONFIG SET parameter value [parameter value ...]` - Set one or more configuration parameters
 - [ ] `CONFIG RESETSTAT` - Reset the stats returned by INFO
 - [ ] `CONFIG REWRITE` - Rewrite the configuration file
+
+`CONFIG GET`/`CONFIG SET` operate on a per-server in-memory store seeded with
+plausible hardcoded defaults (the parameters client libraries commonly probe at
+connection time) — there is no real configuration subsystem behind them.
+`CONFIG SET` only accepts parameters already present in that default set and
+stores the value as-is without applying it anywhere; `CONFIG GET` returns
+whatever is currently stored, glob-matched against the requested patterns.
 
 #### DBSIZE
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,175 @@
+import { defineCommand } from '../core/command-definition'
+import { t } from '../core/command-schema'
+import type { RedisExecutionContext } from '../core/redis-context'
+import {
+  RedisCommandError,
+  WrongNumberOfArgumentsError,
+} from '../core/redis-error'
+import { RedisResult } from '../core/redis-result'
+import { RedisValue } from '../core/redis-value'
+import { ok } from './helpers'
+import { commandSubcommandInfo } from './introspection'
+
+/**
+ * Plausible Redis defaults for the parameters client libraries probe during
+ * connection setup. There is no real configuration subsystem behind this — the
+ * values exist only so that `CONFIG GET` returns something sane and `CONFIG SET`
+ * has a known parameter set to validate against. Extend this map as more
+ * parameters are needed; do not treat any value here as authoritative.
+ */
+const CONFIG_DEFAULTS: Readonly<Record<string, string>> = {
+  appendonly: 'no',
+  'bind-source-addr': '',
+  databases: '16',
+  'hash-max-listpack-entries': '128',
+  'hash-max-listpack-value': '64',
+  'list-max-listpack-size': '128',
+  loglevel: 'notice',
+  maxclients: '10000',
+  maxmemory: '0',
+  'maxmemory-clients': '0',
+  'maxmemory-policy': 'noeviction',
+  'maxmemory-samples': '5',
+  'proto-max-bulk-len': '536870912',
+  save: '3600 1 300 100 60 10000',
+  'set-max-intset-entries': '512',
+  'set-max-listpack-entries': '128',
+  'tcp-keepalive': '300',
+  timeout: '0',
+  'zset-max-listpack-entries': '128',
+  'zset-max-listpack-value': '64',
+}
+
+// Per-server backing store, lazily seeded from CONFIG_DEFAULTS. Keyed on the
+// server object so concurrent in-process servers (e.g. the mock cluster used in
+// tests) never share mutable config state.
+const configStores = new WeakMap<object, Map<string, string>>()
+
+function getConfigStore(ctx: RedisExecutionContext): Map<string, string> {
+  let store = configStores.get(ctx.server)
+  if (store === undefined) {
+    store = new Map(Object.entries(CONFIG_DEFAULTS))
+    configStores.set(ctx.server, store)
+  }
+  return store
+}
+
+function globMatches(pattern: string, value: string): boolean {
+  let source = '^'
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i]
+    if (char === '*') {
+      source += '.*'
+    } else if (char === '?') {
+      source += '.'
+    } else {
+      source += char.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
+    }
+  }
+  source += '$'
+  return new RegExp(source, 'i').test(value)
+}
+
+function configGet(
+  args: readonly Buffer[],
+  ctx: RedisExecutionContext,
+): RedisResult {
+  if (args.length === 0) {
+    throw new WrongNumberOfArgumentsError('config|get')
+  }
+
+  const store = getConfigStore(ctx)
+  const patterns = args.map(arg => arg.toString())
+  const matched = new Map<string, string>()
+  for (const [name, value] of store) {
+    if (patterns.some(pattern => globMatches(pattern, name))) {
+      matched.set(name, value)
+    }
+  }
+
+  const bulk = (text: string): RedisValue =>
+    RedisValue.bulkString(Buffer.from(text))
+
+  if (ctx.session.protocolVersion === 3) {
+    const entries: [RedisValue, RedisValue][] = []
+    for (const [name, value] of matched) {
+      entries.push([bulk(name), bulk(value)])
+    }
+    return RedisResult.create(RedisValue.map(entries))
+  }
+
+  const flat: RedisValue[] = []
+  for (const [name, value] of matched) {
+    flat.push(bulk(name), bulk(value))
+  }
+  return RedisResult.create(RedisValue.array(flat))
+}
+
+function configSet(
+  args: readonly Buffer[],
+  ctx: RedisExecutionContext,
+): RedisResult {
+  if (args.length === 0 || args.length % 2 !== 0) {
+    throw new WrongNumberOfArgumentsError('config|set')
+  }
+
+  const store = getConfigStore(ctx)
+  const updates: [string, string][] = []
+  for (let i = 0; i < args.length; i += 2) {
+    const name = args[i].toString().toLowerCase()
+    const value = args[i + 1].toString()
+    if (!store.has(name)) {
+      throw new RedisCommandError(
+        `Unknown option or number of arguments for CONFIG SET - '${args[i].toString()}'`,
+      )
+    }
+    updates.push([name, value])
+  }
+
+  // Validate every parameter before applying any — CONFIG SET is atomic.
+  for (const [name, value] of updates) {
+    store.set(name, value)
+  }
+  return ok()
+}
+
+export const configCommand = defineCommand({
+  name: 'config',
+  schema: t.object({
+    subcommand: t.string(),
+    args: t.variadic(t.bulk()),
+  }),
+  flags: ['admin', 'noscript'],
+  introspection: {
+    arity: -2,
+    flags: [],
+    firstKey: 0,
+    lastKey: 0,
+    keyStep: 0,
+    categories: ['@admin', '@slow', '@dangerous'],
+    keySpecs: [],
+    subcommands: [
+      commandSubcommandInfo('config|get', -3),
+      commandSubcommandInfo('config|set', -4),
+      commandSubcommandInfo('config|help', 2),
+    ],
+  },
+  keys: () => [],
+  execute: (args, ctx) => {
+    const subcommand = args.subcommand.toLowerCase()
+
+    if (subcommand === 'get') {
+      return configGet(args.args, ctx)
+    }
+
+    if (subcommand === 'set') {
+      return configSet(args.args, ctx)
+    }
+
+    throw new RedisCommandError(
+      `Unknown CONFIG subcommand or wrong number of arguments for '${args.subcommand}'. Try CONFIG HELP.`,
+    )
+  },
+})
+
+export const configCommands = [configCommand]

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,6 +4,7 @@ import { CommandRegistry } from '../core/command-registry'
 import type { ExecutionPolicy } from '../core/execution-policies'
 import { createTransactionPolicy } from '../core/execution-policies'
 import { commandCommand } from './command'
+import { configCommands } from './config'
 import { connectionCommands } from './connection'
 import { hashesCommands } from './hashes'
 import { keysCommands } from './keys'
@@ -19,6 +20,7 @@ import { zsetsCommands } from './zsets'
 export const redisCommandDefinitions: readonly CommandDefinition[] = [
   ...connectionCommands,
   commandCommand,
+  ...configCommands,
   ...transactionCommands,
   ...stringsCommands,
   ...keysCommands,
@@ -63,6 +65,7 @@ export {
   readwriteCommand,
 } from './cluster'
 export { commandCommand } from './command'
+export { configCommand, configCommands } from './config'
 export {
   getCommand,
   setCommand,

--- a/tests-integration/ioredis/config-integration.test.ts
+++ b/tests-integration/ioredis/config-integration.test.ts
@@ -1,0 +1,81 @@
+import { after, before, describe, test } from 'node:test'
+import assert from 'node:assert'
+import { Cluster, Redis } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { connectToSlotOwner, randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+function configArrayToMap(reply: unknown): Map<string, string> {
+  assert.ok(Array.isArray(reply), 'CONFIG GET should reply with an array')
+  const map = new Map<string, string>()
+  for (let i = 0; i < reply.length; i += 2) {
+    // Redis config parameter names are case-insensitive; normalise to lower.
+    map.set(String(reply[i]).toLowerCase(), String(reply[i + 1]))
+  }
+  return map
+}
+
+describe(`CONFIG GET/SET integration (${testRunner.getBackendName()})`, () => {
+  let redisClient: Cluster | undefined
+  let directClient: Redis | undefined
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster('config-integration')
+    directClient = await connectToSlotOwner(
+      redisClient,
+      `{config:${randomKey()}}:probe`,
+    )
+  })
+
+  after(async () => {
+    directClient?.disconnect()
+    await testRunner.cleanup()
+  })
+
+  test('CONFIG GET returns a value for a known parameter', async () => {
+    const reply = await directClient?.call('CONFIG', 'GET', 'appendonly')
+    const config = configArrayToMap(reply)
+    assert.ok(config.has('appendonly'), 'CONFIG GET should return appendonly')
+    assert.strictEqual(typeof config.get('appendonly'), 'string')
+  })
+
+  test('CONFIG GET parameter names are case-insensitive', async () => {
+    const reply = await directClient?.call('CONFIG', 'GET', 'APPENDONLY')
+    const config = configArrayToMap(reply)
+    assert.ok(
+      config.has('appendonly'),
+      'uppercase query should still match appendonly',
+    )
+  })
+
+  test('CONFIG SET updates a value that CONFIG GET reads back', async () => {
+    const setReply = await directClient?.call(
+      'CONFIG',
+      'SET',
+      'maxmemory-policy',
+      'allkeys-lru',
+    )
+    assert.strictEqual(setReply, 'OK')
+
+    const reply = await directClient?.call('CONFIG', 'GET', 'maxmemory-policy')
+    const config = configArrayToMap(reply)
+    assert.strictEqual(config.get('maxmemory-policy'), 'allkeys-lru')
+  })
+
+  test('CONFIG GET supports glob patterns matching multiple parameters', async () => {
+    const reply = await directClient?.call('CONFIG', 'GET', 'maxmemory*')
+    const config = configArrayToMap(reply)
+    assert.ok(config.has('maxmemory'), 'glob should match maxmemory')
+    assert.ok(
+      config.has('maxmemory-policy'),
+      'glob should match maxmemory-policy',
+    )
+  })
+
+  test('CONFIG SET rejects an unknown parameter', async () => {
+    await assert.rejects(async () =>
+      directClient?.call('CONFIG', 'SET', 'definitely-not-a-real-param', '1'),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Both `ioredis` and `node-redis` call `CONFIG GET` during connection setup. With no `CONFIG` command registered, the server returned `ERR unknown command 'CONFIG'`, which some client versions treat as a fatal connection error.
- Adds a `CONFIG` command (`src/commands/config.ts`):
  - `CONFIG GET parameter [parameter ...]` — each arg is glob-matched against a set of plausible hardcoded defaults; replies a RESP3 map / RESP2 flat array of name/value pairs.
  - `CONFIG SET parameter value [parameter value ...]` — validates every parameter is known (errors `Unknown option or number of arguments for CONFIG SET - '<param>'` otherwise, matching real Redis), applies atomically, returns `+OK`.
- Backing store is a per-server in-memory `Map` (keyed on the server object via `WeakMap`, so concurrent in-process servers don't share state), seeded from hardcoded defaults. No real configuration subsystem behind it — just enough to satisfy client-library handshakes.
- Docs: README supported-commands list + `docs/COMMANDS.md` per-command notes updated.

Closes #116

## Test plan
- [x] New test in tests-integration/ioredis/config-integration.test.ts reproduces the gap (red before fix: 4/5 fail on mock — `ERR unknown command`)
- [x] Test passes against real Redis (mock-only gap confirmed: 5/5 on real cluster)
- [x] Fix makes the test pass on mock too (5/5)
- [x] `npm run test:all` passes (unit 124, mock 199, real 199; 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)