### PR TITLE
Fix conditional expiry options

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -106,13 +106,12 @@ surface.
 - [x] `TTL key` - Get the time to live for a key in seconds
 - [x] `PTTL key` - Get the time to live for a key in milliseconds
 - [x] `PERSIST key` - Remove the existing timeout on a key
-- [x] `EXPIRE key seconds` - Set a key's time to live in seconds
-- [x] `PEXPIRE key milliseconds` - Set a key's time to live in milliseconds
-- [x] `EXPIREAT key unix-time-seconds` - Set the expiration as a UNIX timestamp
-- [x] `PEXPIREAT key unix-time-milliseconds` - Set the expiration as a UNIX timestamp in milliseconds
+- [x] `EXPIRE key seconds [NX | XX | GT | LT]` - Set a key's time to live in seconds, optionally only when the current expiry state matches the condition
+- [x] `PEXPIRE key milliseconds [NX | XX | GT | LT]` - Set a key's time to live in milliseconds, optionally only when the current expiry state matches the condition
+- [x] `EXPIREAT key unix-time-seconds [NX | XX | GT | LT]` - Set the expiration as a UNIX timestamp, optionally only when the current expiry state matches the condition
+- [x] `PEXPIREAT key unix-time-milliseconds [NX | XX | GT | LT]` - Set the expiration as a UNIX timestamp in milliseconds, optionally only when the current expiry state matches the condition
 - [x] `EXPIRETIME key` - Get the absolute Unix expiration time in seconds
 - [x] `PEXPIRETIME key` - Get the absolute Unix expiration time in milliseconds
-- [ ] `NX | XX | GT | LT` conditional flags on `EXPIRE`/`PEXPIRE`/`EXPIREAT`/`PEXPIREAT` - not implemented (any extra argument is a wrong-arity error)
 
 #### Not implemented
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -113,6 +113,9 @@ surface.
 - [x] `EXPIRETIME key` - Get the absolute Unix expiration time in seconds
 - [x] `PEXPIRETIME key` - Get the absolute Unix expiration time in milliseconds
 
+`NX`, `GT`, and `LT` follow Redis' mutual-exclusion rules; `XX` can be combined
+with `GT` or `LT`.
+
 #### Not implemented
 
 - [ ] `OBJECT ENCODING|REFCOUNT|IDLETIME|FREQ`

--- a/src/commands/keys.ts
+++ b/src/commands/keys.ts
@@ -2,10 +2,13 @@ import { defineCommand } from '../core/command-definition'
 import { t } from '../core/command-schema'
 import {
   DbIndexOutOfRangeError,
+  ExpireGtLtConflictError,
+  ExpireNxXxGtLtConflictError,
   ExpectedIntegerError,
   NoSuchKeyError,
   RedisSyntaxError,
   SameObjectError,
+  UnsupportedOptionError,
 } from '../core/redis-error'
 import type { ExpirationState, RedisDatabase } from '../state'
 import {
@@ -163,39 +166,80 @@ export const pexpiretimeCommand = defineCommand({
   },
 })
 
-type ExpireCondition = 'NX' | 'XX' | 'GT' | 'LT'
+type ExpireCondition = 'NX' | 'XX'
+type ExpireComparison = 'GT' | 'LT'
+type ExpireOptions = {
+  condition?: ExpireCondition
+  comparison?: ExpireComparison
+}
 
