### PR TITLE
Fix case-insensitive script SHA lookups

### DIFF
--- a/src/state/script-cache.ts
+++ b/src/state/script-cache.ts
@@ -10,12 +10,12 @@ export class RedisScriptCache {
   }
 
   get(sha: string): Buffer | null {
-    const script = this.scripts.get(sha)
+    const script = this.scripts.get(normalizeSha(sha))
     return script ? Buffer.from(script) : null
   }
 
   exists(sha: string): boolean {
-    return this.scripts.has(sha)
+    return this.scripts.has(normalizeSha(sha))
   }
 
   existsAll(shas: readonly string[]): boolean[] {
@@ -29,4 +29,8 @@ export class RedisScriptCache {
   size(): number {
     return this.scripts.size
   }
+}
+
+function normalizeSha(sha: string): string {
+  return sha.toLowerCase()
 }

--- a/tests-integration/ioredis/scripts.test.ts
+++ b/tests-integration/ioredis/scripts.test.ts
@@ -200,6 +200,8 @@ describe(`Redis scripts (ioredis) ${testRunner.getBackendName()}`, () => {
     )
     const script = 'return ARGV[1]'
     const sha = createHash('sha1').update(script).digest('hex')
+    const upperSha = sha.toUpperCase()
+    const mixedSha = `${sha.slice(0, 20).toUpperCase()}${sha.slice(20)}`
     const missingSha = createHash('sha1')
       .update('return "missing"')
       .digest('hex')
@@ -210,7 +212,25 @@ describe(`Redis scripts (ioredis) ${testRunner.getBackendName()}`, () => {
         await directClient.call('SCRIPT', 'EXISTS', sha, missingSha),
         [1, 0],
       )
+      assert.deepStrictEqual(
+        await directClient.call(
+          'SCRIPT',
+          'EXISTS',
+          upperSha,
+          mixedSha,
+          missingSha.toUpperCase(),
+        ),
+        [1, 1, 0],
+      )
       assert.strictEqual(await directClient.evalsha(sha, 0, 'cached'), 'cached')
+      assert.strictEqual(
+        await directClient.evalsha(upperSha, 0, 'cached-uppercase'),
+        'cached-uppercase',
+      )
+      assert.strictEqual(
+        await directClient.evalsha(mixedSha, 0, 'cached-mixed-case'),
+        'cached-mixed-case',
+      )
 
       assert.strictEqual(
         await directClient.call('SCRIPT', 'FLUSH', 'SYNC'),
@@ -220,7 +240,7 @@ describe(`Redis scripts (ioredis) ${testRunner.getBackendName()}`, () => {
         0,
       ])
       await assert.rejects(
-        () => directClient.evalsha(sha, 0, 'cached'),
+        () => directClient.evalsha(upperSha, 0, 'cached'),
         errorWithMessage('NOSCRIPT No matching script. Please use EVAL.'),
       )
     } finally {


### PR DESCRIPTION
## Summary
- Normalize script-cache SHA lookups to lowercase so `EVALSHA` and `SCRIPT EXISTS` match Redis behavior for uppercase and mixed-case SHA1 arguments.
- Extend ioredis integration coverage for uppercase/mixed-case cached script SHAs and post-flush `NOSCRIPT` behavior.

## Root Cause
`RedisScriptCache` stored SHA1 digests in lowercase but looked up caller-provided SHA strings verbatim. Redis treats SHA1 script identifiers case-insensitively for lookup.

## Validation
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/scripts.test.ts` (failed before fix, passes after)
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/scripts.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint` (passes with the existing `src/types/respjs.d.ts` `no-explicit-any` warning)
- pre-push hook reran `npm test` and passed

Fixes #49