### PR TITLE
Fix LPOP/RPOP count argument

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -176,8 +176,8 @@ surface.
 - [x] `RPUSH key element [element ...]` - Append one or more elements
 - [x] `LPUSHX key element [element ...]` - Prepend, only if the key already exists
 - [x] `RPUSHX key element [element ...]` - Append, only if the key already exists
-- [x] `LPOP key` - Remove and return the first element
-- [x] `RPOP key` - Remove and return the last element
+- [x] `LPOP key [count]` - Remove and return the first element, or up to `count` elements
+- [x] `RPOP key [count]` - Remove and return the last element, or up to `count` elements
 - [x] `LLEN key` - Return the length of the list
 - [x] `LRANGE key start stop` - Get a range of elements
 - [x] `LINDEX key index` - Get an element by index
@@ -190,7 +190,6 @@ surface.
 
 #### Not implemented
 
-- [ ] `LPOP key [count]` / `RPOP key [count]` - count argument not supported (single-element pop only)
 - [ ] `LPOS`
 - [ ] `LINSERT`
 - [ ] `LMOVE` / `BLMOVE`

--- a/src/commands/lists.ts
+++ b/src/commands/lists.ts
@@ -6,6 +6,7 @@ import { RedisResult } from '../core/redis-result'
 import {
   IndexOutOfRangeError,
   NoSuchKeyError,
+  PositiveCountError,
   RedisSyntaxError,
   WrongNumberOfArgumentsError,
 } from '../core/redis-error'
@@ -45,6 +46,48 @@ function listRemove(values: Buffer[], count: number, element: Buffer): number {
     }
   }
   return removed
+}
+
+function popList(
+  args: { key: Buffer; count?: number },
+  ctx: RedisExecutionContext,
+  side: 'left' | 'right',
+): RedisResult {
+  const count = args.count
+  if (count !== undefined && count < 0) {
+    throw new PositiveCountError()
+  }
+
+  const list = ctx.db.getList(args.key)
+  if (!list || list.values.length === 0) {
+    return count === undefined
+      ? bulk(null)
+      : RedisResult.create(RedisValue.nullArray())
+  }
+
+  if (count === undefined) {
+    const result = ctx.db.updateList(args.key, list => {
+      const value = side === 'left' ? list.values.shift() : list.values.pop()
+      return { value: value ?? null, empty: list.values.length === 0 }
+    })
+    if (result.empty) ctx.db.delete(args.key)
+    return bulk(result.value)
+  }
+
+  if (count === 0) {
+    return array([])
+  }
+
+  const result = ctx.db.updateList(args.key, list => {
+    const values =
+      side === 'left'
+        ? list.values.splice(0, count)
+        : list.values.splice(Math.max(0, list.values.length - count))
+    return { values, empty: list.values.length === 0 }
+  })
+  if (result.empty) ctx.db.delete(args.key)
+
+  return array(result.values.map(value => RedisValue.bulkString(value)))
 }
 
 export const lpushCommand = defineCommand({
@@ -89,40 +132,22 @@ export const lpopCommand = defineCommand({
   name: 'lpop',
   schema: t.object({
     key: t.key(),
+    count: t.optional(t.integer()),
   }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
-  execute: (args, ctx) => {
-    const list = ctx.db.getList(args.key)
-    if (!list || list.values.length === 0) return bulk(null)
-
-    const result = ctx.db.updateList(args.key, list => {
-      const value = list.values.shift() ?? null
-      return { value, empty: list.values.length === 0 }
-    })
-    if (result.empty) ctx.db.delete(args.key)
-    return bulk(result.value)
-  },
+  execute: (args, ctx) => popList(args, ctx, 'left'),
 })
 
 export const rpopCommand = defineCommand({
   name: 'rpop',
   schema: t.object({
     key: t.key(),
+    count: t.optional(t.integer()),
   }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
-  execute: (args, ctx) => {
-    const list = ctx.db.getList(args.key)
-    if (!list || list.values.length === 0) return bulk(null)
-
-    const result = ctx.db.updateList(args.key, list => {
-      const value = list.values.pop() ?? null
-      return { value, empty: list.values.length === 0 }
-    })
-    if (result.empty) ctx.db.delete(args.key)
-    return bulk(result.value)
-  },
+  execute: (args, ctx) => popList(args, ctx, 'right'),
 })
 
 export const llenCommand = defineCommand({

--- a/tests-integration/ioredis/list-integration.test.ts
+++ b/tests-integration/ioredis/list-integration.test.ts
@@ -51,6 +51,49 @@ describe(`List Commands Integration (${testRunner.getBackendName()})`, () => {
     assert.strictEqual(empty, null)
   })
 
+  test('LPOP and RPOP support count argument', async () => {
+    const tag = `{list-pop-count:${randomKey()}}`
+    const listKey = `${tag}:values`
+    const directClient = await connectToSlotOwner(redisClient!, listKey)
+
+    try {
+      await directClient.del(listKey)
+      await directClient.rpush(listKey, 'a', 'b', 'c', 'd')
+
+      const leftValues = await directClient.call('LPOP', listKey, '2')
+      assert.deepStrictEqual(leftValues, ['a', 'b'])
+
+      const rightValue = await directClient.call('RPOP', listKey, '1')
+      assert.deepStrictEqual(rightValue, ['d'])
+
+      const remaining = await directClient.lrange(listKey, 0, -1)
+      assert.deepStrictEqual(remaining, ['c'])
+
+      const drained = await directClient.call('RPOP', listKey, '5')
+      assert.deepStrictEqual(drained, ['c'])
+      assert.strictEqual(await directClient.exists(listKey), 0)
+
+      const empty = await directClient.call('LPOP', listKey, '1')
+      assert.strictEqual(empty, null)
+
+      await directClient.rpush(listKey, 'x', 'y')
+      const zeroCount = await directClient.call('LPOP', listKey, '0')
+      assert.deepStrictEqual(zeroCount, [])
+      assert.deepStrictEqual(await directClient.lrange(listKey, 0, -1), [
+        'x',
+        'y',
+      ])
+
+      await assert.rejects(
+        () => directClient.call('LPOP', listKey, '-1'),
+        errorWithMessage('ERR value is out of range, must be positive'),
+      )
+    } finally {
+      await directClient.del(listKey)
+      directClient.disconnect()
+    }
+  })
+
   test('LLEN command', async () => {
     // Empty list
     const len1 = await redisClient?.llen('emptylist')


### PR DESCRIPTION
## Summary
- Add Redis 6.2-style optional `count` support for `LPOP` and `RPOP`.
- Preserve single-element bulk replies when count is omitted, and return array/nil-array replies when count is provided.
- Add ioredis integration coverage for count arrays, draining, empty replies, zero count, and negative count validation.

## Root cause
`LPOP` and `RPOP` schemas only accepted `key`, so calls with the Redis-supported optional count argument were rejected at parse time with a wrong-arity error.

## Validation
- Focused mock integration failed before the fix with `ERR wrong number of arguments for 'lpop' command`.
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/list-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/list-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run clean:redis`
- `npm run test:integration:real`
- `npm run lint` (passes with existing warning in `src/types/respjs.d.ts`)

Fixes #21
