### PR TITLE
fix: flush valid pipelined responses before protocol error (#79)

### DIFF
--- a/src/core/transports/resp2/decoder.ts
+++ b/src/core/transports/resp2/decoder.ts
@@ -3,6 +3,11 @@ export type Resp2CommandFrame = {
   args: Buffer[]
 }
 
+export type Resp2DecodeResult = {
+  frames: Resp2CommandFrame[]
+  error?: Resp2ParseError
+}
+
 export class Resp2ParseError extends Error {
   constructor(message: string) {
     super(message)
@@ -18,25 +23,36 @@ type ParseOutcome =
 export class Resp2CommandDecoder {
   private buffered = Buffer.alloc(0)
 
-  push(chunk: Buffer): Resp2CommandFrame[] {
+  push(chunk: Buffer): Resp2DecodeResult {
     this.buffered = Buffer.concat([this.buffered, chunk])
     const frames: Resp2CommandFrame[] = []
     let cursor = 0
+    let error: Resp2ParseError | undefined
 
-    while (cursor < this.buffered.length) {
-      const outcome = this.parseFrame(cursor)
-      if (outcome.kind === 'incomplete') {
-        break
-      }
+    try {
+      while (cursor < this.buffered.length) {
+        const outcome = this.parseFrame(cursor)
+        if (outcome.kind === 'incomplete') {
+          break
+        }
 
-      if (outcome.kind === 'frame') {
-        frames.push(outcome.frame)
+        if (outcome.kind === 'frame') {
+          frames.push(outcome.frame)
+        }
+        cursor = outcome.nextIndex
       }
-      cursor = outcome.nextIndex
+    } catch (err) {
+      if (!(err instanceof Resp2ParseError)) {
+        throw err
+      }
+      // Surface the protocol error alongside the frames already parsed from
+      // earlier in this pipeline so the caller can respond to the valid
+      // commands before reporting the error and closing the connection.
+      error = err
     }
 
     this.buffered = this.buffered.subarray(cursor)
-    return frames
+    return { frames, error }
   }
 
   private parseFrame(index: number): ParseOutcome {

--- a/src/core/transports/resp2/session-adapter.ts
+++ b/src/core/transports/resp2/session-adapter.ts
@@ -37,12 +37,20 @@ export class Resp2SessionAdapter {
   async run(): Promise<void> {
     try {
       for await (const chunk of this.transport.read()) {
-        const frames = this.decoder.push(chunk)
+        const { frames, error } = this.decoder.push(chunk)
         for (const frame of frames) {
           await this.handleFrame(frame)
           if (this.transport.signal.aborted) {
             return
           }
+        }
+
+        if (error) {
+          // Valid frames before the bad one have already been answered above;
+          // now report the protocol error and close, matching real Redis.
+          await this.writeError(error)
+          this.transport.close('resp2 protocol error')
+          return
         }
       }
     } catch (err) {

--- a/tests-integration/raw-tcp/protocol-errors.test.ts
+++ b/tests-integration/raw-tcp/protocol-errors.test.ts
@@ -1,0 +1,68 @@
+import { after, before, describe, test } from 'node:test'
+import assert from 'node:assert'
+import { TestRunner } from '../test-config'
+import { commandFrame, randomKey } from '../utils'
+import { RawRedisConnection } from './raw-connection'
+
+/**
+ * Raw TCP protocol-error integration tests.
+ *
+ * A Redis client never emits a malformed frame, so the only way to exercise
+ * the server's protocol-error path is over a bare socket. This covers issue
+ * #79: when a single pipelined write ends in a bad frame, the server must still
+ * answer the valid commands that preceded it, then send the protocol error and
+ * close the connection — so the client can tell which commands succeeded.
+ */
+const testRunner = new TestRunner()
+
+describe(`Raw TCP protocol errors (${testRunner.getBackendName()})`, () => {
+  let port: number
+  const connections: RawRedisConnection[] = []
+
+  before(async () => {
+    port = await testRunner.setupRawStandalone()
+  })
+
+  after(async () => {
+    for (const connection of connections) {
+      connection.close()
+    }
+    connections.length = 0
+    await testRunner.cleanup()
+  })
+
+  async function connect(): Promise<RawRedisConnection> {
+    const connection = await RawRedisConnection.connect('127.0.0.1', port)
+    connections.push(connection)
+    return connection
+  }
+
+  test('answers valid pipelined commands before a trailing bad frame, then closes (#79)', async () => {
+    const conn = await connect()
+    const key = randomKey()
+
+    // One TCP write: two valid commands, then a malformed frame whose bulk
+    // length is not numeric.
+    conn.write(
+      Buffer.concat([
+        commandFrame('SET', key, 'value'),
+        commandFrame('GET', key),
+        Buffer.from('*1\r\n$abc\r\n'),
+      ]),
+    )
+
+    // The valid commands are answered in order...
+    assert.deepStrictEqual(await conn.readRawFrame(), Buffer.from('+OK\r\n'))
+    assert.deepStrictEqual(
+      await conn.readRawFrame(),
+      Buffer.from('$5\r\nvalue\r\n'),
+    )
+
+    // ...then the protocol error is sent and the server hangs up.
+    const tail = await conn.readUntilClose()
+    assert.strictEqual(
+      tail.toString(),
+      '-ERR Protocol error: invalid bulk length\r\n',
+    )
+  })
+})

--- a/tests/core-transport-session.test.ts
+++ b/tests/core-transport-session.test.ts
@@ -113,6 +113,33 @@ describe('new transport-neutral session path', () => {
     assert.strictEqual(transport.getWrittenBuffer().toString(), '+OK\r\n')
   })
 
+  test('flushes responses for valid pipelined frames before a protocol error', async () => {
+    const { session } = createHarness()
+    const transport = new InMemoryConnectionTransport()
+    const adapter = new Resp2SessionAdapter({ transport, session })
+    const running = adapter.run()
+
+    // A single TCP write: two valid commands followed by a malformed frame
+    // (bulk length is not numeric). Real Redis replies to the valid commands
+    // first, then sends the protocol error and closes the connection.
+    transport.feed(
+      Buffer.concat([
+        commandFrame('SET', 'key', 'value'),
+        commandFrame('GET', 'key'),
+        Buffer.from('*1\r\n$abc\r\n'),
+      ]),
+    )
+    transport.endRead()
+
+    await running
+
+    assert.strictEqual(
+      transport.getWrittenBuffer().toString(),
+      '+OK\r\n$5\r\nvalue\r\n-ERR Protocol error: invalid bulk length\r\n',
+    )
+    assert.strictEqual(transport.signal.aborted, true)
+  })
+
   test('drains ResponseStream frames through the same adapter', async () => {
     const { session } = createHarness({ extraCommands: [streamCommand] })
     const transport = new InMemoryConnectionTransport()


### PR DESCRIPTION
## Summary
- A bad frame in a RESP2 pipeline dropped the responses for all valid commands that preceded it and closed the connection.
- Root cause: `Resp2CommandDecoder.push()` threw synchronously on the malformed frame, discarding the `frames` array already collected for the valid earlier commands. `Resp2SessionAdapter` caught the throw, sent a single `-ERR Protocol error`, and closed — so the client never saw replies for the commands that succeeded and couldn't correlate which ones did.
- Fix: `push()` now returns `{ frames, error? }` (new `Resp2DecodeResult` type) instead of throwing — it preserves the valid frames and surfaces the parse error alongside them. `Resp2SessionAdapter.run()` answers the valid frames first, then writes the protocol error and closes, matching real Redis (one reply per valid frame → `-ERR Protocol error...` → close).

Closes #79

## Test plan
- [x] New unit test in `tests/core-transport-session.test.ts` feeds a pipeline of two valid commands + a malformed frame; asserts `+OK\r\n$5\r\nvalue\r\n-ERR Protocol error: invalid bulk length\r\n` and that the connection closed (red before the fix — only the error was written).
- [x] Unit (125) + mock integration (210) + real integration (210) all pass via `npm run test:all`.
- [x] `npm run build` and `npm run lint` clean (1 pre-existing unrelated warning).

> Note: this is a raw-bytes protocol bug — real clients (ioredis/node-redis) never emit malformed frames and the mock backend uses an in-memory transport (no socket), so it's covered at the transport/decoder unit level rather than via the client integration suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)