### PR TITLE
fix: EXEC prioritizes EXECABORT over WATCH-nil (#123)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -228,7 +228,7 @@ sequenceDiagram
 
     Cl->>CS: EXEC
     CS->>CE: executeRaw(EXEC, [], ctx)
-    Note over CE,CS: WATCH dirty → discard, reply *-1<br/>queue dirty (e.g. unknown cmd) → discard, EXECABORT<br/>EXEC itself malformed (e.g. `EXEC foo`) → discard immediately,<br/>EXECABORT "Transaction discarded because of: &lt;reason&gt;"
+    Note over CE,CS: queue dirty (e.g. unknown cmd) → discard, EXECABORT<br/>(takes precedence over WATCH)<br/>else WATCH dirty → discard, reply *-1<br/>EXEC itself malformed (e.g. `EXEC foo`) → discard immediately,<br/>EXECABORT "Transaction discarded because of: &lt;reason&gt;"
     CE->>CS: drainTransaction() → plans[]
     CS->>CS: executeTransaction(plans)<br/>runs each plan through the executor, in order
     CS-->>Cl: array of per-command replies
@@ -245,9 +245,12 @@ which reuses the normal `executePlan` path per command.
 
 `WATCH` subscribes to per-key mutation events on the database
 ([`ClientSession.watch`](../src/core/client-session.ts#L185)); any write,
-delete, or lazy-eviction on a watched key marks the session dirty, and `EXEC`
-checks `isWatchDirty()` before running the queue (see
-[State & data model](#state--data-model) for how mutation events propagate).
+delete, or lazy-eviction on a watched key marks the session dirty. Before
+running the queue `EXEC` checks `isTransactionDirty()` first — a bad queued
+command aborts with `EXECABORT` regardless of WATCH state — then
+`isWatchDirty()`, which replies `*-1` only when the queue is otherwise clean
+(matching real Redis `CLIENT_DIRTY_EXEC` over `CLIENT_DIRTY_CAS` precedence;
+see [State & data model](#state--data-model) for how mutation events propagate).
 
 ### Cluster routing
 

--- a/src/commands/transactions.ts
+++ b/src/commands/transactions.ts
@@ -34,14 +34,17 @@ export const execCommand = defineCommand({
       throw new ExecWithoutMultiError()
     }
 
-    if (ctx.session.isWatchDirty()) {
-      ctx.session.discardTransaction()
-      return RedisResult.create(RedisValue.nullArray())
-    }
-
+    // Real Redis prioritises CLIENT_DIRTY_EXEC over CLIENT_DIRTY_CAS: a bad
+    // command in the queue aborts with -EXECABORT regardless of WATCH state.
+    // The (nil) CAS-abort reply is only returned when the queue itself is clean.
     if (ctx.session.isTransactionDirty()) {
       ctx.session.discardTransaction()
       throw new TransactionDiscardedError()
+    }
+
+    if (ctx.session.isWatchDirty()) {
+      ctx.session.discardTransaction()
+      return RedisResult.create(RedisValue.nullArray())
     }
 
     const plans = ctx.session.drainTransaction()

--- a/tests-integration/ioredis/exec-dirty-precedence.test.ts
+++ b/tests-integration/ioredis/exec-dirty-precedence.test.ts
@@ -1,0 +1,126 @@
+import { Cluster, Redis } from 'ioredis'
+import { after, before, describe, it } from 'node:test'
+import assert from 'node:assert'
+import { TestRunner } from '../test-config'
+import { connectToSlotOwner, errorWithMessage } from '../utils'
+
+const testRunner = new TestRunner()
+
+// Real Redis sets CLIENT_DIRTY_EXEC when a queued command fails (e.g. an
+// unknown command) and CLIENT_DIRTY_CAS when a WATCHed key is touched. EXEC
+// must prioritise DIRTY_EXEC: if the queue itself is bad it returns
+// -EXECABORT regardless of WATCH state, only returning the (nil) CAS-abort
+// reply when the queue is clean. See issue #123.
+describe('EXEC dirty-flag precedence (EXECABORT over WATCH-nil)', () => {
+  let redisClient: Cluster | undefined
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster()
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  it('returns EXECABORT (not nil) when the queue is bad AND a watched key changed', async () => {
+    const key = 'execdirty:precedence:1'
+    let directClient: Redis | undefined
+    let mutatingClient: Redis | undefined
+
+    try {
+      // Two direct connections to the same slot owner so WATCH/MULTI/EXEC stay
+      // on one node and the mutation is seen by the watching session.
+      directClient = await connectToSlotOwner(redisClient!, key)
+      mutatingClient = await connectToSlotOwner(redisClient!, key)
+
+      await directClient.call('SET', key, 'init')
+      await directClient.call('WATCH', key)
+
+      // Dirty the WATCH (CLIENT_DIRTY_CAS) from another connection.
+      await mutatingClient.call('SET', key, 'modified')
+
+      assert.strictEqual(await directClient.call('MULTI'), 'OK')
+
+      // Queue an unknown command -> dirties the transaction (CLIENT_DIRTY_EXEC).
+      await assert.rejects(() => directClient!.call('NOTACOMMAND', 'x'))
+
+      // DIRTY_EXEC must win over DIRTY_CAS: EXECABORT, not a nil array.
+      await assert.rejects(
+        () => directClient!.call('EXEC'),
+        errorWithMessage(
+          'EXECABORT Transaction discarded because of previous errors.',
+        ),
+      )
+    } finally {
+      directClient?.disconnect()
+      mutatingClient?.disconnect()
+    }
+  })
+
+  it('returns EXECABORT when the queue is bad and no key is watched', async () => {
+    const key = 'execdirty:precedence:2'
+    let directClient: Redis | undefined
+
+    try {
+      directClient = await connectToSlotOwner(redisClient!, key)
+
+      assert.strictEqual(await directClient.call('MULTI'), 'OK')
+      await assert.rejects(() => directClient!.call('NOTACOMMAND', 'x'))
+
+      await assert.rejects(
+        () => directClient!.call('EXEC'),
+        errorWithMessage(
+          'EXECABORT Transaction discarded because of previous errors.',
+        ),
+      )
+    } finally {
+      directClient?.disconnect()
+    }
+  })
+
+  it('returns nil (not EXECABORT) when only a watched key changed and the queue is clean', async () => {
+    const key = 'execdirty:precedence:3'
+    let directClient: Redis | undefined
+    let mutatingClient: Redis | undefined
+
+    try {
+      directClient = await connectToSlotOwner(redisClient!, key)
+      mutatingClient = await connectToSlotOwner(redisClient!, key)
+
+      await directClient.call('SET', key, 'init')
+      await directClient.call('WATCH', key)
+      await mutatingClient.call('SET', key, 'modified')
+
+      assert.strictEqual(await directClient.call('MULTI'), 'OK')
+      assert.strictEqual(
+        await directClient.call('SET', key, 'queued'),
+        'QUEUED',
+      )
+
+      // Clean queue + dirty CAS -> aborts with a nil array, never EXECABORT.
+      const result = await directClient.call('EXEC')
+      assert.strictEqual(result, null)
+
+      // The watched key keeps the other client's value.
+      assert.strictEqual(await directClient.call('GET', key), 'modified')
+    } finally {
+      directClient?.disconnect()
+      mutatingClient?.disconnect()
+    }
+  })
+
+  it('returns ERR EXEC without MULTI when called outside a transaction', async () => {
+    const key = 'execdirty:precedence:4'
+    let directClient: Redis | undefined
+
+    try {
+      directClient = await connectToSlotOwner(redisClient!, key)
+      await assert.rejects(
+        () => directClient!.call('EXEC'),
+        errorWithMessage('ERR EXEC without MULTI'),
+      )
+    } finally {
+      directClient?.disconnect()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- `EXEC` checked `isWatchDirty()` **before** `isTransactionDirty()`, so a transaction that was *both* WATCH-dirty (a watched key changed → `CLIENT_DIRTY_CAS`) and queue-dirty (a bad command was queued → `CLIENT_DIRTY_EXEC`) returned a nil array instead of `-EXECABORT`.
- Real Redis prioritizes `CLIENT_DIRTY_EXEC` over `CLIENT_DIRTY_CAS`: a bad queue always aborts with `EXECABORT` regardless of WATCH state; the nil CAS-abort reply is only returned when the queue is clean.
- Fix: swap the two checks in [src/commands/transactions.ts](src/commands/transactions.ts) so `isTransactionDirty()` is checked first. Updated the EXEC sequence note + prose in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).

Verified against real Redis: dirty-CAS + dirty-EXEC → `EXECABORT Transaction discarded because of previous errors.`

Closes #123

## Test plan
- [x] New test in `tests-integration/ioredis/exec-dirty-precedence.test.ts` reproduces the bug (red on mock before fix, case 1)
- [x] Test passes against real Redis cluster (mock-only bug confirmed)
- [x] Fix makes the test pass on mock too
- [x] Covers regression paths: EXECABORT without WATCH, nil on clean-queue+dirty-CAS, `ERR EXEC without MULTI`
- [x] `npm run test:all` passes (unit 126, mock 258, real 258)

🤖 Generated with [Claude Code](https://claude.com/claude-code)