### PR TITLE
Fix HELLO replica role reporting

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -12,7 +12,7 @@ only a subset of the real Redis syntax, the supported syntax is shown and a
 - [x] `QUIT` - Close the connection
 - [x] `SELECT index` - Change the selected database
 - [x] `RESET` - Reset connection state (auth, MULTI/WATCH, RESP version, db, cluster read-only flag, client name) to defaults
-- [x] `HELLO [protover [AUTH username password] [SETNAME clientname]]` - Switch protocol (RESP2/3), optionally authenticate and set the connection name in one round trip
+- [x] `HELLO [protover [AUTH username password] [SETNAME clientname]]` - Switch protocol (RESP2/3), optionally authenticate and set the connection name in one round trip; reports the current cluster node role
 
 #### AUTH
 

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -148,6 +148,7 @@ export function buildRedisCluster(options: RedisClusterOptions): RedisCluster {
       server: state,
       executor,
       logger: options.logger,
+      nodeRole: node.role,
     })
 
     handles.push({

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -482,7 +482,7 @@ export const helloCommand = defineCommand({
       [value('proto'), RedisValue.integer(version)],
       [value('id'), RedisValue.integer(getClientId(ctx.session))],
       [value('mode'), value(redisMode(ctx))],
-      [value('role'), value('master')],
+      [value('role'), value(ctx.nodeRole ?? 'master')],
       [value('modules'), RedisValue.array([])],
     ]
 

--- a/src/core/client-session.ts
+++ b/src/core/client-session.ts
@@ -13,13 +13,19 @@ import { RedisResult } from './redis-result'
 import { RedisValue } from './redis-value'
 import type { RespVersion } from './resp-encoder'
 import { type RedisTurnHandle, type RedisTurnQueue } from './turn-queue'
-import type { RedisDatabase, RedisServerState, Unsubscribe } from '../state'
+import type {
+  RedisClusterNodeRole,
+  RedisDatabase,
+  RedisServerState,
+  Unsubscribe,
+} from '../state'
 
 export type ClientSessionOptions = {
   id?: string
   server: RedisServerState
   executor: CommandExecutor
   database?: number
+  nodeRole?: RedisClusterNodeRole
   signal?: AbortSignal
   park?: ParkHandler
   turnQueue?: RedisTurnQueue
@@ -68,6 +74,7 @@ export class ClientSession implements RedisClientSession {
 
   private readonly executor: CommandExecutor
   private readonly signalSource?: AbortController
+  private readonly nodeRole?: RedisClusterNodeRole
   private readonly parkHandler: ParkHandler
   private readonly turnQueueOverride?: RedisTurnQueue
   /**
@@ -96,6 +103,7 @@ export class ClientSession implements RedisClientSession {
     this.server = options.server
     this.executor = options.executor
     this.selectedDatabaseId = options.database ?? 0
+    this.nodeRole = options.nodeRole
     this.parkHandler = options.park ?? createDefaultParkHandler()
     this.turnQueueOverride = options.turnQueue
 
@@ -406,6 +414,7 @@ export class ClientSession implements RedisClientSession {
       server: this.server,
       session: this,
       executor: this.executor,
+      ...(this.nodeRole ? { nodeRole: this.nodeRole } : {}),
       signal: this.signal,
       park:
         parkOverride ??

--- a/src/core/redis-context.ts
+++ b/src/core/redis-context.ts
@@ -1,4 +1,8 @@
-import type { RedisDatabase, RedisServerState } from '../state'
+import type {
+  RedisClusterNodeRole,
+  RedisDatabase,
+  RedisServerState,
+} from '../state'
 import type { CommandExecutor } from './command-executor'
 import type { CommandPlan } from './command-definition'
 import type { RedisResult } from './redis-result'
@@ -44,6 +48,7 @@ export interface RedisExecutionContext {
   readonly server: RedisServerState
   readonly session: RedisClientSession
   readonly executor: CommandExecutor
+  readonly nodeRole?: RedisClusterNodeRole
   readonly signal: AbortSignal
   park: ParkHandler
 }

--- a/src/core/transports/resp2/server.ts
+++ b/src/core/transports/resp2/server.ts
@@ -2,7 +2,7 @@ import { AddressInfo, Server, Socket, createServer } from 'net'
 import { ClientSession } from '../../client-session'
 import type { CommandExecutor } from '../../command-executor'
 import type { Logger } from '../../../logger'
-import type { RedisServerState } from '../../../state'
+import type { RedisClusterNodeRole, RedisServerState } from '../../../state'
 import type { RespEncodeOptions } from '../../resp-encoder'
 import { SocketConnectionTransport } from '../socket-connection-transport'
 import { Resp2SessionAdapter } from './session-adapter'
@@ -12,6 +12,7 @@ export type Resp2ServerOptions = {
   executor: CommandExecutor
   logger?: Pick<Logger, 'error'>
   encoder?: RespEncodeOptions
+  nodeRole?: RedisClusterNodeRole
 }
 
 export class Resp2Server {
@@ -21,6 +22,7 @@ export class Resp2Server {
   private readonly executor: CommandExecutor
   private readonly logger?: Pick<Logger, 'error'>
   private readonly encoder?: RespEncodeOptions
+  private readonly nodeRole?: RedisClusterNodeRole
   private readonly adapters = new Set<Resp2SessionAdapter>()
 
   constructor(options: Resp2ServerOptions) {
@@ -28,6 +30,7 @@ export class Resp2Server {
     this.executor = options.executor
     this.logger = options.logger
     this.encoder = options.encoder
+    this.nodeRole = options.nodeRole
 
     this.server = createServer({ keepAlive: true })
       .on('error', err => this.logger?.error(err))
@@ -85,6 +88,7 @@ export class Resp2Server {
     const session = new ClientSession({
       server: this.state,
       executor: this.executor,
+      nodeRole: this.nodeRole,
     })
     const adapter = new Resp2SessionAdapter({
       transport,

--- a/tests-integration/ioredis/cluster-integration.test.ts
+++ b/tests-integration/ioredis/cluster-integration.test.ts
@@ -101,6 +101,27 @@ describe(`Cluster protocol integration (${testRunner.getBackendName()})`, () => 
     }
   })
 
+  test('HELLO reports master and replica roles for direct node connections', async () => {
+    const key = `{hello-role:${randomKey()}}:probe`
+    const { master, replica } = await findSlotMasterAndReplica(
+      redisClient!,
+      key,
+    )
+    const masterClient = await connectToEndpoint(master)
+    const replicaClient = await connectToEndpoint(replica)
+
+    try {
+      const masterHello = (await masterClient.call('HELLO', '2')) as unknown[]
+      const replicaHello = (await replicaClient.call('HELLO', '2')) as unknown[]
+
+      assertHelloEntry(masterHello, 'role', 'master')
+      assertHelloEntry(replicaHello, 'role', 'replica')
+    } finally {
+      masterClient.disconnect()
+      replicaClient.disconnect()
+    }
+  })
+
   test('READONLY lets direct replica connections serve readonly commands for master slots', async () => {
     const tag = `readonly:${randomKey()}`
     const key = `{${tag}}:key`
@@ -277,4 +298,14 @@ async function findDifferentNodeKeys(cluster: Cluster): Promise<{
   }
 
   throw new Error('Could not find keys owned by different cluster nodes')
+}
+
+function assertHelloEntry(
+  reply: unknown[],
+  key: string,
+  expected: string | number,
+): void {
+  const index = reply.indexOf(key)
+  assert.notStrictEqual(index, -1)
+  assert.strictEqual(reply[index + 1], expected)
 }


### PR DESCRIPTION
## Summary
- Thread the cluster node role into command execution contexts for direct node connections.
- Use that role in HELLO so replicas report `role=replica` while standalone/master nodes still report `master`.
- Add ioredis cluster integration coverage for direct master and replica HELLO responses.

## Root Cause
`helloCommand` hardcoded the HELLO `role` field to `master`, and the command execution context had no node-role metadata for cluster replicas.

## Validation
- Focused mock integration red before fix: new HELLO role test failed with `actual: master`, `expected: replica`.
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/cluster-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/cluster-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`
- Pre-push hook: `npm test`

Fixes #14