### PR TITLE
fix: flag transaction commands as noscript (#122)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -302,6 +302,10 @@ Parsing and key extraction (and therefore early `CROSSSLOT`/`MOVED` errors in
 cluster mode) happen at queue time, not at `EXEC` time. `EXECABORT` is
 returned if the queue is dirty (e.g. an unknown command was queued).
 
+All five transaction-control commands are flagged `noscript` (rejected from
+Lua with the standard script error), matching real Redis — a script cannot
+flip its session into transaction mode or register a `WATCH`.
+
 ## 12. Scripting Commands
 
 - [x] `EVAL script numkeys [key ...] [arg ...]` - Execute a Lua script

--- a/src/commands/transactions.ts
+++ b/src/commands/transactions.ts
@@ -13,7 +13,7 @@ import { ok } from './helpers'
 export const multiCommand = defineCommand({
   name: 'multi',
   schema: t.object({}),
-  flags: ['readonly', 'fast', 'transaction'],
+  flags: ['readonly', 'fast', 'transaction', 'noscript'],
   keys: () => [],
   execute: (_args, ctx) => {
     ctx.session.beginTransaction()
@@ -27,7 +27,7 @@ export const execCommand = defineCommand({
   // EXEC inherits flags from queued commands at runtime. The flag list here
   // only marks it as transaction-control so policies do not treat it as a
   // normal write/read command.
-  flags: ['transaction'],
+  flags: ['transaction', 'noscript'],
   keys: () => [],
   execute: async (_args, ctx) => {
     if (ctx.session.mode !== 'transaction') {
@@ -55,7 +55,7 @@ export const execCommand = defineCommand({
 export const discardCommand = defineCommand({
   name: 'discard',
   schema: t.object({}),
-  flags: ['readonly', 'fast', 'transaction'],
+  flags: ['readonly', 'fast', 'transaction', 'noscript'],
   keys: () => [],
   execute: (_args, ctx) => {
     if (ctx.session.mode !== 'transaction') {
@@ -72,7 +72,7 @@ export const watchCommand = defineCommand({
   schema: t.object({
     keys: t.variadic(t.key(), { min: 1 }),
   }),
-  flags: ['readonly', 'fast', 'transaction'],
+  flags: ['readonly', 'fast', 'transaction', 'noscript'],
   keys: args => args.keys,
   execute: (args, ctx) => {
     if (ctx.session.mode === 'transaction') {
@@ -87,7 +87,7 @@ export const watchCommand = defineCommand({
 export const unwatchCommand = defineCommand({
   name: 'unwatch',
   schema: t.object({}),
-  flags: ['readonly', 'fast'],
+  flags: ['readonly', 'fast', 'noscript'],
   keys: () => [],
   execute: (_args, ctx) => {
     ctx.session.unwatch()

--- a/tests-integration/ioredis/scripts.test.ts
+++ b/tests-integration/ioredis/scripts.test.ts
@@ -191,6 +191,57 @@ describe(`Redis scripts (ioredis) ${testRunner.getBackendName()}`, () => {
         directClient.disconnect()
       }
     })
+
+    test('transaction control commands are rejected from scripts (noscript)', async () => {
+      const tag = `{noscript:${randomKey()}}`
+      const directClient = await connectToSlotOwner(redisClient!, tag)
+      const cases: Array<{ script: string; keys: string[] }> = [
+        { script: "return redis.call('multi')", keys: [] },
+        { script: "return redis.call('exec')", keys: [] },
+        { script: "return redis.call('discard')", keys: [] },
+        { script: "return redis.call('unwatch')", keys: [] },
+        { script: "return redis.call('watch', KEYS[1])", keys: [tag] },
+      ]
+
+      try {
+        for (const { script, keys } of cases) {
+          const sha = createHash('sha1').update(script).digest('hex')
+          await assert.rejects(
+            () => directClient.eval(script, keys.length, ...keys),
+            errorWithMessage(
+              `ERR This Redis command is not allowed from script script: ${sha}, on @user_script:1.`,
+            ),
+          )
+        }
+      } finally {
+        directClient.disconnect()
+      }
+    })
+
+    test('a rejected multi from a script leaves no session-state side effects', async () => {
+      const tag = `{noscript:${randomKey()}}`
+      const directClient = await connectToSlotOwner(redisClient!, tag)
+      const script = "return redis.call('multi')"
+
+      try {
+        await assert.rejects(() => directClient.eval(script, 0))
+
+        // The session must NOT be stuck in transaction mode: a normal command
+        // executes immediately ("OK"), it is not queued ("QUEUED").
+        assert.strictEqual(await directClient.set(tag, 'v'), 'OK')
+        assert.strictEqual(await directClient.get(tag), 'v')
+
+        // A real transaction still works on the same connection.
+        const txn = await directClient.multi().set(tag, 'v2').get(tag).exec()
+        assert.deepStrictEqual(txn, [
+          [null, 'OK'],
+          [null, 'v2'],
+        ])
+      } finally {
+        await directClient.del(tag)
+        directClient.disconnect()
+      }
+    })
   })
 
   test('SCRIPT LOAD, EXISTS, EVALSHA, and FLUSH use the node script cache', async () => {


### PR DESCRIPTION
## Summary
- `MULTI`/`EXEC`/`DISCARD`/`WATCH`/`UNWATCH` lacked the `'noscript'` flag, so the Lua sync path (`runRedisCommand` in [src/core/lua-runtime.ts](src/core/lua-runtime.ts)) never blocked them.
- `redis.call('multi')` flipped `ClientSession.mode` to `'transaction'` — every later `redis.call` in the script got queued (`+QUEUED`), and the session was left **permanently stuck** in transaction mode with a populated queue after the script returned. `redis.call('watch', ...)` registered a never-cleaned-up keyspace WATCH subscription.
- Real Redis rejects all five with `This Redis command is not allowed from script`. Fix adds `'noscript'` to their `flags` so the runtime rejects them with no session-state side effects.

Closes #122

## Test plan
- [x] New test in tests-integration/ioredis/scripts.test.ts reproduces the bug (red on mock before fix)
- [x] Tests pass against real Redis (mock-only bug confirmed)
- [x] Fix makes the tests pass on mock too
- [x] `npm run test:all` passes (unit 126, mock 260, real 260)

🤖 Generated with [Claude Code](https://claude.com/claude-code)