### PR TITLE
Fix HDEL missing-key phantom hashes

### DIFF
--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -90,13 +90,17 @@ export const hdelCommand = defineCommand({
   flags: ['write', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
+    const existingHash = ctx.db.getHash(args.key)
+    if (!existingHash) return integer(0)
+
     let deleted = 0
-    ctx.db.updateHash(args.key, hash => {
+    const remaining = ctx.db.updateHash(args.key, hash => {
       for (const field of args.fields) {
         if (hash.fields.delete(field.toString('hex'))) deleted++
       }
+      return hash.fields.size
     })
-    if (deleted > 0 && (ctx.db.getHash(args.key)?.fields.size ?? 0) === 0) {
+    if (remaining === 0) {
       ctx.db.delete(args.key)
     }
     return integer(deleted)

--- a/tests-integration/ioredis/hash-integration.test.ts
+++ b/tests-integration/ioredis/hash-integration.test.ts
@@ -160,8 +160,10 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
   })
 
   test('HDEL command', async () => {
+    const key = `{hdel:${randomKey()}}:hash`
+
     await redisClient?.hset(
-      'hash7',
+      key,
       'field1',
       'value1',
       'field2',
@@ -171,16 +173,32 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
     )
 
     // Delete single field
-    const del1 = await redisClient?.hdel('hash7', 'field1')
+    const del1 = await redisClient?.hdel(key, 'field1')
     assert.strictEqual(del1, 1)
 
     // Delete multiple fields
-    const del2 = await redisClient?.hdel('hash7', 'field2', 'field3')
+    const del2 = await redisClient?.hdel(key, 'field2', 'field3')
     assert.strictEqual(del2, 2)
 
-    // Verify hash is empty
-    const len = await redisClient?.hlen('hash7')
+    // Verify hash is removed after its last field is deleted.
+    const len = await redisClient?.hlen(key)
     assert.strictEqual(len, 0)
+    assert.strictEqual(await redisClient?.exists(key), 0)
+    assert.strictEqual(await redisClient?.type(key), 'none')
+  })
+
+  test('HDEL on a missing key does not create an empty hash', async () => {
+    const key = `{hdel-missing:${randomKey()}}:hash`
+
+    assert.strictEqual(await redisClient?.hdel(key, 'field1'), 0)
+    assert.strictEqual(await redisClient?.exists(key), 0)
+    assert.strictEqual(await redisClient?.type(key), 'none')
+
+    await redisClient?.hset(key, 'field1', 'value1')
+    assert.strictEqual(await redisClient?.hdel(key, 'field1'), 1)
+    assert.strictEqual(await redisClient?.hdel(key, 'field1'), 0)
+    assert.strictEqual(await redisClient?.exists(key), 0)
+    assert.strictEqual(await redisClient?.type(key), 'none')
   })
 
   test('HINCRBY command', async () => {


### PR DESCRIPTION
## Summary
- Prevent `HDEL` from creating an empty hash when the target key is missing.
- Remove the hash key when its last field is deleted, and cover the behavior in the ioredis hash integration suite.

## Root Cause
`HDEL` called `ctx.db.updateHash()` unconditionally. `updateHash()` creates a hash value for missing keys before running the mutator, so deleting zero fields from a missing key left a persistent empty hash visible to `EXISTS`, `TYPE`, `KEYS`, and `SCAN`.

## Validation
- Focused mock red test failed before the fix on `EXISTS key === 1` after `HDEL` against a missing key.
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/hash-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/hash-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`

Docs checked: `README.md`, `docs/COMMANDS.md`, and `docs/ARCHITECTURE.md`; no documentation update was needed because this fixes existing `HDEL` behavior without adding a command or structural change.

Fixes #38