### PR TITLE
Fix zset infinite score handling

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -223,11 +223,11 @@ with `GT` or `LT`.
 
 ## 8. Sorted Set Commands
 
-- [x] `ZADD key [NX | XX] [GT | LT] [CH] [INCR] score member [score member ...]` - Add or update members with scores
+- [x] `ZADD key [NX | XX] [GT | LT] [CH] [INCR] score member [score member ...]` - Add or update members with scores (`inf`, `+inf`, and `-inf` score tokens supported)
 - [x] `ZREM key member [member ...]` - Remove one or more members
 - [x] `ZCARD key` - Get the number of members
 - [x] `ZSCORE key member` - Get the score of a member
-- [x] `ZINCRBY key increment member` - Increment the score of a member
+- [x] `ZINCRBY key increment member` - Increment the score of a member (`inf`, `+inf`, and `-inf` increments supported; NaN results rejected)
 - [x] `ZRANK key member` - Get the index of a member, lowest score first
 - [x] `ZREVRANK key member` - Get the index of a member, highest score first
 - [x] `ZRANGE key start stop [WITHSCORES]` - Return a range of members by index
@@ -241,6 +241,7 @@ with `GT` or `LT`.
 
 #### Notes / gaps vs. real Redis
 
+- Score replies from `ZSCORE`, `ZINCRBY`, `ZRANGE WITHSCORES`, `ZREVRANGE WITHSCORES`, `ZPOPMIN`, `ZPOPMAX`, and `ZSCAN` serialize infinite scores as `inf` / `-inf`.
 - [ ] `ZRANGE`/`ZREVRANGE` do not support the Redis 6.2+ unified syntax (`BYSCORE`, `BYLEX`, `REV`, `LIMIT offset count`) - `start`/`stop` are always treated as indexes
 - [ ] `ZRANGEBYSCORE` does not support `WITHSCORES` or `LIMIT offset count`
 - [ ] `ZRANK`/`ZREVRANK` do not support the Redis 7.2 `WITHSCORE` option

--- a/src/commands/helpers.ts
+++ b/src/commands/helpers.ts
@@ -20,6 +20,12 @@ export function integer(value: number | bigint): RedisResult {
   return RedisResult.create(RedisValue.integer(value))
 }
 
