### PR TITLE
Fix ZADD option flags

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -217,7 +217,7 @@ surface.
 
 ## 8. Sorted Set Commands
 
-- [x] `ZADD key score member [score member ...]` - Add or update members with scores
+- [x] `ZADD key [NX | XX] [GT | LT] [CH] [INCR] score member [score member ...]` - Add or update members with scores
 - [x] `ZREM key member [member ...]` - Remove one or more members
 - [x] `ZCARD key` - Get the number of members
 - [x] `ZSCORE key member` - Get the score of a member
@@ -235,7 +235,6 @@ surface.
 
 #### Notes / gaps vs. real Redis
 
-- [ ] `ZADD` does not support `NX`, `XX`, `GT`, `LT`, `CH`, or `INCR` - only plain `score member` pairs
 - [ ] `ZRANGE`/`ZREVRANGE` do not support the Redis 6.2+ unified syntax (`BYSCORE`, `BYLEX`, `REV`, `LIMIT offset count`) - `start`/`stop` are always treated as indexes
 - [ ] `ZRANGEBYSCORE` does not support `WITHSCORES` or `LIMIT offset count`
 - [ ] `ZRANK`/`ZREVRANK` do not support the Redis 7.2 `WITHSCORE` option

--- a/src/commands/zsets.ts
+++ b/src/commands/zsets.ts
@@ -5,9 +5,13 @@ import {
   MinMaxNotFloatError,
   PositiveCountError,
   WrongNumberOfArgumentsError,
+  ZaddGtLtNxConflictError,
+  ZaddIncrPairError,
+  ZaddNxXxConflictError,
 } from '../core/redis-error'
 import { RedisResult } from '../core/redis-result'
 import { RedisValue } from '../core/redis-value'
