### PR TITLE
Fix SPOP count argument

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -202,7 +202,7 @@ surface.
 - [x] `SCARD key` - Get the number of members in a set
 - [x] `SMEMBERS key` - Get all members in a set
 - [x] `SISMEMBER key member` - Determine if a value is a member of a set
-- [x] `SPOP key` - Remove and return a random member
+- [x] `SPOP key [count]` - Remove and return one or more random members
 - [x] `SRANDMEMBER key [count]` - Get one or more random members without removing them
 - [x] `SMOVE source destination member` - Move a member between sets
 - [x] `SDIFF key [key ...]` / `SDIFFSTORE destination key [key ...]` - Set difference
@@ -212,7 +212,6 @@ surface.
 
 #### Not implemented
 
-- [ ] `SPOP key count` - count argument not supported (single-element pop only)
 - [ ] `SMISMEMBER key member [member ...]`
 - [ ] `SINTERCARD`
 

--- a/src/commands/sets.ts
+++ b/src/commands/sets.ts
@@ -2,7 +2,7 @@ import { defineCommand } from '../core/command-definition'
 import { t } from '../core/command-schema'
 import { integer, bulk, array } from './helpers'
 import { RedisValue } from '../core/redis-value'
-import { WrongTypeRedisError } from '../core/redis-error'
+import { PositiveCountError, WrongTypeRedisError } from '../core/redis-error'
 import type { RedisDatabase } from '../state'
 
 // ---------------------------------------------------------------------------
@@ -167,28 +167,58 @@ export const sismemberCommand = defineCommand({
 })
 
 // ---------------------------------------------------------------------------
-// SPOP key
+// SPOP key [count]
 // ---------------------------------------------------------------------------
 
 export const spopCommand = defineCommand({
   name: 'spop',
-  schema: t.object({ key: t.key() }),
+  schema: t.object({ key: t.key(), count: t.optional(t.integer()) }),
   flags: ['write', 'random', 'fast', 'noscript'],
   keys: args => [args.key],
   execute: (args, ctx) => {
+    if (args.count !== undefined && args.count < 0) {
+      throw new PositiveCountError()
+    }
+
     const type = ctx.db.getType(args.key)
-    if (type === null) return bulk(null)
+    if (type === null) return args.count === undefined ? bulk(null) : array([])
     if (type !== 'set') throw new WrongTypeRedisError()
+
+    if (args.count === undefined) {
+      const result = ctx.db.updateSet(args.key, set => {
+        if (set.members.size === 0)
+          return { member: null as Buffer | null, empty: false }
+        const entries = Array.from(set.members.entries())
+        const [hex, member] =
+          entries[Math.floor(Math.random() * entries.length)]
+        set.members.delete(hex)
+        return { member, empty: set.members.size === 0 }
+      })
+      if (result.empty) ctx.db.delete(args.key)
+      return bulk(result.member)
+    }
+
+    if (args.count === 0) return array([])
+
     const result = ctx.db.updateSet(args.key, set => {
       if (set.members.size === 0)
-        return { member: null as Buffer | null, empty: false }
+        return { members: [] as Buffer[], empty: true }
       const entries = Array.from(set.members.entries())
-      const [hex, member] = entries[Math.floor(Math.random() * entries.length)]
-      set.members.delete(hex)
-      return { member, empty: set.members.size === 0 }
+      const size = Math.min(args.count!, entries.length)
+      const members: Buffer[] = []
+
+      for (let i = 0; i < size; i++) {
+        const j = i + Math.floor(Math.random() * (entries.length - i))
+        ;[entries[i], entries[j]] = [entries[j], entries[i]]
+        const [hex, member] = entries[i]
+        set.members.delete(hex)
+        members.push(member)
+      }
+
+      return { members, empty: set.members.size === 0 }
     })
     if (result.empty) ctx.db.delete(args.key)
-    return bulk(result.member)
+    return array(result.members.map(member => RedisValue.bulkString(member)))
   },
 })
 

--- a/tests-integration/ioredis/set-commands-integration.test.ts
+++ b/tests-integration/ioredis/set-commands-integration.test.ts
@@ -100,6 +100,50 @@ describe(`Set Commands Integration (${testRunner.getBackendName()})`, () => {
     assert.strictEqual(empty, null)
   })
 
+  test('SPOP command with count', async () => {
+    const key = `{spop-count:${randomKey()}}:set`
+    const missingKey = `${key}:missing`
+
+    try {
+      await redisClient?.sadd(key, 'a', 'b', 'c', 'd')
+
+      const poppedOne = await redisClient?.spop(key, 1)
+      assert.ok(Array.isArray(poppedOne))
+      assert.strictEqual(poppedOne.length, 1)
+      assert.ok(['a', 'b', 'c', 'd'].includes(poppedOne[0]))
+
+      const cardAfterOne = await redisClient?.scard(key)
+      assert.strictEqual(cardAfterOne, 3)
+
+      const poppedRest = await redisClient?.spop(key, 10)
+      assert.ok(Array.isArray(poppedRest))
+      assert.strictEqual(poppedRest.length, 3)
+      assert.deepStrictEqual([...poppedOne, ...poppedRest].sort(), [
+        'a',
+        'b',
+        'c',
+        'd',
+      ])
+
+      const missing = await redisClient?.spop(missingKey, 2)
+      assert.deepStrictEqual(missing, [])
+
+      await redisClient?.sadd(key, 'remaining')
+      const zero = await redisClient?.spop(key, 0)
+      assert.deepStrictEqual(zero, [])
+
+      const cardAfterZero = await redisClient?.scard(key)
+      assert.strictEqual(cardAfterZero, 1)
+
+      await assert.rejects(
+        () => redisClient?.call('SPOP', key, '-1'),
+        errorWithMessage('ERR value is out of range, must be positive'),
+      )
+    } finally {
+      await redisClient?.del(key, missingKey)
+    }
+  })
+
   test('SRANDMEMBER command', async () => {
     await redisClient?.sadd('set6', 'a', 'b', 'c')
 


### PR DESCRIPTION
Summary:
- add Redis-compatible SPOP key [count] support
- return arrays for counted SPOP calls, including empty arrays for missing keys and count 0
- document SPOP count support and cover it in ioredis integration tests

Root cause:
- spopCommand only accepted a key argument and always returned a bulk string, so clients calling the Redis 3.2+ count form received a wrong-arity error.

Validation:
- focused mock ioredis set integration failed before the fix on SPOP key count
- TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/set-commands-integration.test.ts
- TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/set-commands-integration.test.ts
- npm run build
- npm test
- npm run test:integration:mock
- npm run test:integration:real
- npm run lint (passes with existing warning in src/types/respjs.d.ts)

Fixes #22