### PR TITLE
Fix XADD sequence overflow handling

### DIFF
--- a/src/commands/streams.ts
+++ b/src/commands/streams.ts
@@ -8,6 +8,8 @@ import {
   ExpectedIntegerError,
   InvalidStreamIdError,
   RedisSyntaxError,
+  StreamElementTooLargeError,
+  StreamIdExhaustedError,
   StreamIdEqualOrSmallerError,
   StreamIdNotGreaterThanZeroError,
   WrongNumberOfArgumentsError,
@@ -67,12 +69,22 @@ function resolveXaddId(spec: string, lastId: StreamId): StreamId {
 function nextAutoId(lastId: StreamId): StreamId {
   const now = BigInt(Date.now())
   if (now > lastId.ms) return { ms: now, seq: 0n }
-  return { ms: lastId.ms, seq: lastId.seq + 1n }
+  if (lastId.seq < MAX_UINT64) return { ms: lastId.ms, seq: lastId.seq + 1n }
+  if (lastId.ms < MAX_UINT64) return { ms: lastId.ms + 1n, seq: 0n }
+
+  throw new StreamIdExhaustedError()
 }
 
 function nextSeqForMs(ms: bigint, lastId: StreamId): StreamId {
   if (ms > lastId.ms) return { ms, seq: 0n }
-  // Same ms (or smaller, which is rejected later by the monotonicity check).
+  if (ms < lastId.ms) {
+    return { ms, seq: lastId.seq === MAX_UINT64 ? MAX_UINT64 : lastId.seq + 1n }
+  }
+  if (lastId.seq === MAX_UINT64) {
+    if (ms === MAX_UINT64) throw new StreamIdExhaustedError()
+    throw new StreamElementTooLargeError()
+  }
+
   return { ms, seq: lastId.seq + 1n }
 }
 

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -255,6 +255,20 @@ export class StreamIdNotGreaterThanZeroError extends RedisCommandError {
   }
 }
 
+export class StreamElementTooLargeError extends RedisCommandError {
+  constructor() {
+    super('Elements are too large to be stored')
+  }
+}
+
+export class StreamIdExhaustedError extends RedisCommandError {
+  constructor() {
+    super(
+      'The stream has exhausted the last possible ID, unable to add more items',
+    )
+  }
+}
+
 export class HashValueNotIntegerError extends RedisCommandError {
   constructor() {
     super('hash value is not an integer')

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,8 @@ export {
   ScriptCallNoCommandError,
   ScriptFlushOptionError,
   ScriptUnknownCommandError,
+  StreamElementTooLargeError,
+  StreamIdExhaustedError,
   RedisSyntaxError,
   TransactionDiscardedError,
   UnknownClusterSubcommandError,

--- a/tests-integration/ioredis/stream-integration.test.ts
+++ b/tests-integration/ioredis/stream-integration.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../raw-tcp/raw-connection'
 
 const testRunner = new TestRunner()
+const MAX_UINT64 = '18446744073709551615'
 
 describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
   let redisClient: Cluster | undefined
@@ -54,6 +55,36 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
     const key = randomKey()
     assert.strictEqual(await redisClient?.xadd(key, '5-*', 'f', 'v'), '5-0')
     assert.strictEqual(await redisClient?.xadd(key, '5-*', 'f', 'v'), '5-1')
+  })
+
+  test('XADD handles auto-generated ids when the sequence overflows', async () => {
+    const taggedKey = `{${randomKey()}}`
+    const fixedMsKey = `${taggedKey}:fixed-ms`
+    const autoKey = `${taggedKey}:auto`
+    const node = await connectToSlotOwner(redisClient!, fixedMsKey)
+    const futureMs = BigInt(Date.now()) + 60_000n
+
+    try {
+      assert.strictEqual(
+        await node.call('XADD', fixedMsKey, `7-${MAX_UINT64}`, 'f', 'v'),
+        `7-${MAX_UINT64}`,
+      )
+      await assert.rejects(
+        () => node.call('XADD', fixedMsKey, '7-*', 'f', 'v'),
+        errorWithMessage('ERR Elements are too large to be stored'),
+      )
+
+      assert.strictEqual(
+        await node.call('XADD', autoKey, `${futureMs}-${MAX_UINT64}`, 'f', 'v'),
+        `${futureMs}-${MAX_UINT64}`,
+      )
+      assert.strictEqual(
+        await node.call('XADD', autoKey, '*', 'f', 'v'),
+        `${futureMs + 1n}-0`,
+      )
+    } finally {
+      node.disconnect()
+    }
   })
 
   test('XADD rejects ids equal to or smaller than the top item', async () => {


### PR DESCRIPTION
## Summary
- Keep XADD-generated stream IDs inside the uint64 Redis ID domain.
- Match Redis behavior for sequence overflow: `XADD *` advances to the next millisecond when possible, while fixed-ms `XADD <ms>-*` returns Redis' overflow errors.
- Add ioredis integration coverage that passes against both mock and real Redis backends.

## Root cause
`nextAutoId` and `nextSeqForMs` incremented `lastId.seq` without checking `MAX_UINT64`, which let the mock emit invalid IDs like `7-18446744073709551616`. Real Redis has split behavior at this boundary: fully automatic IDs can roll the millisecond forward, but fixed-millisecond auto-sequence generation errors once that millisecond is exhausted.

## Validation
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/stream-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/stream-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint` (passes with existing warning in `src/types/respjs.d.ts`)

Fixes #10