+export function scoreBuffer(score: number): Buffer {
+  if (score === Infinity) return Buffer.from('inf')
+  if (score === -Infinity) return Buffer.from('-inf')
+  return Buffer.from(score.toString())
+}
+
 export function simpleString(value: string): RedisResult {
   return RedisResult.create(RedisValue.simpleString(value))
 }

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -8,7 +8,7 @@ import {
 import { RedisResult } from '../core/redis-result'
 import { RedisValue } from '../core/redis-value'
 import type { RedisDataTypeName } from '../state'
-import { array } from './helpers'
+import { array, scoreBuffer } from './helpers'
 
 type ScanOptions = {
   cursor: bigint
@@ -121,7 +121,7 @@ export const zscanCommand = defineCommand({
       }
 
       items.push(RedisValue.bulkString(entry.member))
-      items.push(RedisValue.bulkString(Buffer.from(entry.score.toString())))
+      items.push(RedisValue.bulkString(scoreBuffer(entry.score)))
     }
 
     return scanResult(items, args, 2)

--- a/src/commands/zsets.ts
+++ b/src/commands/zsets.ts
@@ -4,6 +4,7 @@ import {
   ExpectedFloatError,
   MinMaxNotFloatError,
   PositiveCountError,
+  ResultingScoreNaNError,
   WrongNumberOfArgumentsError,
   ZaddGtLtNxConflictError,
   ZaddIncrPairError,
@@ -16,7 +17,7 @@ import type {
   RedisSortedSetData,
   RedisSortedSetMember,
 } from '../state/data-types'
-import { bulk, integer, array } from './helpers'
+import { bulk, integer, array, scoreBuffer } from './helpers'
 
 function getSortedMembers(zset: RedisSortedSetData): RedisSortedSetMember[] {
   return Array.from(zset.members.values()).sort((a, b) =>
@@ -27,9 +28,19 @@ function getSortedMembers(zset: RedisSortedSetData): RedisSortedSetMember[] {
 }
 
 function parseFloatArg(s: string): number {
+  const normalized = s.toLowerCase()
+  if (normalized === 'inf' || normalized === '+inf') return Infinity
+  if (normalized === '-inf') return -Infinity
+
   const n = Number(s)
   if (!Number.isFinite(n)) throw new ExpectedFloatError()
   return n
+}
+
+function assertValidResultingScore(score: number) {
+  if (Number.isNaN(score)) {
+    throw new ResultingScoreNaNError()
+  }
 }
 
 type ScoreBound = { value: number; exclusive: boolean }
@@ -179,8 +190,7 @@ function parseZaddPairs(
       throw new WrongNumberOfArgumentsError(ctx.commandName)
     }
 
-    const score = Number(scoreToken.toString())
-    if (!Number.isFinite(score)) throw new ExpectedFloatError()
+    const score = parseFloatArg(scoreToken.toString())
 
     pairs.push({ score, member: memberToken })
     cursor += 2
@@ -219,6 +229,7 @@ export const zaddCommand = defineCommand({
         const hex = member.toString('hex')
         const existing = zset.members.get(hex)
         const nextScore = (existing?.score ?? 0) + score
+        assertValidResultingScore(nextScore)
 
         if (!shouldApplyZaddUpdate(existing, nextScore, args.options)) {
           return null
@@ -228,7 +239,7 @@ export const zaddCommand = defineCommand({
         return nextScore
       })
       deleteSortedSetIfEmpty(ctx.db, args.key)
-      return bulk(newScore === null ? null : Buffer.from(newScore.toString()))
+      return bulk(newScore === null ? null : scoreBuffer(newScore))
     }
 
     const changed = ctx.db.updateSortedSet(args.key, zset => {
@@ -332,7 +343,7 @@ export const zscoreCommand = defineCommand({
     if (!zset) return bulk(null)
     const entry = zset.members.get(args.member.toString('hex'))
     if (!entry) return bulk(null)
-    return bulk(Buffer.from(entry.score.toString()))
+    return bulk(scoreBuffer(entry.score))
   },
 })
 
@@ -347,10 +358,11 @@ export const zincrbyCommand = defineCommand({
       const hex = args.member.toString('hex')
       const existing = zset.members.get(hex)
       const score = (existing?.score ?? 0) + inc
+      assertValidResultingScore(score)
       zset.members.set(hex, { member: args.member, score })
       return score
     })
-    return bulk(Buffer.from(newScore.toString()))
+    return bulk(scoreBuffer(newScore))
   },
 })
 
@@ -377,7 +389,7 @@ export const zrangeCommand = defineCommand({
     for (const entry of slice) {
       items.push(RedisValue.bulkString(entry.member))
       if (args.withScores) {
-        items.push(RedisValue.bulkString(Buffer.from(entry.score.toString())))
+        items.push(RedisValue.bulkString(scoreBuffer(entry.score)))
       }
     }
     return array(items)
@@ -407,7 +419,7 @@ export const zrevrangeCommand = defineCommand({
     for (const entry of slice) {
       items.push(RedisValue.bulkString(entry.member))
       if (args.withScores) {
-        items.push(RedisValue.bulkString(Buffer.from(entry.score.toString())))
+        items.push(RedisValue.bulkString(scoreBuffer(entry.score)))
       }
     }
     return array(items)
@@ -502,7 +514,7 @@ export const zpopminCommand = defineCommand({
     const items: RedisValue[] = []
     for (const entry of toRemove) {
       items.push(RedisValue.bulkString(entry.member))
-      items.push(RedisValue.bulkString(Buffer.from(entry.score.toString())))
+      items.push(RedisValue.bulkString(scoreBuffer(entry.score)))
     }
     return array(items)
   },
@@ -531,7 +543,7 @@ export const zpopmaxCommand = defineCommand({
     const items: RedisValue[] = []
     for (const entry of toRemove) {
       items.push(RedisValue.bulkString(entry.member))
-      items.push(RedisValue.bulkString(Buffer.from(entry.score.toString())))
+      items.push(RedisValue.bulkString(scoreBuffer(entry.score)))
     }
     return array(items)
   },

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -55,6 +55,12 @@ export class ExpectedFloatError extends RedisCommandError {
   }
 }
 
+export class ResultingScoreNaNError extends RedisCommandError {
+  constructor() {
+    super('resulting score is not a number (NaN)')
+  }
+}
+
 export class MinMaxNotFloatError extends RedisCommandError {
   constructor() {
     super('min or max is not a float')

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ export {
   RedisCrossSlotError,
   RedisCommandError,
   RedisMovedError,
+  ResultingScoreNaNError,
   ScriptDebugModeError,
   ScriptCallNoCommandError,
   ScriptFlushOptionError,

--- a/tests-integration/ioredis/zset-integration.test.ts
+++ b/tests-integration/ioredis/zset-integration.test.ts
@@ -207,6 +207,78 @@ describe(`Sorted Set Commands Integration (${testRunner.getBackendName()})`, () 
     assert.strictEqual(score2, '50')
   })
 
+  test('sorted set commands accept and return Redis infinity score tokens', async () => {
+    const tag = `{zset-infinity:${randomKey()}}`
+    const zincrbyKey = `${tag}:zincrby`
+    const zaddKey = `${tag}:zadd`
+
+    try {
+      assert.strictEqual(await redisClient?.zadd(zincrbyKey, 5, 'finite'), 1)
+      assert.strictEqual(
+        await redisClient?.zincrby(zincrbyKey, '+INF', 'positive'),
+        'inf',
+      )
+      assert.strictEqual(
+        await redisClient?.zincrby(zincrbyKey, '-inf', 'negative'),
+        '-inf',
+      )
+
+      assert.strictEqual(
+        await redisClient?.zscore(zincrbyKey, 'positive'),
+        'inf',
+      )
+      assert.strictEqual(
+        await redisClient?.zscore(zincrbyKey, 'negative'),
+        '-inf',
+      )
+      await assert.rejects(
+        () => redisClient?.zincrby(zincrbyKey, '-inf', 'positive'),
+        errorWithMessage('ERR resulting score is not a number (NaN)'),
+      )
+      assert.strictEqual(
+        await redisClient?.zscore(zincrbyKey, 'positive'),
+        'inf',
+      )
+      assert.deepStrictEqual(
+        await redisClient?.zrange(zincrbyKey, 0, -1, 'WITHSCORES'),
+        ['negative', '-inf', 'finite', '5', 'positive', 'inf'],
+      )
+      assert.deepStrictEqual(await redisClient?.zpopmin(zincrbyKey), [
+        'negative',
+        '-inf',
+      ])
+      assert.deepStrictEqual(await redisClient?.zpopmax(zincrbyKey), [
+        'positive',
+        'inf',
+      ])
+
+      assert.strictEqual(
+        await redisClient?.zadd(
+          zaddKey,
+          '+inf',
+          'positive',
+          '-INF',
+          'negative',
+        ),
+        2,
+      )
+      assert.strictEqual(await redisClient?.zscore(zaddKey, 'positive'), 'inf')
+      assert.strictEqual(await redisClient?.zscore(zaddKey, 'negative'), '-inf')
+
+      const zscan = await redisClient?.zscan(zaddKey, '0')
+      assert.ok(zscan)
+      const [, zscanItems] = zscan
+      const scannedScores = new Map<string, string>()
+      for (let i = 0; i < zscanItems.length; i += 2) {
+        scannedScores.set(zscanItems[i], zscanItems[i + 1])
+      }
+      assert.strictEqual(scannedScores.get('positive'), 'inf')
+      assert.strictEqual(scannedScores.get('negative'), '-inf')
+    } finally {
+      await redisClient?.del(zincrbyKey, zaddKey)
+    }
+  })
+
   test('Sorted set command errors match Redis', async () => {
     const tag = `{zset-errors:${randomKey()}}`
     const zsetKey = `${tag}:zset`
@@ -228,6 +300,10 @@ describe(`Sorted Set Commands Integration (${testRunner.getBackendName()})`, () 
       )
       await assert.rejects(
         () => redisClient?.call('ZINCRBY', zsetKey, 'abc', 'a'),
+        errorWithMessage('ERR value is not a valid float'),
+      )
+      await assert.rejects(
+        () => redisClient?.call('ZINCRBY', zsetKey, 'nan', 'a'),
         errorWithMessage('ERR value is not a valid float'),
       )
       await assert.rejects(


### PR DESCRIPTION
## Summary
- accept Redis `inf`, `+inf`, and `-inf` score tokens for ZADD and ZINCRBY
- serialize infinite sorted-set scores as `inf` / `-inf` across ZSCORE, ZINCRBY, range-with-score replies, ZPOP*, and ZSCAN
- reject ZINCRBY/ZADD INCR arithmetic that would produce `NaN` with Redis' `ERR resulting score is not a number (NaN)` error

## Root cause
Sorted-set score parsing reused `Number()` but rejected every non-finite value, so Redis' valid infinity tokens failed as invalid floats. Score replies also used JavaScript `Number.toString()`, which emits `Infinity` / `-Infinity` instead of Redis' `inf` / `-inf` bulk-string tokens.

## Validation
- focused mock zset integration failed before the fix on `ERR value is not a valid float`
- focused real zset integration passed the new infinity/NaN behavior before the implementation
- focused mock zset integration passed after the fix
- focused real zset integration passed after the fix
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run clean:redis`
- `npm run test:integration:real`
- `npm run lint` (passes with existing warning in `src/types/respjs.d.ts`)

Fixes #39
Fixes #40