### PR TITLE
Fix zset score range bounds

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -226,9 +226,9 @@ surface.
 - [x] `ZREVRANK key member` - Get the index of a member, highest score first
 - [x] `ZRANGE key start stop [WITHSCORES]` - Return a range of members by index
 - [x] `ZREVRANGE key start stop [WITHSCORES]` - Return a range of members by index, high to low
-- [x] `ZRANGEBYSCORE key min max` - Return members with scores between min and max
-- [x] `ZREMRANGEBYSCORE key min max` - Remove members with scores between min and max
-- [x] `ZCOUNT key min max` - Count members with scores between min and max
+- [x] `ZRANGEBYSCORE key min max` - Return members with scores between min and max (`-inf`, `+inf`, and exclusive `(score` bounds supported)
+- [x] `ZREMRANGEBYSCORE key min max` - Remove members with scores between min and max (`-inf`, `+inf`, and exclusive `(score` bounds supported)
+- [x] `ZCOUNT key min max` - Count members with scores between min and max (`-inf`, `+inf`, and exclusive `(score` bounds supported)
 - [x] `ZPOPMIN key [count]` - Remove and return members with the lowest scores
 - [x] `ZPOPMAX key [count]` - Remove and return members with the highest scores
 - [x] `ZSCAN key cursor [MATCH pattern] [COUNT count]` - Incrementally iterate members and scores (see [Scan Family](#10-scan-family))
@@ -237,7 +237,6 @@ surface.
 
 - [ ] `ZADD` does not support `NX`, `XX`, `GT`, `LT`, `CH`, or `INCR` - only plain `score member` pairs
 - [ ] `ZRANGE`/`ZREVRANGE` do not support the Redis 6.2+ unified syntax (`BYSCORE`, `BYLEX`, `REV`, `LIMIT offset count`) - `start`/`stop` are always treated as indexes
-- [ ] `ZRANGEBYSCORE`/`ZREMRANGEBYSCORE`/`ZCOUNT` `min`/`max` must be plain numbers - `-inf`/`+inf` and exclusive `(score` syntax are **not** supported and throw `ERR min or max is not a float`
 - [ ] `ZRANGEBYSCORE` does not support `WITHSCORES` or `LIMIT offset count`
 - [ ] `ZRANK`/`ZREVRANK` do not support the Redis 7.2 `WITHSCORE` option
 

--- a/src/commands/zsets.ts
+++ b/src/commands/zsets.ts
@@ -28,10 +28,27 @@ function parseFloatArg(s: string): number {
   return n
 }
 
-function parseScoreBoundArg(s: string): number {
-  const n = Number(s)
+type ScoreBound = { value: number; exclusive: boolean }
+
+function parseScoreBoundArg(s: string): ScoreBound {
+  const exclusive = s.startsWith('(')
+  const raw = exclusive ? s.slice(1) : s
+
+  if (raw.length === 0) throw new MinMaxNotFloatError()
+
+  const normalized = raw.toLowerCase()
+  if (normalized === '+inf') return { value: Infinity, exclusive }
+  if (normalized === '-inf') return { value: -Infinity, exclusive }
+
+  const n = Number(raw)
   if (!Number.isFinite(n)) throw new MinMaxNotFloatError()
-  return n
+  return { value: n, exclusive }
+}
+
+function scoreWithinBounds(score: number, min: ScoreBound, max: ScoreBound) {
+  if (min.exclusive ? score <= min.value : score < min.value) return false
+  if (max.exclusive ? score >= max.value : score > max.value) return false
+  return true
 }
 
 function parsePopCountArg(s: string): number {
@@ -262,7 +279,7 @@ export const zrangebyscoreCommand = defineCommand({
     if (!zset) return array([])
     const items: RedisValue[] = []
     for (const entry of getSortedMembers(zset)) {
-      if (entry.score >= min && entry.score <= max) {
+      if (scoreWithinBounds(entry.score, min, max)) {
         items.push(RedisValue.bulkString(entry.member))
       }
     }
@@ -281,7 +298,7 @@ export const zremrangebyscoreCommand = defineCommand({
     let removed = 0
     ctx.db.updateSortedSet(args.key, zset => {
       for (const [hex, entry] of zset.members) {
-        if (entry.score >= min && entry.score <= max) {
+        if (scoreWithinBounds(entry.score, min, max)) {
           zset.members.delete(hex)
           removed++
         }
@@ -309,7 +326,7 @@ export const zcountCommand = defineCommand({
     if (!zset) return integer(0)
     let count = 0
     for (const entry of zset.members.values()) {
-      if (entry.score >= min && entry.score <= max) count++
+      if (scoreWithinBounds(entry.score, min, max)) count++
     }
     return integer(count)
   },

--- a/tests-integration/ioredis/zset-integration.test.ts
+++ b/tests-integration/ioredis/zset-integration.test.ts
@@ -183,6 +183,48 @@ describe(`Sorted Set Commands Integration (${testRunner.getBackendName()})`, () 
     }
   })
 
+  test('score range commands support infinite and exclusive bounds', async () => {
+    const zsetKey = `{zset-score-bounds:${randomKey()}}`
+
+    try {
+      await redisClient?.zadd(
+        zsetKey,
+        0,
+        'zero',
+        1,
+        'one',
+        2,
+        'two',
+        3,
+        'three',
+      )
+
+      assert.deepStrictEqual(
+        await redisClient?.zrangebyscore(zsetKey, '-inf', '+inf'),
+        ['zero', 'one', 'two', 'three'],
+      )
+      assert.deepStrictEqual(
+        await redisClient?.zrangebyscore(zsetKey, '(1', '3'),
+        ['two', 'three'],
+      )
+      assert.deepStrictEqual(
+        await redisClient?.zrangebyscore(zsetKey, '1', '(3'),
+        ['one', 'two'],
+      )
+      assert.strictEqual(await redisClient?.zcount(zsetKey, '(1', '+inf'), 2)
+      assert.strictEqual(
+        await redisClient?.zremrangebyscore(zsetKey, '-inf', '(2'),
+        2,
+      )
+      assert.deepStrictEqual(await redisClient?.zrange(zsetKey, 0, -1), [
+        'two',
+        'three',
+      ])
+    } finally {
+      await redisClient?.del(zsetKey)
+    }
+  })
+
   test('ZREM command', async () => {
     await redisClient?.zadd('zset7', 1, 'one', 2, 'two', 3, 'three', 4, 'four')
 


### PR DESCRIPTION
## Summary
- Accept `-inf`/`+inf` score bounds for `ZRANGEBYSCORE`, `ZREMRANGEBYSCORE`, and `ZCOUNT`.
- Respect Redis exclusive score bounds using `(score` syntax.
- Add ioredis integration coverage for infinite and exclusive sorted-set ranges, and update command docs.

## Root Cause
The sorted-set score-bound parser used `Number(...)` and rejected all non-finite values, so Redis-valid `-inf`/`+inf` bounds failed. It also returned only a number, leaving no way for range comparisons to distinguish inclusive from exclusive bounds.

## Validation
- Focused mock integration: `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/zset-integration.test.ts`
- Focused real integration: `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/zset-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`

Fixes #15
