### PR TITLE
Fix Lua async command ghost writes

### DIFF
--- a/src/core/command-executor.ts
+++ b/src/core/command-executor.ts
@@ -198,8 +198,11 @@ export class CommandExecutor {
    * `redis.call` / `redis.pcall`. Lua expects each nested command to resolve
    * immediately, so anything that would require awaiting — a command that
    * returns a promise, a {@link ResponseStream}, or an async policy hook — is
-   * rejected with a {@link RedisCommandError} instead of being awaited (see
-   * {@link assertSyncCommandResult} / {@link assertSyncPolicyResult}).
+   * rejected with a {@link RedisCommandError} instead of being awaited. Async
+   * command definitions are rejected before invocation so they cannot leave
+   * orphaned work running after the script error (see
+   * {@link assertSyncCommandDefinition}, {@link assertSyncCommandResult}, and
+   * {@link assertSyncPolicyResult}).
    *
    * The policy chain and transaction-dirty handling otherwise mirror the async
    * path exactly.
@@ -221,6 +224,7 @@ export class CommandExecutor {
         }
       }
 
+      assertSyncCommandDefinition(plan)
       const rawResult = plan.definition.execute(plan.args, ctx)
       const result = assertSyncCommandResult(plan, rawResult)
 
@@ -318,6 +322,16 @@ function assertSyncCommandResult(
   return result
 }
 
+function assertSyncCommandDefinition(plan: CommandPlan): void {
+  if (!isAsyncFunction(plan.definition.execute)) {
+    return
+  }
+
+  throw new RedisCommandError(
+    `${plan.definition.name.toUpperCase()} cannot run asynchronously from scripts`,
+  )
+}
+
 /**
  * Same idea as {@link assertSyncCommandResult} but for policy hooks: an async
  * hook result cannot be awaited on the Lua path, so it is rejected with a
@@ -347,6 +361,12 @@ function isThenable(value: unknown): value is PromiseLike<unknown> {
   }
 
   return typeof (value as { then?: unknown }).then === 'function'
+}
+
+function isAsyncFunction(value: unknown): boolean {
+  return (
+    typeof value === 'function' && value.constructor?.name === 'AsyncFunction'
+  )
 }
 
 /**

--- a/tests/core-command-executor.test.ts
+++ b/tests/core-command-executor.test.ts
@@ -303,6 +303,42 @@ describe('new command executor core', () => {
     )
   })
 
+  test('does not start async command definitions in sync execution', async () => {
+    let started = false
+    let mutatedAfterError = false
+    const registry = new CommandRegistry()
+    registry.register(
+      defineCommand({
+        name: 'async-write',
+        schema: t.object({}),
+        flags: ['write'],
+        keys: () => [],
+        execute: async () => {
+          started = true
+          await Promise.resolve()
+          mutatedAfterError = true
+          return RedisResult.ok()
+        },
+      }),
+    )
+
+    const executor = new CommandExecutor({ registry })
+
+    assert.deepStrictEqual(
+      executor.executePlanSync(
+        executor.plan('async-write', []),
+        createContext(executor),
+      ),
+      RedisResult.error(
+        'ASYNC-WRITE cannot run asynchronously from scripts',
+        'ERR',
+      ),
+    )
+    await Promise.resolve()
+    assert.strictEqual(started, false)
+    assert.strictEqual(mutatedAfterError, false)
+  })
+
   test('supports response streams and stream policy hooks', async () => {
     const stream: ResponseStream = {
       kind: 'response-stream',


### PR DESCRIPTION
## Summary
- Reject async command definitions before `executePlanSync` invokes them on the Lua path.
- Keep the existing post-call thenable guard for non-async functions that still return promises.
- Add a regression test proving async command bodies do not start or mutate after the script-facing error.

## Root Cause
`executePlanSync` checked for a thenable only after calling `definition.execute`. For `async` command definitions, the function body starts immediately before returning its promise, so scheduled work can outlive the Lua script error.

## Validation
- Focused regression test failed before the fix and passes after it.
- `node --enable-source-maps --import tsx --no-warnings --test ./tests/core-command-executor.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint` exits 0; existing warning remains in `src/types/respjs.d.ts` for `no-explicit-any`.

Fixes #90