+import type { RedisDatabase } from '../state/database'
 import type {
   RedisSortedSetData,
   RedisSortedSetMember,
@@ -65,45 +69,188 @@ function parsePopCountArg(s: string): number {
 }
 
 type ZaddPair = { score: number; member: Buffer }
+type ZaddCondition = 'NX' | 'XX'
+type ZaddComparison = 'GT' | 'LT'
 
-function createZaddPairsSchema() {
-  return t.custom<ZaddPair[]>(
+type ZaddOptions = {
+  condition?: ZaddCondition
+  comparison?: ZaddComparison
+  ch: boolean
+  incr: boolean
+}
+
+type ZaddArgs = {
+  key: Buffer
+  options: ZaddOptions
+  pairs: ZaddPair[]
+}
+
+function createZaddSchema() {
+  return t.custom<ZaddArgs>(
     (input: readonly Buffer[], index: number, ctx: ParseContext) => {
-      const pairs: ZaddPair[] = []
-      let cursor = index
-      if (cursor >= input.length)
+      const key = input[index]
+      if (!key) {
         throw new WrongNumberOfArgumentsError(ctx.commandName)
-      while (cursor < input.length) {
-        const scoreToken = input[cursor]
-        const memberToken = input[cursor + 1]
-        if (!scoreToken || !memberToken)
-          throw new WrongNumberOfArgumentsError(ctx.commandName)
-        const score = Number(scoreToken.toString())
-        if (!Number.isFinite(score)) throw new ExpectedFloatError()
-        pairs.push({ score, member: memberToken })
-        cursor += 2
       }
-      return { value: pairs, nextIndex: cursor }
+
+      const options: ZaddOptions = { ch: false, incr: false }
+      let cursor = index + 1
+
+      while (cursor < input.length) {
+        const option = input[cursor]!.toString().toUpperCase()
+
+        if (option === 'NX') {
+          if (options.condition === 'XX') throw new ZaddNxXxConflictError()
+          options.condition = 'NX'
+          cursor++
+          continue
+        }
+
+        if (option === 'XX') {
+          if (options.condition === 'NX') throw new ZaddNxXxConflictError()
+          options.condition = 'XX'
+          cursor++
+          continue
+        }
+
+        if (option === 'GT') {
+          if (options.comparison === 'LT') {
+            throw new ZaddGtLtNxConflictError()
+          }
+          options.comparison = 'GT'
+          cursor++
+          continue
+        }
+
+        if (option === 'LT') {
+          if (options.comparison === 'GT') {
+            throw new ZaddGtLtNxConflictError()
+          }
+          options.comparison = 'LT'
+          cursor++
+          continue
+        }
+
+        if (option === 'CH') {
+          options.ch = true
+          cursor++
+          continue
+        }
+
+        if (option === 'INCR') {
+          options.incr = true
+          cursor++
+          continue
+        }
+
+        break
+      }
+
+      if (options.condition === 'NX' && options.comparison) {
+        throw new ZaddGtLtNxConflictError()
+      }
+
+      const pairs = parseZaddPairs(input, cursor, ctx)
+      if (options.incr && pairs.length !== 1) {
+        throw new ZaddIncrPairError()
+      }
+
+      return { value: { key, options, pairs }, nextIndex: input.length }
     },
   )
 }
 
+function parseZaddPairs(
+  input: readonly Buffer[],
+  index: number,
+  ctx: ParseContext,
+): ZaddPair[] {
+  const pairs: ZaddPair[] = []
+  let cursor = index
+
+  if (cursor >= input.length) {
+    throw new WrongNumberOfArgumentsError(ctx.commandName)
+  }
+
+  while (cursor < input.length) {
+    const scoreToken = input[cursor]
+    const memberToken = input[cursor + 1]
+    if (!scoreToken || !memberToken) {
+      throw new WrongNumberOfArgumentsError(ctx.commandName)
+    }
+
+    const score = Number(scoreToken.toString())
+    if (!Number.isFinite(score)) throw new ExpectedFloatError()
+
+    pairs.push({ score, member: memberToken })
+    cursor += 2
+  }
+
+  return pairs
+}
+
+function shouldApplyZaddUpdate(
+  existing: RedisSortedSetMember | undefined,
+  score: number,
+  options: ZaddOptions,
+): boolean {
+  if (!existing) return options.condition !== 'XX'
+  if (options.condition === 'NX') return false
+  if (options.comparison === 'GT') return score > existing.score
+  if (options.comparison === 'LT') return score < existing.score
+  return true
+}
+
+function deleteSortedSetIfEmpty(db: RedisDatabase, key: Buffer) {
+  if ((db.getSortedSet(key)?.members.size ?? 0) === 0) {
+    db.delete(key)
+  }
+}
+
 export const zaddCommand = defineCommand({
   name: 'zadd',
-  schema: t.object({ key: t.key(), pairs: createZaddPairsSchema() }),
+  schema: createZaddSchema(),
   flags: ['write', 'denyoom', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const added = ctx.db.updateSortedSet(args.key, zset => {
+    if (args.options.incr) {
+      const [{ score, member }] = args.pairs
+      const newScore = ctx.db.updateSortedSet(args.key, zset => {
+        const hex = member.toString('hex')
+        const existing = zset.members.get(hex)
+        const nextScore = (existing?.score ?? 0) + score
+
+        if (!shouldApplyZaddUpdate(existing, nextScore, args.options)) {
+          return null
+        }
+
+        zset.members.set(hex, { member, score: nextScore })
+        return nextScore
+      })
+      deleteSortedSetIfEmpty(ctx.db, args.key)
+      return bulk(newScore === null ? null : Buffer.from(newScore.toString()))
+    }
+
+    const changed = ctx.db.updateSortedSet(args.key, zset => {
       let count = 0
       for (const { score, member } of args.pairs) {
         const hex = member.toString('hex')
-        if (!zset.members.has(hex)) count++
+        const existing = zset.members.get(hex)
+
+        if (!shouldApplyZaddUpdate(existing, score, args.options)) {
+          continue
+        }
+
+        if (!existing || args.options.ch) {
+          if (!existing || existing.score !== score) count++
+        }
+
         zset.members.set(hex, { member, score })
       }
       return count
     })
-    return integer(added)
+    deleteSortedSetIfEmpty(ctx.db, args.key)
+    return integer(changed)
   },
 })
 

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -67,6 +67,24 @@ export class PositiveCountError extends RedisCommandError {
   }
 }
 
+export class ZaddNxXxConflictError extends RedisCommandError {
+  constructor() {
+    super('XX and NX options at the same time are not compatible')
+  }
+}
+
+export class ZaddGtLtNxConflictError extends RedisCommandError {
+  constructor() {
+    super('GT, LT, and/or NX options at the same time are not compatible')
+  }
+}
+
+export class ZaddIncrPairError extends RedisCommandError {
+  constructor() {
+    super('INCR option supports a single increment-element pair')
+  }
+}
+
 export class OffsetOutOfRangeError extends RedisCommandError {
   constructor() {
     super('offset is out of range')

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,9 @@ export {
   NoAuthError,
   NoPasswordConfiguredError,
   WrongPassError,
+  ZaddGtLtNxConflictError,
+  ZaddIncrPairError,
+  ZaddNxXxConflictError,
 } from './core/redis-error'
 export {
   createAuthPolicy,

--- a/tests-integration/ioredis/zset-integration.test.ts
+++ b/tests-integration/ioredis/zset-integration.test.ts
@@ -35,6 +35,87 @@ describe(`Sorted Set Commands Integration (${testRunner.getBackendName()})`, () 
     assert.strictEqual(card, 3)
   })
 
+  test('ZADD option flags match Redis', async () => {
+    const zsetKey = `{zadd-options:${randomKey()}}`
+
+    try {
+      assert.strictEqual(await redisClient?.zadd(zsetKey, 'NX', 1, 'one'), 1)
+      assert.strictEqual(await redisClient?.zadd(zsetKey, 'NX', 2, 'one'), 0)
+      assert.strictEqual(await redisClient?.zscore(zsetKey, 'one'), '1')
+
+      assert.strictEqual(await redisClient?.zadd(zsetKey, 'XX', 2, 'one'), 0)
+      assert.strictEqual(await redisClient?.zscore(zsetKey, 'one'), '2')
+      assert.strictEqual(await redisClient?.zadd(zsetKey, 'XX', 3, 'two'), 0)
+      assert.strictEqual(await redisClient?.zscore(zsetKey, 'two'), null)
+
+      assert.strictEqual(await redisClient?.zadd(zsetKey, 'GT', 1, 'one'), 0)
+      assert.strictEqual(await redisClient?.zscore(zsetKey, 'one'), '2')
+      assert.strictEqual(await redisClient?.zadd(zsetKey, 'GT', 3, 'one'), 0)
+      assert.strictEqual(await redisClient?.zscore(zsetKey, 'one'), '3')
+
+      assert.strictEqual(await redisClient?.zadd(zsetKey, 'LT', 4, 'one'), 0)
+      assert.strictEqual(await redisClient?.zscore(zsetKey, 'one'), '3')
+      assert.strictEqual(await redisClient?.zadd(zsetKey, 'LT', 2, 'one'), 0)
+      assert.strictEqual(await redisClient?.zscore(zsetKey, 'one'), '2')
+
+      assert.strictEqual(
+        await redisClient?.zadd(zsetKey, 'CH', 2, 'one', 4, 'two'),
+        1,
+      )
+      assert.strictEqual(await redisClient?.zadd(zsetKey, 'CH', 5, 'two'), 1)
+      assert.strictEqual(await redisClient?.zadd(zsetKey, 'CH', 5, 'two'), 0)
+
+      assert.strictEqual(
+        await redisClient?.zadd(zsetKey, 'INCR', 2.5, 'one'),
+        '4.5',
+      )
+      assert.strictEqual(await redisClient?.zscore(zsetKey, 'one'), '4.5')
+      assert.strictEqual(
+        await redisClient?.zadd(zsetKey, 'NX', 'INCR', 1, 'one'),
+        null,
+      )
+      assert.strictEqual(
+        await redisClient?.zadd(zsetKey, 'XX', 'INCR', 1, 'missing'),
+        null,
+      )
+    } finally {
+      await redisClient?.del(zsetKey)
+    }
+  })
+
+  test('ZADD option syntax errors match Redis', async () => {
+    const zsetKey = `{zadd-option-errors:${randomKey()}}`
+
+    try {
+      await assert.rejects(
+        () => redisClient?.zadd(zsetKey, 'NX', 'XX', 1, 'one'),
+        errorWithMessage(
+          'ERR XX and NX options at the same time are not compatible',
+        ),
+      )
+      await assert.rejects(
+        () => redisClient?.zadd(zsetKey, 'GT', 'LT', 1, 'one'),
+        errorWithMessage(
+          'ERR GT, LT, and/or NX options at the same time are not compatible',
+        ),
+      )
+      await assert.rejects(
+        () => redisClient?.zadd(zsetKey, 'NX', 'GT', 1, 'one'),
+        errorWithMessage(
+          'ERR GT, LT, and/or NX options at the same time are not compatible',
+        ),
+      )
+      await assert.rejects(
+        () => redisClient?.zadd(zsetKey, 'INCR', 1, 'one', 2, 'two'),
+        errorWithMessage(
+          'ERR INCR option supports a single increment-element pair',
+        ),
+      )
+    } finally {
+      await redisClient?.del(zsetKey)
+    }
+  })
+
   test('ZSCORE command', async () => {
     await redisClient?.zadd('zset2', 15, 'member1', 25, 'member2')
 


### PR DESCRIPTION
## Summary
- Add Redis-compatible `ZADD` parsing for `NX`, `XX`, `GT`, `LT`, `CH`, and `INCR`.
- Match Redis conflict errors for incompatible option combinations and `INCR` arity.
- Document the expanded `ZADD` syntax and cover the behavior in ioredis integration tests.

## Root Cause
`ZADD` only parsed plain `score member` pairs, so option tokens were treated as scores and failed with `ERR value is not a valid float` before command semantics could run.

## Validation
- Focused mock: `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/zset-integration.test.ts`
- Focused real: `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/zset-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint` (passes with existing warning in `src/types/respjs.d.ts`)

Fixes #16