-const expireConditionSchema = t.custom<ExpireCondition | undefined>(
-  (input, index) => {
-    if (index >= input.length) {
-      return { value: undefined, nextIndex: index }
+const expireOptionsSchema = t.custom<ExpireOptions>((input, index) => {
+  const options: ExpireOptions = {}
+  let cursor = index
+
+  while (cursor < input.length) {
+    const token = input[cursor]!.toString()
+    const option = token.toUpperCase()
+
+    if (option === 'NX') {
+      if (options.condition === 'XX' || options.comparison !== undefined) {
+        throw new ExpireNxXxGtLtConflictError()
+      }
+      options.condition = 'NX'
+      cursor += 1
+      continue
     }
 
-    const condition = input[index]!.toString().toUpperCase()
-    if (
-      condition === 'NX' ||
-      condition === 'XX' ||
-      condition === 'GT' ||
-      condition === 'LT'
-    ) {
-      return { value: condition, nextIndex: index + 1 }
+    if (option === 'XX') {
+      if (options.condition === 'NX') {
+        throw new ExpireNxXxGtLtConflictError()
+      }
+      options.condition = 'XX'
+      cursor += 1
+      continue
     }
 
-    throw new RedisSyntaxError()
-  },
-)
+    if (option === 'GT') {
+      if (options.condition === 'NX') {
+        throw new ExpireNxXxGtLtConflictError()
+      }
+      if (options.comparison === 'LT') {
+        throw new ExpireGtLtConflictError()
+      }
+      options.comparison = 'GT'
+      cursor += 1
+      continue
+    }
+
+    if (option === 'LT') {
+      if (options.condition === 'NX') {
+        throw new ExpireNxXxGtLtConflictError()
+      }
+      if (options.comparison === 'GT') {
+        throw new ExpireGtLtConflictError()
+      }
+      options.comparison = 'LT'
+      cursor += 1
+      continue
+    }
+
+    throw new UnsupportedOptionError(token)
+  }
+
+  return { value: options, nextIndex: cursor }
+})
 
 export const expireCommand = defineCommand({
   name: 'expire',
   schema: t.object({
     key: t.key(),
     seconds: t.integer(),
-    condition: expireConditionSchema,
+    options: expireOptionsSchema,
   }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) =>
-    expireKey(ctx.db, args.key, args.seconds, 1000, args.condition),
+    expireKey(ctx.db, args.key, args.seconds, 1000, args.options),
 })
 
 export const pexpireCommand = defineCommand({
@@ -203,12 +247,12 @@ export const pexpireCommand = defineCommand({
   schema: t.object({
     key: t.key(),
     milliseconds: t.integer(),
-    condition: expireConditionSchema,
+    options: expireOptionsSchema,
   }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) =>
-    expireKey(ctx.db, args.key, args.milliseconds, 1, args.condition),
+    expireKey(ctx.db, args.key, args.milliseconds, 1, args.options),
 })
 
 export const persistCommand = defineCommand({
@@ -248,12 +292,12 @@ export const expireatCommand = defineCommand({
   schema: t.object({
     key: t.key(),
     timestamp: t.integer(),
-    condition: expireConditionSchema,
+    options: expireOptionsSchema,
   }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    return expireAtKey(ctx.db, args.key, args.timestamp * 1000, args.condition)
+    return expireAtKey(ctx.db, args.key, args.timestamp * 1000, args.options)
   },
 })
 
@@ -262,12 +306,12 @@ export const pexpireatCommand = defineCommand({
   schema: t.object({
     key: t.key(),
     timestamp: t.integer(),
-    condition: expireConditionSchema,
+    options: expireOptionsSchema,
   }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    return expireAtKey(ctx.db, args.key, args.timestamp, args.condition)
+    return expireAtKey(ctx.db, args.key, args.timestamp, args.options)
   },
 })
 
@@ -434,17 +478,17 @@ function expireKey(
   key: Buffer,
   duration: number,
   multiplier: number,
-  condition?: ExpireCondition,
+  options: ExpireOptions,
 ) {
   const now = Date.now()
-  return expireAtKey(db, key, now + duration * multiplier, condition, now)
+  return expireAtKey(db, key, now + duration * multiplier, options, now)
 }
 
 function expireAtKey(
   db: RedisDatabase,
   key: Buffer,
   expiresAt: number,
-  condition?: ExpireCondition,
+  options: ExpireOptions,
   now = Date.now(),
 ) {
   const expiration = db.getExpiration(key)
@@ -452,7 +496,7 @@ function expireAtKey(
     return integer(0)
   }
 
-  if (!shouldApplyExpireCondition(expiration, expiresAt, condition)) {
+  if (!shouldApplyExpireOptions(expiration, expiresAt, options)) {
     return integer(0)
   }
 
@@ -463,25 +507,25 @@ function expireAtKey(
   return integer(db.expire(key, expiresAt) ? 1 : 0)
 }
 
-function shouldApplyExpireCondition(
+function shouldApplyExpireOptions(
   expiration: Exclude<ExpirationState, { kind: 'missing' }>,
   expiresAt: number,
-  condition?: ExpireCondition,
+  options: ExpireOptions,
 ): boolean {
-  if (condition === undefined) {
-    return true
-  }
-
-  if (condition === 'NX') {
+  if (options.condition === 'NX') {
     return expiration.kind === 'persistent'
   }
 
-  if (condition === 'XX') {
-    return expiration.kind === 'expires'
+  if (options.condition === 'XX' && expiration.kind !== 'expires') {
+    return false
   }
 
-  if (condition === 'GT') {
+  if (options.comparison === 'GT') {
     return expiration.kind === 'expires' && expiresAt > expiration.expiresAt
+  }
+
+  if (options.comparison !== 'LT') {
+    return true
   }
 
   if (expiration.kind === 'persistent') {

--- a/src/commands/keys.ts
+++ b/src/commands/keys.ts
@@ -7,7 +7,7 @@ import {
   RedisSyntaxError,
   SameObjectError,
 } from '../core/redis-error'
-import type { RedisDatabase } from '../state'
+import type { ExpirationState, RedisDatabase } from '../state'
 import {
   integer,
   ok,
@@ -163,15 +163,39 @@ export const pexpiretimeCommand = defineCommand({
   },
 })
 
+type ExpireCondition = 'NX' | 'XX' | 'GT' | 'LT'
+
+const expireConditionSchema = t.custom<ExpireCondition | undefined>(
+  (input, index) => {
+    if (index >= input.length) {
+      return { value: undefined, nextIndex: index }
+    }
+
+    const condition = input[index]!.toString().toUpperCase()
+    if (
+      condition === 'NX' ||
+      condition === 'XX' ||
+      condition === 'GT' ||
+      condition === 'LT'
+    ) {
+      return { value: condition, nextIndex: index + 1 }
+    }
+
+    throw new RedisSyntaxError()
+  },
+)
+
 export const expireCommand = defineCommand({
   name: 'expire',
   schema: t.object({
     key: t.key(),
     seconds: t.integer(),
+    condition: expireConditionSchema,
   }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
-  execute: (args, ctx) => expireKey(ctx.db, args.key, args.seconds, 1000),
+  execute: (args, ctx) =>
+    expireKey(ctx.db, args.key, args.seconds, 1000, args.condition),
 })
 
 export const pexpireCommand = defineCommand({
@@ -179,10 +203,12 @@ export const pexpireCommand = defineCommand({
   schema: t.object({
     key: t.key(),
     milliseconds: t.integer(),
+    condition: expireConditionSchema,
   }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
-  execute: (args, ctx) => expireKey(ctx.db, args.key, args.milliseconds, 1),
+  execute: (args, ctx) =>
+    expireKey(ctx.db, args.key, args.milliseconds, 1, args.condition),
 })
 
 export const persistCommand = defineCommand({
@@ -219,32 +245,29 @@ export const flushallCommand = defineCommand({
 
 export const expireatCommand = defineCommand({
   name: 'expireat',
-  schema: t.object({ key: t.key(), timestamp: t.integer() }),
+  schema: t.object({
+    key: t.key(),
+    timestamp: t.integer(),
+    condition: expireConditionSchema,
+  }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    if (ctx.db.getType(args.key) === null) return integer(0)
-    const expiresAt = args.timestamp * 1000
-    if (expiresAt <= Date.now()) {
-      ctx.db.delete(args.key)
-      return integer(1)
-    }
-    return integer(ctx.db.expire(args.key, expiresAt) ? 1 : 0)
+    return expireAtKey(ctx.db, args.key, args.timestamp * 1000, args.condition)
   },
 })
 
 export const pexpireatCommand = defineCommand({
   name: 'pexpireat',
-  schema: t.object({ key: t.key(), timestamp: t.integer() }),
+  schema: t.object({
+    key: t.key(),
+    timestamp: t.integer(),
+    condition: expireConditionSchema,
+  }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    if (ctx.db.getType(args.key) === null) return integer(0)
-    if (args.timestamp <= Date.now()) {
-      ctx.db.delete(args.key)
-      return integer(1)
-    }
-    return integer(ctx.db.expire(args.key, args.timestamp) ? 1 : 0)
+    return expireAtKey(ctx.db, args.key, args.timestamp, args.condition)
   },
 })
 
@@ -411,14 +434,59 @@ function expireKey(
   key: Buffer,
   duration: number,
   multiplier: number,
+  condition?: ExpireCondition,
 ) {
-  if (db.getType(key) === null) {
+  const now = Date.now()
+  return expireAtKey(db, key, now + duration * multiplier, condition, now)
+}
+
+function expireAtKey(
+  db: RedisDatabase,
+  key: Buffer,
+  expiresAt: number,
+  condition?: ExpireCondition,
+  now = Date.now(),
+) {
+  const expiration = db.getExpiration(key)
+  if (expiration.kind === 'missing') {
     return integer(0)
   }
 
-  if (duration <= 0) {
+  if (!shouldApplyExpireCondition(expiration, expiresAt, condition)) {
+    return integer(0)
+  }
+
+  if (expiresAt <= now) {
     return integer(db.delete(key) ? 1 : 0)
   }
 
-  return integer(db.expire(key, Date.now() + duration * multiplier) ? 1 : 0)
+  return integer(db.expire(key, expiresAt) ? 1 : 0)
+}
+
+function shouldApplyExpireCondition(
+  expiration: Exclude<ExpirationState, { kind: 'missing' }>,
+  expiresAt: number,
+  condition?: ExpireCondition,
+): boolean {
+  if (condition === undefined) {
+    return true
+  }
+
+  if (condition === 'NX') {
+    return expiration.kind === 'persistent'
+  }
+
+  if (condition === 'XX') {
+    return expiration.kind === 'expires'
+  }
+
+  if (condition === 'GT') {
+    return expiration.kind === 'expires' && expiresAt > expiration.expiresAt
+  }
+
+  if (expiration.kind === 'persistent') {
+    return true
+  }
+
+  return expiresAt < expiration.expiresAt
 }

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -79,6 +79,24 @@ export class ZaddGtLtNxConflictError extends RedisCommandError {
   }
 }
 
+export class ExpireNxXxGtLtConflictError extends RedisCommandError {
+  constructor() {
+    super('NX and XX, GT or LT options at the same time are not compatible')
+  }
+}
+
+export class ExpireGtLtConflictError extends RedisCommandError {
+  constructor() {
+    super('GT and LT options at the same time are not compatible')
+  }
+}
+
+export class UnsupportedOptionError extends RedisCommandError {
+  constructor(option: string) {
+    super(`Unsupported option ${option}`)
+  }
+}
+
 export class ZaddIncrPairError extends RedisCommandError {
   constructor() {
     super('INCR option supports a single increment-element pair')

--- a/tests-integration/ioredis/key-integration.test.ts
+++ b/tests-integration/ioredis/key-integration.test.ts
@@ -493,6 +493,7 @@ describe(`Key Commands Integration (${testRunner.getBackendName()})`, () => {
     const pexpireKey = `${tag}:pexpire`
     const expireatKey = `${tag}:expireat`
     const pexpireatKey = `${tag}:pexpireat`
+    const duplicateOptionKey = `${tag}:duplicate`
     const missing = `${tag}:missing`
     const directClient = await connectToSlotOwner(redisClient!, expireKey)
 
@@ -545,6 +546,20 @@ describe(`Key Commands Integration (${testRunner.getBackendName()})`, () => {
       )
       const pexpireTtl = await directClient.pttl(pexpireKey)
       assert.ok(pexpireTtl > 120_000 && pexpireTtl <= 240_000)
+      assert.strictEqual(
+        await directClient.call('PEXPIRE', pexpireKey, 300_000, 'XX', 'GT'),
+        1,
+      )
+      assert.strictEqual(
+        await directClient.call('PEXPIRE', pexpireKey, 100_000, 'XX', 'LT'),
+        1,
+      )
+
+      await directClient.set(duplicateOptionKey, 'value')
+      assert.strictEqual(
+        await directClient.call('EXPIRE', duplicateOptionKey, 30, 'NX', 'NX'),
+        1,
+      )
 
       await directClient.set(expireatKey, 'value')
       const nowSeconds = Math.floor(Date.now() / 1000)
@@ -639,13 +654,19 @@ describe(`Key Commands Integration (${testRunner.getBackendName()})`, () => {
 
       await assert.rejects(
         () => directClient.call('EXPIRE', expireKey, 10, 'BOGUS'),
-        (error: unknown) =>
-          error instanceof Error && error.message.startsWith('ERR '),
+        errorWithMessage('ERR Unsupported option BOGUS'),
       )
       await assert.rejects(
         () => directClient.call('EXPIRE', expireKey, 10, 'NX', 'XX'),
-        (error: unknown) =>
-          error instanceof Error && error.message.startsWith('ERR '),
+        errorWithMessage(
+          'ERR NX and XX, GT or LT options at the same time are not compatible',
+        ),
+      )
+      await assert.rejects(
+        () => directClient.call('EXPIRE', expireKey, 10, 'GT', 'LT'),
+        errorWithMessage(
+          'ERR GT and LT options at the same time are not compatible',
+        ),
       )
     } finally {
       await directClient.del(
@@ -653,6 +674,7 @@ describe(`Key Commands Integration (${testRunner.getBackendName()})`, () => {
         pexpireKey,
         expireatKey,
         pexpireatKey,
+        duplicateOptionKey,
         missing,
       )
       directClient.disconnect()

--- a/tests-integration/ioredis/key-integration.test.ts
+++ b/tests-integration/ioredis/key-integration.test.ts
@@ -4,6 +4,7 @@ import { Cluster } from 'ioredis'
 import { TestRunner } from '../test-config'
 import {
   assertDbSizeDelta,
+  connectToSlotOwner,
   errorWithMessage,
   getTotalDbSize,
   randomKey,
@@ -484,6 +485,178 @@ describe(`Key Commands Integration (${testRunner.getBackendName()})`, () => {
       futureTimestamp,
     )
     assert.strictEqual(expireatNonExistent, 0)
+  })
+
+  test('EXPIRE family supports conditional expiry options', async () => {
+    const tag = `{expire-options:${randomKey()}}`
+    const expireKey = `${tag}:expire`
+    const pexpireKey = `${tag}:pexpire`
+    const expireatKey = `${tag}:expireat`
+    const pexpireatKey = `${tag}:pexpireat`
+    const missing = `${tag}:missing`
+    const directClient = await connectToSlotOwner(redisClient!, expireKey)
+
+    try {
+      await directClient.set(expireKey, 'value')
+      assert.strictEqual(
+        await directClient.call('EXPIRE', expireKey, 120, 'GT'),
+        0,
+      )
+      assert.strictEqual(await directClient.ttl(expireKey), -1)
+      assert.strictEqual(
+        await directClient.call('EXPIRE', expireKey, 120, 'LT'),
+        1,
+      )
+      assert.strictEqual(
+        await directClient.call('EXPIRE', expireKey, 60, 'GT'),
+        0,
+      )
+      assert.strictEqual(
+        await directClient.call('EXPIRE', expireKey, 240, 'GT'),
+        1,
+      )
+      assert.strictEqual(
+        await directClient.call('EXPIRE', expireKey, 300, 'LT'),
+        0,
+      )
+      assert.strictEqual(
+        await directClient.call('EXPIRE', expireKey, 120, 'LT'),
+        1,
+      )
+      const expireTtl = await directClient.ttl(expireKey)
+      assert.ok(expireTtl > 0 && expireTtl <= 120)
+
+      await directClient.set(pexpireKey, 'value')
+      assert.strictEqual(
+        await directClient.call('PEXPIRE', pexpireKey, 120_000, 'XX'),
+        0,
+      )
+      assert.strictEqual(
+        await directClient.call('PEXPIRE', pexpireKey, 120_000, 'NX'),
+        1,
+      )
+      assert.strictEqual(
+        await directClient.call('PEXPIRE', pexpireKey, 240_000, 'NX'),
+        0,
+      )
+      assert.strictEqual(
+        await directClient.call('PEXPIRE', pexpireKey, 240_000, 'XX'),
+        1,
+      )
+      const pexpireTtl = await directClient.pttl(pexpireKey)
+      assert.ok(pexpireTtl > 120_000 && pexpireTtl <= 240_000)
+
+      await directClient.set(expireatKey, 'value')
+      const nowSeconds = Math.floor(Date.now() / 1000)
+      assert.strictEqual(
+        await directClient.call(
+          'EXPIREAT',
+          expireatKey,
+          nowSeconds + 120,
+          'NX',
+        ),
+        1,
+      )
+      assert.strictEqual(
+        await directClient.call(
+          'EXPIREAT',
+          expireatKey,
+          nowSeconds + 240,
+          'GT',
+        ),
+        1,
+      )
+      assert.strictEqual(
+        await directClient.call(
+          'EXPIREAT',
+          expireatKey,
+          nowSeconds + 300,
+          'LT',
+        ),
+        0,
+      )
+      assert.strictEqual(
+        await directClient.call(
+          'EXPIREAT',
+          expireatKey,
+          nowSeconds + 120,
+          'LT',
+        ),
+        1,
+      )
+
+      await directClient.set(pexpireatKey, 'value')
+      const nowMilliseconds = Date.now()
+      assert.strictEqual(
+        await directClient.call(
+          'PEXPIREAT',
+          pexpireatKey,
+          nowMilliseconds + 120_000,
+          'XX',
+        ),
+        0,
+      )
+      assert.strictEqual(
+        await directClient.call(
+          'PEXPIREAT',
+          pexpireatKey,
+          nowMilliseconds + 120_000,
+          'NX',
+        ),
+        1,
+      )
+      assert.strictEqual(
+        await directClient.call(
+          'PEXPIREAT',
+          pexpireatKey,
+          nowMilliseconds + 240_000,
+          'XX',
+        ),
+        1,
+      )
+
+      assert.strictEqual(
+        await directClient.call('EXPIRE', missing, 10, 'NX'),
+        0,
+      )
+      assert.strictEqual(
+        await directClient.call('PEXPIRE', missing, 10, 'XX'),
+        0,
+      )
+      assert.strictEqual(
+        await directClient.call('EXPIREAT', missing, nowSeconds + 10, 'GT'),
+        0,
+      )
+      assert.strictEqual(
+        await directClient.call(
+          'PEXPIREAT',
+          missing,
+          nowMilliseconds + 10_000,
+          'LT',
+        ),
+        0,
+      )
+
+      await assert.rejects(
+        () => directClient.call('EXPIRE', expireKey, 10, 'BOGUS'),
+        (error: unknown) =>
+          error instanceof Error && error.message.startsWith('ERR '),
+      )
+      await assert.rejects(
+        () => directClient.call('EXPIRE', expireKey, 10, 'NX', 'XX'),
+        (error: unknown) =>
+          error instanceof Error && error.message.startsWith('ERR '),
+      )
+    } finally {
+      await directClient.del(
+        expireKey,
+        pexpireKey,
+        expireatKey,
+        pexpireatKey,
+        missing,
+      )
+      directClient.disconnect()
+    }
   })
 
   test('TTL integration with EXPIRE and EXPIREAT', async () => {


### PR DESCRIPTION
## Summary
- Add Redis 7 conditional expiry options (`NX`, `XX`, `GT`, `LT`) to `EXPIRE`, `PEXPIRE`, `EXPIREAT`, and `PEXPIREAT`.
- Share expiry option handling across relative and absolute expiry commands, including missing-key, persistent-key, past-expiry/delete behavior, duplicate flags, `XX` + `GT`/`LT`, and Redis-compatible conflict/unsupported-option errors.
- Add ioredis integration coverage that runs against both mock and real Redis, and update command support docs.

## Root cause
The expiry command schemas only accepted the key and integer time/timestamp arguments. Any conditional option was left as an extra argument, so the executor rejected Redis-compatible calls such as `EXPIRE key 10 NX` with a wrong-arity error before command logic ran.

## Validation
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/key-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/key-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint` (passes with one existing warning in `src/types/respjs.d.ts`)

Fixes #23