### PR TITLE
fix: return RESP3 maps for map replies

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -347,11 +347,14 @@ inline arguments) for the request side.
 On the reply side, [`encodeRedisValue`](../src/core/resp-encoder.ts#L17)
 serializes the protocol-agnostic [`RedisValue`](../src/core/redis-value.ts)
 union (`simple-string`, `bulk-string`, `integer`, `double`, `boolean`,
-`big-number`, `verbatim`, `array`, `set`, `map`, `push`, `null`, `error`, ...)
+`big-number`, `verbatim`, `array`, `set`, `map`, `map-pairs`, `push`, `null`, `error`, ...)
 to either RESP2 or RESP3 wire bytes. Each connection starts on RESP2; sending
-`HELLO 3` switches that single session to RESP3 — `RedisValue.map`/`set`/`double`/
-`boolean`/`bigNumber`/`push` then encode as their native RESP3 types (`%`, `~`,
-`,`, `#`, `(`, `>`) instead of being downgraded to arrays/bulk-strings. See the
+`HELLO 3` switches that single session to RESP3 — `RedisValue.map`/`mapPairs`/
+`set`/`double`/`boolean`/`bigNumber`/`push` then encode as their native RESP3
+types (`%`, `%`, `~`, `,`, `#`, `(`, `>`) instead of being downgraded to
+arrays/bulk-strings. `map` downgrades to a flat RESP2 key/value array, while
+`mapPairs` downgrades to a RESP2 array of `[key, value]` pairs for commands like
+`XREAD`. See the
 [README's protocol-version section](../README.md#protocol-version-resp2--resp3)
 for the client-facing view of this negotiation.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -53,7 +53,7 @@ only a subset of the real Redis syntax, the supported syntax is shown and a
 - [x] `COMMAND COUNT` - Return the command count for the active registry
 - [x] `COMMAND LIST [FILTERBY PATTERN pattern|MODULE module]` - Return command names
 - [x] `COMMAND INFO [command-name ...]` - Return command metadata
-- [x] `COMMAND DOCS [command-name ...]` - Return command documentation
+- [x] `COMMAND DOCS [command-name ...]` - Return command documentation (RESP3 maps / RESP2 flat arrays)
 - [x] `COMMAND GETKEYS command [arg ...]` - Extract keys through the command definition
 - [x] `COMMAND GETKEYSANDFLAGS command [arg ...]` - Extract keys with access flags
 - [x] `COMMAND HELP` - Return command help
@@ -155,7 +155,7 @@ surface.
 - [x] `HGET key field` - Get the value of a hash field
 - [x] `HMSET key field value [field value ...]` - Set multiple hash fields (deprecated, use HSET)
 - [x] `HMGET key field [field ...]` - Get the values of multiple hash fields
-- [x] `HGETALL key` - Get all fields and values in a hash
+- [x] `HGETALL key` - Get all fields and values in a hash (RESP3 map / RESP2 flat array)
 - [x] `HDEL key field [field ...]` - Delete one or more hash fields
 - [x] `HEXISTS key field` - Determine if a hash field exists
 - [x] `HKEYS key` - Get all fields in a hash
@@ -254,7 +254,7 @@ surface.
 - [x] `XREVRANGE key end start [COUNT count]` - Return entries in descending ID order
 - [x] `XDEL key ID [ID ...]` - Remove entries by ID
 - [x] `XTRIM key MAXLEN|MINID [~] threshold` - Trim a stream to a size or minimum ID
-- [x] `XREAD [COUNT count] [BLOCK milliseconds] STREAMS key [key ...] id [id ...]` - Read entries, optionally blocking for new ones
+- [x] `XREAD [COUNT count] [BLOCK milliseconds] STREAMS key [key ...] id [id ...]` - Read entries, optionally blocking for new ones (RESP3 map / RESP2 array of stream-entry pairs)
 
 #### Notes / gaps vs. real Redis
 
@@ -316,7 +316,7 @@ flags are enforced inside `redis.call`/`redis.pcall`.
 - [x] `CLUSTER INFO` - Provides info about Redis Cluster node state
 - [x] `CLUSTER NODES` - Get the cluster config for the node
 - [x] `CLUSTER SLOTS` - Get array of slot ranges with assigned nodes
-- [x] `CLUSTER SHARDS` - Get array of shards with their slot ranges and nodes
+- [x] `CLUSTER SHARDS` - Get array of shards with their slot ranges and nodes (RESP3 maps / RESP2 flat arrays)
 - [x] `CLUSTER MYID` - Return the node's own ID
 - [x] `READONLY` - Allow read-only commands against a direct replica connection for slots served by its master
 - [x] `READWRITE` - Disable replica read mode on the current connection

--- a/src/commands/cluster.ts
+++ b/src/commands/cluster.ts
@@ -172,30 +172,48 @@ function clusterShards(topology: RedisClusterTopology): RedisResult {
     }
 
     const shardNodes = [master, ...replicasOf(topology, master.id)].map(node =>
-      RedisValue.array([
-        RedisValue.bulkString(Buffer.from('id')),
-        RedisValue.bulkString(Buffer.from(node.id)),
-        RedisValue.bulkString(Buffer.from('port')),
-        RedisValue.integer(node.port),
-        RedisValue.bulkString(Buffer.from('ip')),
-        RedisValue.bulkString(Buffer.from(node.host)),
-        RedisValue.bulkString(Buffer.from('endpoint')),
-        RedisValue.bulkString(Buffer.from(node.host)),
-        RedisValue.bulkString(Buffer.from('role')),
-        RedisValue.bulkString(Buffer.from(node.role)),
-        RedisValue.bulkString(Buffer.from('replication-offset')),
-        RedisValue.integer(0),
-        RedisValue.bulkString(Buffer.from('health')),
-        RedisValue.bulkString(Buffer.from('online')),
+      RedisValue.map([
+        [
+          RedisValue.bulkString(Buffer.from('id')),
+          RedisValue.bulkString(Buffer.from(node.id)),
+        ],
+        [
+          RedisValue.bulkString(Buffer.from('port')),
+          RedisValue.integer(node.port),
+        ],
+        [
+          RedisValue.bulkString(Buffer.from('ip')),
+          RedisValue.bulkString(Buffer.from(node.host)),
+        ],
+        [
+          RedisValue.bulkString(Buffer.from('endpoint')),
+          RedisValue.bulkString(Buffer.from(node.host)),
+        ],
+        [
+          RedisValue.bulkString(Buffer.from('role')),
+          RedisValue.bulkString(Buffer.from(node.role)),
+        ],
+        [
+          RedisValue.bulkString(Buffer.from('replication-offset')),
+          RedisValue.integer(0),
+        ],
+        [
+          RedisValue.bulkString(Buffer.from('health')),
+          RedisValue.bulkString(Buffer.from('online')),
+        ],
       ]),
     )
 
     shards.push(
-      RedisValue.array([
-        RedisValue.bulkString(Buffer.from('slots')),
-        RedisValue.array(slotRanges),
-        RedisValue.bulkString(Buffer.from('nodes')),
-        RedisValue.array(shardNodes),
+      RedisValue.map([
+        [
+          RedisValue.bulkString(Buffer.from('slots')),
+          RedisValue.array(slotRanges),
+        ],
+        [
+          RedisValue.bulkString(Buffer.from('nodes')),
+          RedisValue.array(shardNodes),
+        ],
       ]),
     )
   }

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -164,16 +164,16 @@ function commandDocsSubcommand(
           .map(name => findCommandInfo(ctx, name.toString()))
           .filter((info): info is CommandInfo => info !== null)
 
-  const items: RedisValue[] = []
+  const entries: [RedisValue, RedisValue][] = []
   for (const info of infos) {
     if (!info.docs) {
       continue
     }
 
-    items.push(bulkString(info.name), formatDocs(info.docs))
+    entries.push([bulkString(info.name), formatDocs(info.docs)])
   }
 
-  return RedisResult.create(RedisValue.array(items))
+  return RedisResult.create(RedisValue.map(entries))
 }
 
 function commandGetKeys(
@@ -417,52 +417,55 @@ function formatKeySpec(spec: CommandKeySpec): RedisValue {
 }
 
 function formatDocs(docs: CommandDocumentation): RedisValue {
-  const items: RedisValue[] = [bulkString('summary'), bulkString(docs.summary)]
+  const entries: [RedisValue, RedisValue][] = [
+    [bulkString('summary'), bulkString(docs.summary)],
+  ]
 
   if (docs.since) {
-    items.push(bulkString('since'), bulkString(docs.since))
+    entries.push([bulkString('since'), bulkString(docs.since)])
   }
 
-  items.push(bulkString('group'), bulkString(docs.group))
+  entries.push([bulkString('group'), bulkString(docs.group)])
 
   if (docs.complexity) {
-    items.push(bulkString('complexity'), bulkString(docs.complexity))
+    entries.push([bulkString('complexity'), bulkString(docs.complexity)])
   }
 
   if (docs.arguments) {
-    items.push(
+    entries.push([
       bulkString('arguments'),
       RedisValue.array(docs.arguments.map(formatDocsArgument)),
-    )
+    ])
   }
 
-  return RedisValue.array(items)
+  return RedisValue.map(entries)
 }
 
 function formatDocsArgument(arg: CommandDocumentationArgument): RedisValue {
-  const items: RedisValue[] = [
-    bulkString('name'),
-    bulkString(arg.name),
-    bulkString('type'),
-    bulkString(arg.type),
+  const entries: [RedisValue, RedisValue][] = [
+    [bulkString('name'), bulkString(arg.name)],
+    [bulkString('type'), bulkString(arg.type)],
   ]
 
   if (arg.keySpecIndex !== undefined) {
-    items.push(
+    entries.push([
       bulkString('key_spec_index'),
       RedisValue.integer(arg.keySpecIndex),
-    )
+    ])
   }
 
   if (arg.token) {
-    items.push(bulkString('token'), bulkString(arg.token))
+    entries.push([bulkString('token'), bulkString(arg.token)])
   }
 
   if (arg.flags) {
-    items.push(bulkString('flags'), RedisValue.array(arg.flags.map(bulkString)))
+    entries.push([
+      bulkString('flags'),
+      RedisValue.array(arg.flags.map(bulkString)),
+    ])
   }
 
-  return RedisValue.array(items)
+  return RedisValue.map(entries)
 }
 
 function keyAccessFlags(definition: CommandDefinition<unknown>): RedisValue[] {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -90,19 +90,11 @@ function configGet(
   const bulk = (text: string): RedisValue =>
     RedisValue.bulkString(Buffer.from(text))
 
-  if (ctx.session.protocolVersion === 3) {
-    const entries: [RedisValue, RedisValue][] = []
-    for (const [name, value] of matched) {
-      entries.push([bulk(name), bulk(value)])
-    }
-    return RedisResult.create(RedisValue.map(entries))
-  }
-
-  const flat: RedisValue[] = []
+  const entries: [RedisValue, RedisValue][] = []
   for (const [name, value] of matched) {
-    flat.push(bulk(name), bulk(value))
+    entries.push([bulk(name), bulk(value)])
   }
-  return RedisResult.create(RedisValue.array(flat))
+  return RedisResult.create(RedisValue.map(entries))
 }
 
 function configSet(

--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -5,6 +5,7 @@ import {
   HashValueNotIntegerError,
   WrongNumberOfArgumentsError,
 } from '../core/redis-error'
+import { RedisResult } from '../core/redis-result'
 import { RedisValue } from '../core/redis-value'
 import { bulk, integer, ok, array } from './helpers'
 
@@ -140,13 +141,11 @@ export const hgetallCommand = defineCommand({
   keys: args => [args.key],
   execute: (args, ctx) => {
     const hash = ctx.db.getHash(args.key)
-    if (!hash) return array([])
-    const items: RedisValue[] = []
-    for (const { field, value } of hash.fields.values()) {
-      items.push(RedisValue.bulkString(field))
-      items.push(RedisValue.bulkString(value))
+    const entries: [RedisValue, RedisValue][] = []
+    for (const { field, value } of hash?.fields.values() ?? []) {
+      entries.push([RedisValue.bulkString(field), RedisValue.bulkString(value)])
     }
-    return array(items)
+    return RedisResult.create(RedisValue.map(entries))
   },
 })
 

--- a/src/commands/streams.ts
+++ b/src/commands/streams.ts
@@ -478,7 +478,7 @@ function readStreamEntries(
   count: number | null,
   ctx: RedisExecutionContext,
 ): RedisResult | null {
-  const results: RedisValue[] = []
+  const results: [RedisValue, RedisValue][] = []
 
   for (const { key, afterId } of streams) {
     const stream = ctx.db.getStream(key)
@@ -493,17 +493,12 @@ function readStreamEntries(
     }
 
     if (entries.length > 0) {
-      results.push(
-        RedisValue.array([
-          RedisValue.bulkString(key),
-          RedisValue.array(entries),
-        ]),
-      )
+      results.push([RedisValue.bulkString(key), RedisValue.array(entries)])
     }
   }
 
   return results.length > 0
-    ? RedisResult.create(RedisValue.array(results))
+    ? RedisResult.create(RedisValue.mapPairs(results))
     : null
 }
 

--- a/src/core/lua-runtime.ts
+++ b/src/core/lua-runtime.ts
@@ -157,6 +157,11 @@ function redisValueToLuaReply(value: RedisValue): ReplyValue {
         redisValueToLuaReply(key),
         redisValueToLuaReply(entryValue),
       ])
+    case 'map-pairs':
+      return value.entries.map(([key, entryValue]) => [
+        redisValueToLuaReply(key),
+        redisValueToLuaReply(entryValue),
+      ])
     case 'push':
       return [Buffer.from(value.name), ...value.items.map(redisValueToLuaReply)]
     case 'null':

--- a/src/core/redis-value.ts
+++ b/src/core/redis-value.ts
@@ -9,6 +9,7 @@ export type RedisValue =
   | { kind: 'array'; items: RedisValue[] }
   | { kind: 'set'; items: RedisValue[] }
   | { kind: 'map'; entries: [RedisValue, RedisValue][] }
+  | { kind: 'map-pairs'; entries: [RedisValue, RedisValue][] }
   | { kind: 'push'; name: string; items: RedisValue[] }
   | { kind: 'null' }
   | { kind: 'null-array' }
@@ -36,6 +37,10 @@ export const RedisValue = {
   set: (items: RedisValue[]): RedisValue => ({ kind: 'set', items }),
   map: (entries: [RedisValue, RedisValue][]): RedisValue => ({
     kind: 'map',
+    entries,
+  }),
+  mapPairs: (entries: [RedisValue, RedisValue][]): RedisValue => ({
+    kind: 'map-pairs',
     entries,
   }),
   push: (name: string, items: RedisValue[]): RedisValue => ({

--- a/src/core/resp-encoder.ts
+++ b/src/core/resp-encoder.ts
@@ -50,6 +50,12 @@ function encodeResp2(value: RedisValue): Buffer {
       return encodeArray(
         value.entries.flatMap(([key, entryValue]) => [key, entryValue]),
       )
+    case 'map-pairs':
+      return encodeArray(
+        value.entries.map(([key, entryValue]) =>
+          RedisValue.array([key, entryValue]),
+        ),
+      )
     case 'push':
       return encodeArray([
         { kind: 'bulk-string', value: Buffer.from(value.name) },
@@ -85,6 +91,8 @@ function encodeResp3(value: RedisValue): Buffer {
     case 'set':
       return encodeResp3Set(value.items)
     case 'map':
+      return encodeResp3Map(value.entries)
+    case 'map-pairs':
       return encodeResp3Map(value.entries)
     case 'push':
       return encodeResp3Push(value.name, value.items)

--- a/tests-integration/ioredis/cluster-integration.test.ts
+++ b/tests-integration/ioredis/cluster-integration.test.ts
@@ -5,6 +5,7 @@ import { Cluster } from 'ioredis'
 import clusterKeySlot from 'cluster-key-slot'
 import { TestRunner } from '../test-config'
 import {
+  commandFrame,
   connectToEndpoint,
   connectToSlotOwner,
   eventually,
@@ -13,6 +14,12 @@ import {
   findSlotOwner,
   randomKey,
 } from '../utils'
+import {
+  RawRedisConnection,
+  respMapGet,
+  respNumber,
+  respText,
+} from '../raw-tcp/raw-connection'
 
 const testRunner = new TestRunner()
 
@@ -256,6 +263,35 @@ describe(`Cluster protocol integration (${testRunner.getBackendName()})`, () => 
       }
     } finally {
       directClient.disconnect()
+    }
+  })
+
+  test('CLUSTER SHARDS returns RESP3 maps after HELLO 3', async () => {
+    const port = testRunner.getClusterPorts()[0]
+    assert.notStrictEqual(port, undefined)
+    const connection = await RawRedisConnection.connect('127.0.0.1', port!)
+
+    try {
+      connection.write(commandFrame('HELLO', '3'))
+      assert.ok((await connection.readFrame()) instanceof Map)
+
+      connection.write(commandFrame('CLUSTER', 'SHARDS'))
+      const reply = await connection.readFrame()
+      assert.ok(Array.isArray(reply))
+      assert.ok(reply.length > 0)
+
+      const shard = reply[0]
+      assert.ok(shard instanceof Map)
+      assert.ok(Array.isArray(respMapGet(shard, 'slots')))
+
+      const nodes = respMapGet(shard, 'nodes')
+      assert.ok(Array.isArray(nodes))
+      assert.ok(nodes[0] instanceof Map)
+      assert.ok(respText(respMapGet(nodes[0], 'id')).length > 0)
+      assert.ok(respNumber(respMapGet(nodes[0], 'port')) > 0)
+      assert.match(respText(respMapGet(nodes[0], 'role')), /^(master|replica)$/)
+    } finally {
+      connection.close()
     }
   })
 })

--- a/tests-integration/ioredis/command-integration.test.ts
+++ b/tests-integration/ioredis/command-integration.test.ts
@@ -2,7 +2,12 @@ import { test, describe, before, after } from 'node:test'
 import assert from 'node:assert'
 import { Cluster } from 'ioredis'
 import { TestRunner } from '../test-config'
-import { errorWithMessage } from '../utils'
+import { commandFrame, errorWithMessage } from '../utils'
+import {
+  RawRedisConnection,
+  respMapGet,
+  respText,
+} from '../raw-tcp/raw-connection'
 
 const testRunner = new TestRunner()
 
@@ -117,6 +122,36 @@ describe(`COMMAND integration (${testRunner.getBackendName()})`, () => {
       'NOSUCHCOMMAND',
     )) as unknown[]
     assert.deepStrictEqual(unknownDocs, [])
+  })
+
+  test('COMMAND DOCS returns RESP3 maps after HELLO 3', async () => {
+    const port = testRunner.getClusterPorts()[0]
+    assert.notStrictEqual(port, undefined)
+    const connection = await RawRedisConnection.connect('127.0.0.1', port!)
+
+    try {
+      connection.write(commandFrame('HELLO', '3'))
+      assert.ok((await connection.readFrame()) instanceof Map)
+
+      connection.write(commandFrame('COMMAND', 'DOCS', 'GET'))
+      const reply = await connection.readFrame()
+      assert.ok(reply instanceof Map)
+
+      const getDocs = respMapGet(reply, 'get')
+      assert.ok(getDocs instanceof Map)
+      assert.strictEqual(
+        respText(respMapGet(getDocs, 'summary')),
+        'Get the value of a key',
+      )
+      assert.strictEqual(respText(respMapGet(getDocs, 'group')), 'string')
+
+      const args = respMapGet(getDocs, 'arguments')
+      assert.ok(Array.isArray(args))
+      assert.ok(args[0] instanceof Map)
+      assert.strictEqual(respText(respMapGet(args[0], 'name')), 'key')
+    } finally {
+      connection.close()
+    }
   })
 
   test('COMMAND GETKEYS and GETKEYSANDFLAGS use command key extraction', async () => {

--- a/tests-integration/ioredis/hash-integration.test.ts
+++ b/tests-integration/ioredis/hash-integration.test.ts
@@ -2,7 +2,17 @@ import { test, describe, before, after } from 'node:test'
 import assert from 'node:assert'
 import { Cluster } from 'ioredis'
 import { TestRunner } from '../test-config'
-import { errorWithMessage, randomKey } from '../utils'
+import {
+  commandFrame,
+  errorWithMessage,
+  findSlotOwner,
+  randomKey,
+} from '../utils'
+import {
+  RawRedisConnection,
+  respMapGet,
+  respText,
+} from '../raw-tcp/raw-connection'
 
 const testRunner = new TestRunner()
 
@@ -64,6 +74,33 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
 
     const all = await redisClient?.hgetall('hash3')
     assert.deepStrictEqual(all, { field1: 'value1', field2: 'value2' })
+  })
+
+  test('HGETALL returns a RESP3 map after HELLO 3', async () => {
+    assert.ok(redisClient)
+
+    const key = `{hash-resp3:${randomKey()}}:hash`
+    const [host, port] = await findSlotOwner(redisClient, key)
+    const connection = await RawRedisConnection.connect(host, port)
+
+    try {
+      connection.write(commandFrame('HELLO', '3'))
+      assert.ok((await connection.readFrame()) instanceof Map)
+
+      connection.write(
+        commandFrame('HSET', key, 'field1', 'value1', 'field2', 'value2'),
+      )
+      assert.strictEqual(await connection.readFrame(), 2)
+
+      connection.write(commandFrame('HGETALL', key))
+      const reply = await connection.readFrame()
+      assert.ok(reply instanceof Map)
+      assert.strictEqual(respText(respMapGet(reply, 'field1')), 'value1')
+      assert.strictEqual(respText(respMapGet(reply, 'field2')), 'value2')
+    } finally {
+      connection.close()
+      await redisClient.del(key)
+    }
   })
 
   test('HKEYS and HVALS commands', async () => {

--- a/tests-integration/ioredis/stream-integration.test.ts
+++ b/tests-integration/ioredis/stream-integration.test.ts
@@ -2,7 +2,18 @@ import { test, describe, before, after } from 'node:test'
 import assert from 'node:assert'
 import { Cluster } from 'ioredis'
 import { TestRunner } from '../test-config'
-import { connectToSlotOwner, errorWithMessage, randomKey } from '../utils'
+import {
+  commandFrame,
+  connectToSlotOwner,
+  errorWithMessage,
+  findSlotOwner,
+  randomKey,
+} from '../utils'
+import {
+  RawRedisConnection,
+  respMapGet,
+  respText,
+} from '../raw-tcp/raw-connection'
 
 const testRunner = new TestRunner()
 
@@ -332,6 +343,42 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
       ])
     } finally {
       node.disconnect()
+    }
+  })
+
+  test('XREAD returns a RESP3 map after HELLO 3', async () => {
+    assert.ok(redisClient)
+
+    const key = `{stream-resp3:${randomKey()}}:stream`
+    const [host, port] = await findSlotOwner(redisClient, key)
+    const connection = await RawRedisConnection.connect(host, port)
+
+    try {
+      connection.write(commandFrame('HELLO', '3'))
+      assert.ok((await connection.readFrame()) instanceof Map)
+
+      connection.write(commandFrame('XADD', key, '*', 'field1', 'value1'))
+      assert.match(respText(await connection.readFrame()), /^\d+-\d+$/)
+
+      connection.write(commandFrame('XREAD', 'STREAMS', key, '0-0'))
+      const reply = await connection.readFrame()
+      assert.ok(reply instanceof Map)
+
+      const entries = respMapGet(reply, key)
+      assert.ok(Array.isArray(entries))
+      assert.strictEqual(entries.length, 1)
+
+      const entry = entries[0]
+      assert.ok(Array.isArray(entry))
+      assert.strictEqual(entry.length, 2)
+      assert.match(respText(entry[0]), /^\d+-\d+$/)
+      assert.deepStrictEqual(
+        (entry[1] as unknown[]).map(value => respText(value)),
+        ['field1', 'value1'],
+      )
+    } finally {
+      connection.close()
+      await redisClient.del(key)
     }
   })
 

--- a/tests/commands-blocking.test.ts
+++ b/tests/commands-blocking.test.ts
@@ -19,6 +19,13 @@ function nullArrayResult(): RedisResult {
   return RedisResult.create(RedisValue.nullArray())
 }
 
+function xreadReplyEntries(result: RedisResult, streamIndex = 0): RedisValue[] {
+  assert.strictEqual(result.value.kind, 'map-pairs')
+  const [, entries] = result.value.entries[streamIndex]
+  assert.strictEqual(entries.kind, 'array')
+  return entries.items
+}
+
 // Drain all pending microtasks so blocking commands reach their parked state.
 function yieldToEventLoop(): Promise<void> {
   return new Promise(resolve => setImmediate(resolve))
@@ -107,7 +114,7 @@ describe('XREAD BLOCK (unit)', () => {
       buf('BLOCK', '0', 'STREAMS', 's', '0-0'),
     )
     assert.ok(result instanceof RedisResult)
-    assert.strictEqual(result.value.kind, 'array')
+    assert.strictEqual(result.value.kind, 'map-pairs')
   })
 
   test('XREAD BLOCK with $ on non-empty stream blocks on new entries only', async () => {
@@ -127,7 +134,7 @@ describe('XREAD BLOCK (unit)', () => {
     const result = await blockPromise
 
     assert.ok(result instanceof RedisResult)
-    assert.strictEqual(result.value.kind, 'array')
+    assert.strictEqual(result.value.kind, 'map-pairs')
   })
 
   test('XREAD BLOCK timeout returns nil', async () => {
@@ -147,7 +154,7 @@ describe('XREAD BLOCK (unit)', () => {
     await session.execute('xadd', buf('s', '1-1', 'f', 'v'))
     const result = await session.execute('xread', buf('STREAMS', 's', '0-0'))
     assert.ok(result instanceof RedisResult)
-    assert.strictEqual(result.value.kind, 'array')
+    assert.strictEqual(result.value.kind, 'map-pairs')
   })
 
   test('XREAD BLOCK with COUNT limits results', async () => {
@@ -166,16 +173,7 @@ describe('XREAD BLOCK (unit)', () => {
     const result = await blockPromise
 
     assert.ok(result instanceof RedisResult)
-    assert.strictEqual(result.value.kind, 'array')
-    const streamResults = (
-      result.value as { kind: 'array'; items: RedisValue[] }
-    ).items
-    const entries = (streamResults[0] as { kind: 'array'; items: RedisValue[] })
-      .items[1]
-    assert.strictEqual(
-      (entries as { kind: 'array'; items: RedisValue[] }).items.length,
-      1,
-    )
+    assert.strictEqual(xreadReplyEntries(result).length, 1)
   })
 
   test('XREAD COUNT is per-stream: each stream returns up to COUNT entries independently', async () => {
@@ -193,15 +191,12 @@ describe('XREAD BLOCK (unit)', () => {
     )
 
     assert.ok(result instanceof RedisResult)
-    const streams = (result.value as { kind: 'array'; items: RedisValue[] })
-      .items
-    assert.strictEqual(streams.length, 2, 'both streams returned')
+    assert.strictEqual(result.value.kind, 'map-pairs')
+    assert.strictEqual(result.value.entries.length, 2, 'both streams returned')
 
-    for (const streamResult of streams) {
-      const entries = (streamResult as { kind: 'array'; items: RedisValue[] })
-        .items[1]
+    for (let i = 0; i < result.value.entries.length; i++) {
       assert.strictEqual(
-        (entries as { kind: 'array'; items: RedisValue[] }).items.length,
+        xreadReplyEntries(result, i).length,
         2,
         'COUNT=2 is applied per-stream',
       )

--- a/tests/commands-streams.test.ts
+++ b/tests/commands-streams.test.ts
@@ -17,6 +17,13 @@ function bulkResult(s: string | null): RedisResult {
   )
 }
 
+function xreadReplyEntries(result: RedisResult, streamIndex = 0): RedisValue[] {
+  assert.strictEqual(result.value.kind, 'map-pairs')
+  const [, entries] = result.value.entries[streamIndex]
+  assert.strictEqual(entries.kind, 'array')
+  return entries.items
+}
+
 describe('stream commands (unit)', () => {
   // XTRIM MAXLEN
 
@@ -177,13 +184,7 @@ describe('stream commands (unit)', () => {
     const result = await session.execute('xread', buf('STREAMS', 's', '1-1'))
     assert.ok(result.value !== null)
     // Should return entries 2-1 and 3-1 only.
-    const streamEntries = (
-      (
-        (result.value as { items: RedisValue[] }).items[0] as {
-          items: RedisValue[]
-        }
-      ).items[1] as { items: RedisValue[] }
-    ).items
+    const streamEntries = xreadReplyEntries(result)
     assert.strictEqual(streamEntries.length, 2)
   })
 
@@ -198,13 +199,7 @@ describe('stream commands (unit)', () => {
       buf('COUNT', '1', 'STREAMS', 's', '0-0'),
     )
     assert.ok(result.value !== null)
-    const streamEntries = (
-      (
-        (result.value as { items: RedisValue[] }).items[0] as {
-          items: RedisValue[]
-        }
-      ).items[1] as { items: RedisValue[] }
-    ).items
+    const streamEntries = xreadReplyEntries(result)
     assert.strictEqual(streamEntries.length, 1)
   })
 
@@ -246,7 +241,7 @@ describe('stream commands (unit)', () => {
       buf('STREAMS', 's1', 's2', '0-0', '0-0'),
     )
     assert.ok(result.value !== null)
-    const streams = (result.value as { items: RedisValue[] }).items
-    assert.strictEqual(streams.length, 2)
+    assert.strictEqual(result.value.kind, 'map-pairs')
+    assert.strictEqual(result.value.entries.length, 2)
   })
 })

--- a/tests/core-resp-encoder.test.ts
+++ b/tests/core-resp-encoder.test.ts
@@ -63,6 +63,16 @@ describe('RESP encoder core', () => {
 
     assert.deepStrictEqual(
       encodeRedisValue(
+        RedisValue.mapPairs([
+          [RedisValue.bulkString(Buffer.from('a')), RedisValue.integer(1)],
+          [RedisValue.bulkString(Buffer.from('b')), RedisValue.boolean(true)],
+        ]),
+      ),
+      Buffer.from('*2\r\n*2\r\n$1\r\na\r\n:1\r\n*2\r\n$1\r\nb\r\n:1\r\n'),
+    )
+
+    assert.deepStrictEqual(
+      encodeRedisValue(
         RedisValue.push('message', [RedisValue.bulkString(Buffer.from('x'))]),
       ),
       Buffer.from('*2\r\n$7\r\nmessage\r\n$1\r\nx\r\n'),
@@ -95,6 +105,16 @@ describe('RESP encoder core', () => {
     assert.deepStrictEqual(
       encodeRedisValue(
         RedisValue.map([
+          [RedisValue.bulkString(Buffer.from('a')), RedisValue.integer(1)],
+          [RedisValue.bulkString(Buffer.from('b')), RedisValue.null()],
+        ]),
+        { version: 3 },
+      ),
+      Buffer.from('%2\r\n$1\r\na\r\n:1\r\n$1\r\nb\r\n_\r\n'),
+    )
+    assert.deepStrictEqual(
+      encodeRedisValue(
+        RedisValue.mapPairs([
           [RedisValue.bulkString(Buffer.from('a')), RedisValue.integer(1)],
           [RedisValue.bulkString(Buffer.from('b')), RedisValue.null()],
         ]),


### PR DESCRIPTION
## Summary
- Return logical map replies as RESP3 maps for HGETALL, CONFIG GET, COMMAND DOCS, and CLUSTER SHARDS
- Add RedisValue.mapPairs for replies like XREAD that are RESP3 maps but RESP2 arrays of [key, value] pairs
- Keep map-producing commands protocol-neutral; the encoder now owns flat-array vs pair-array RESP2 downgrades
- Add raw RESP3 integration coverage for HGETALL, XREAD, COMMAND DOCS, and CLUSTER SHARDS

## Root cause
Several command implementations encoded map-like replies as RESP2 arrays directly. That made RESP3 sessions return arrays where real Redis returns `%` map replies. HGETALL exposed the issue first, but CONFIG GET, COMMAND DOCS, CLUSTER SHARDS, and XREAD needed the same protocol-shape treatment.

## Validation
- Real Redis shape probes for HGETALL, CONFIG GET, XREAD, COMMAND DOCS, CLUSTER SHARDS, COMMAND INFO, COMMAND GETKEYSANDFLAGS, HSCAN, XRANGE, and XREVRANGE
- Focused mock integration: hash, stream, command, cluster
- Focused real integration: hash, stream, command, cluster
- npm run build
- npm test
- npm run test:integration:mock
- npm run test:integration:real
- npm run lint

Fixes #71