### PR TITLE
Add Redis Pub/Sub support

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -301,7 +301,8 @@ flowchart LR
 is server-wide rather than per-DB: the cluster topology, the Lua
 [`RedisScriptCache`](../src/state/script-cache.ts) (so `FLUSHALL`/`FLUSHDB`
 clear keyspace data but **not** cached scripts — only `SCRIPT FLUSH` does),
-and the (currently stubbed) [`RedisPubSubBroker`](../src/state/pubsub-broker.ts).
+and the [`RedisPubSubBroker`](../src/state/pubsub-broker.ts) used by client
+Pub/Sub commands for channel and pattern fan-out within that server state.
 
 Each database wraps a [`RedisKeyspace`](../src/state/keyspace.ts#L34): a
 `Map<keyId, KeyspaceEntry>` holding byte-safe `Buffer` keys and typed

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -341,12 +341,18 @@ flags are enforced inside `redis.call`/`redis.pcall`.
 
 ## 14. Pub/Sub Commands
 
-- [ ] `PUBLISH channel message`
-- [ ] `SUBSCRIBE` / `UNSUBSCRIBE` / `PSUBSCRIBE` / `PUNSUBSCRIBE` / `SSUBSCRIBE` / `SUNSUBSCRIBE` / `SPUBLISH`
-- [ ] `PUBSUB CHANNELS|NUMSUB|NUMPAT`
+- [x] `PUBLISH channel message`
+- [x] `SUBSCRIBE` / `UNSUBSCRIBE`
+- [x] `PSUBSCRIBE` / `PUNSUBSCRIBE`
+- [x] `PUBSUB CHANNELS|NUMSUB|NUMPAT`
+- [x] `PUBSUB SHARDCHANNELS|SHARDNUMSUB` - Present for Redis 7 command compatibility; returns empty shard pub/sub state because sharded Pub/Sub subscriptions are not implemented yet.
 
-> The mutation-event bus used internally for `WATCH` is unrelated to client
-> pub/sub; no pub/sub command module exists yet.
+- [ ] `SSUBSCRIBE` / `SUNSUBSCRIBE` / `SPUBLISH`
+
+Subscribed connections enforce Redis' restricted command mode: only subscribe,
+unsubscribe, `PING`, `RESET`, and `QUIT` are accepted until all subscriptions
+are removed. Pub/Sub state is process-local to the `RedisServerState` instance;
+cluster-wide fan-out between separate mock cluster nodes is not implemented.
 
 ## 15. Persistence Commands
 

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -324,10 +324,7 @@ export const pingCommand = defineCommand({
   flags: ['readonly', 'fast', 'subscribed'],
   keys: () => [],
   execute: (args, ctx) => {
-    if (
-      ctx.session.mode === 'subscribed' &&
-      ctx.session.protocolVersion === 2
-    ) {
+    if (ctx.session.usesSubscribedReplyMode) {
       return RedisResult.create(
         RedisValue.push('pong', [
           RedisValue.bulkString(Buffer.from(args.message ?? '')),

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -201,9 +201,9 @@ function formatClientLine(
     `db=${ctx.session.selectedDatabase}`,
     'age=0',
     'idle=0',
-    'flags=N',
-    'sub=0',
-    'psub=0',
+    `flags=${session.mode === 'subscribed' ? 'P' : 'N'}`,
+    `sub=${session.pubsubChannelCount}`,
+    `psub=${session.pubsubPatternCount}`,
     'multi=-1',
     'qbuf=0',
     'qbuf-free=0',
@@ -321,9 +321,17 @@ export const pingCommand = defineCommand({
   schema: t.object({
     message: t.optional(t.bulk()),
   }),
-  flags: ['readonly', 'fast'],
+  flags: ['readonly', 'fast', 'subscribed'],
   keys: () => [],
-  execute: args => {
+  execute: (args, ctx) => {
+    if (ctx.session.mode === 'subscribed') {
+      return RedisResult.create(
+        RedisValue.push('pong', [
+          RedisValue.bulkString(Buffer.from(args.message ?? '')),
+        ]),
+      )
+    }
+
     if (args.message) {
       return bulk(args.message)
     }
@@ -335,7 +343,7 @@ export const pingCommand = defineCommand({
 export const quitCommand = defineCommand({
   name: 'quit',
   schema: t.object({}),
-  flags: ['readonly', 'fast'],
+  flags: ['readonly', 'fast', 'subscribed'],
   keys: () => [],
   execute: () =>
     RedisResult.create(RedisValue.simpleString('OK'), { close: true }),
@@ -530,12 +538,13 @@ export const authCommand = defineCommand({
 export const resetCommand = defineCommand({
   name: 'reset',
   schema: t.object({}),
-  flags: ['admin'],
+  flags: ['admin', 'subscribed'],
   keys: () => [],
   execute: (_args, ctx) => {
     clientNames.delete(ctx.session)
     clientLibraryNames.delete(ctx.session)
     clientLibraryVersions.delete(ctx.session)
+    ctx.session.resetPubSub()
     ctx.session.discardTransaction()
     ctx.session.unwatch()
     ctx.session.selectDatabase(0)

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -324,7 +324,10 @@ export const pingCommand = defineCommand({
   flags: ['readonly', 'fast', 'subscribed'],
   keys: () => [],
   execute: (args, ctx) => {
-    if (ctx.session.mode === 'subscribed') {
+    if (
+      ctx.session.mode === 'subscribed' &&
+      ctx.session.protocolVersion === 2
+    ) {
       return RedisResult.create(
         RedisValue.push('pong', [
           RedisValue.bulkString(Buffer.from(args.message ?? '')),

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,6 +4,7 @@ import { CommandRegistry } from '../core/command-registry'
 import type { ExecutionPolicy } from '../core/execution-policies'
 import {
   createAuthPolicy,
+  createSubscribedModePolicy,
   createTransactionPolicy,
 } from '../core/execution-policies'
 import { commandCommand } from './command'
@@ -12,6 +13,7 @@ import { connectionCommands } from './connection'
 import { hashesCommands } from './hashes'
 import { keysCommands } from './keys'
 import { listsCommands } from './lists'
+import { pubsubCommands } from './pubsub'
 import { scanCommands } from './scan'
 import { scriptsCommands } from './scripts'
 import { setsCommands } from './sets'
@@ -32,6 +34,7 @@ export const redisCommandDefinitions: readonly CommandDefinition[] = [
   ...listsCommands,
   ...setsCommands,
   ...zsetsCommands,
+  ...pubsubCommands,
   ...streamsCommands,
   ...scriptsCommands,
 ]
@@ -53,6 +56,7 @@ export function createRedisCommandExecutor(options?: {
     registry: createRedisCommandRegistry(options?.extraCommands),
     policies: [
       createAuthPolicy(),
+      createSubscribedModePolicy(),
       ...(options?.policies ?? []),
       createTransactionPolicy(),
     ],
@@ -153,6 +157,15 @@ export {
   rpushCommand,
   rpushxCommand,
 } from './lists'
+export {
+  publishCommand,
+  psubscribeCommand,
+  pubsubCommand,
+  pubsubCommands,
+  punsubscribeCommand,
+  subscribeCommand,
+  unsubscribeCommand,
+} from './pubsub'
 export {
   hashesCommands,
   hexistsCommand,

--- a/src/commands/pubsub.ts
+++ b/src/commands/pubsub.ts
@@ -1,0 +1,285 @@
+import { defineCommand } from '../core/command-definition'
+import { t } from '../core/command-schema'
+import {
+  RedisCommandError,
+  WrongNumberOfArgumentsError,
+} from '../core/redis-error'
+import { RedisResult } from '../core/redis-result'
+import { RedisValue } from '../core/redis-value'
+import type { RedisExecutionContext } from '../core/redis-context'
+import type { ResponseStream } from '../core/response-stream'
+import { array, integer } from './helpers'
+import { commandSubcommandInfo } from './introspection'
+
+type PubSubArgs = {
+  subcommand: string
+  args: Buffer[]
+}
+
+export const subscribeCommand = defineCommand({
+  name: 'subscribe',
+  schema: t.object({
+    channels: t.variadic(t.bulk(), { min: 1 }),
+  }),
+  flags: ['pubsub', 'noscript', 'subscribed'],
+  introspection: {
+    arity: -2,
+    flags: ['pubsub', 'noscript', 'loading', 'stale'],
+    firstKey: 0,
+    lastKey: 0,
+    keyStep: 0,
+    categories: ['@pubsub', '@slow'],
+  },
+  keys: () => [],
+  execute: (args, ctx) =>
+    framesResult(ctx.session.subscribePubSubChannels(args.channels)),
+})
+
+export const unsubscribeCommand = defineCommand({
+  name: 'unsubscribe',
+  schema: t.object({
+    channels: t.variadic(t.bulk()),
+  }),
+  flags: ['pubsub', 'noscript', 'subscribed'],
+  introspection: {
+    arity: -1,
+    flags: ['pubsub', 'noscript', 'loading', 'stale'],
+    firstKey: 0,
+    lastKey: 0,
+    keyStep: 0,
+    categories: ['@pubsub', '@slow'],
+  },
+  keys: () => [],
+  execute: (args, ctx) =>
+    framesResult(ctx.session.unsubscribePubSubChannels(args.channels)),
+})
+
+export const psubscribeCommand = defineCommand({
+  name: 'psubscribe',
+  schema: t.object({
+    patterns: t.variadic(t.bulk(), { min: 1 }),
+  }),
+  flags: ['pubsub', 'noscript', 'subscribed'],
+  introspection: {
+    arity: -2,
+    flags: ['pubsub', 'noscript', 'loading', 'stale'],
+    firstKey: 0,
+    lastKey: 0,
+    keyStep: 0,
+    categories: ['@pubsub', '@slow'],
+  },
+  keys: () => [],
+  execute: (args, ctx) =>
+    framesResult(ctx.session.subscribePubSubPatterns(args.patterns)),
+})
+
+export const punsubscribeCommand = defineCommand({
+  name: 'punsubscribe',
+  schema: t.object({
+    patterns: t.variadic(t.bulk()),
+  }),
+  flags: ['pubsub', 'noscript', 'subscribed'],
+  introspection: {
+    arity: -1,
+    flags: ['pubsub', 'noscript', 'loading', 'stale'],
+    firstKey: 0,
+    lastKey: 0,
+    keyStep: 0,
+    categories: ['@pubsub', '@slow'],
+  },
+  keys: () => [],
+  execute: (args, ctx) =>
+    framesResult(ctx.session.unsubscribePubSubPatterns(args.patterns)),
+})
+
+export const publishCommand = defineCommand({
+  name: 'publish',
+  schema: t.object({
+    channel: t.bulk(),
+    message: t.bulk(),
+  }),
+  flags: ['pubsub', 'fast'],
+  introspection: {
+    arity: 3,
+    flags: ['pubsub', 'loading', 'stale', 'fast'],
+    firstKey: 0,
+    lastKey: 0,
+    keyStep: 0,
+    categories: ['@pubsub', '@fast'],
+  },
+  keys: () => [],
+  execute: (args, ctx) =>
+    integer(ctx.server.pubsubBroker.publish(args.channel, args.message)),
+})
+
+export const pubsubCommand = defineCommand({
+  name: 'pubsub',
+  schema: t.object({
+    subcommand: t.string(),
+    args: t.variadic(t.bulk()),
+  }),
+  flags: ['readonly', 'pubsub', 'fast'],
+  introspection: {
+    arity: -2,
+    flags: ['pubsub', 'loading', 'stale', 'fast'],
+    firstKey: 0,
+    lastKey: 0,
+    keyStep: 0,
+    categories: ['@pubsub', '@slow'],
+    subcommands: [
+      commandSubcommandInfo('pubsub|channels', -2, {
+        categories: ['@pubsub', '@slow'],
+      }),
+      commandSubcommandInfo('pubsub|numsub', -2, {
+        categories: ['@pubsub', '@slow'],
+      }),
+      commandSubcommandInfo('pubsub|numpat', 2, {
+        categories: ['@pubsub', '@slow'],
+      }),
+      commandSubcommandInfo('pubsub|shardchannels', -2, {
+        categories: ['@pubsub', '@slow'],
+      }),
+      commandSubcommandInfo('pubsub|shardnumsub', -2, {
+        categories: ['@pubsub', '@slow'],
+      }),
+      commandSubcommandInfo('pubsub|help', 2, {
+        categories: ['@pubsub', '@slow'],
+      }),
+    ],
+  },
+  keys: () => [],
+  execute: (args, ctx) => {
+    const subcommand = args.subcommand.toLowerCase()
+
+    if (subcommand === 'channels') {
+      return pubsubChannels(args, ctx)
+    }
+
+    if (subcommand === 'numsub') {
+      return pubsubNumsub(args, ctx)
+    }
+
+    if (subcommand === 'numpat') {
+      expectArgCount('pubsub|numpat', args.args, 0)
+      return integer(ctx.server.pubsubBroker.patternSubscriptionCount())
+    }
+
+    if (subcommand === 'shardchannels') {
+      expectPubSubSubcommandMaxArgCount(args.subcommand, args.args, 1)
+      return array([])
+    }
+
+    if (subcommand === 'shardnumsub') {
+      return RedisResult.create(
+        RedisValue.array(
+          args.args.flatMap(channel => [
+            RedisValue.bulkString(Buffer.from(channel)),
+            RedisValue.integer(0),
+          ]),
+        ),
+      )
+    }
+
+    if (subcommand === 'help') {
+      expectArgCount('pubsub|help', args.args, 0)
+      return pubsubHelp()
+    }
+
+    throw new RedisCommandError(
+      `unknown subcommand '${args.subcommand}'. Try PUBSUB HELP.`,
+    )
+  },
+})
+
+export const pubsubCommands = [
+  subscribeCommand,
+  unsubscribeCommand,
+  psubscribeCommand,
+  punsubscribeCommand,
+  publishCommand,
+  pubsubCommand,
+]
+
+function pubsubChannels(args: PubSubArgs, ctx: RedisExecutionContext) {
+  expectPubSubSubcommandMaxArgCount(args.subcommand, args.args, 1)
+  const channels = ctx.server.pubsubBroker.channelsMatching(args.args[0])
+  return RedisResult.create(
+    RedisValue.array(channels.map(channel => RedisValue.bulkString(channel))),
+  )
+}
+
+function pubsubNumsub(args: PubSubArgs, ctx: RedisExecutionContext) {
+  return RedisResult.create(
+    RedisValue.array(
+      args.args.flatMap(channel => [
+        RedisValue.bulkString(Buffer.from(channel)),
+        RedisValue.integer(ctx.server.pubsubBroker.subscriberCount(channel)),
+      ]),
+    ),
+  )
+}
+
+function pubsubHelp(): RedisResult {
+  return RedisResult.create(
+    RedisValue.array(
+      [
+        'PUBSUB <subcommand> [<arg> [value] [opt] ...]. Subcommands are:',
+        'CHANNELS [<pattern>]',
+        '    Return the currently active channels matching a pattern.',
+        'NUMSUB [<channel> ...]',
+        '    Return the number of subscribers for the specified channels.',
+        'NUMPAT',
+        '    Return the number of pattern subscriptions.',
+        'SHARDCHANNELS [<pattern>]',
+        '    Return active shard channels matching a pattern.',
+        'SHARDNUMSUB [<channel> ...]',
+        '    Return the number of shard subscribers for the specified channels.',
+        'HELP',
+        '    Prints this help.',
+      ].map(line => RedisValue.bulkString(Buffer.from(line))),
+    ),
+  )
+}
+
+function framesResult(frames: RedisResult[]): RedisResult | ResponseStream {
+  if (frames.length === 1) {
+    return frames[0]
+  }
+
+  return {
+    kind: 'response-stream',
+    closed: Promise.resolve(),
+    frames: async function* () {
+      for (const frame of frames) {
+        yield frame
+      }
+    },
+    close: () => {},
+  }
+}
+
+function expectArgCount(
+  commandName: string,
+  args: readonly Buffer[],
+  count: number,
+): void {
+  if (args.length !== count) {
+    throw new WrongNumberOfArgumentsError(commandName)
+  }
+}
+
+function expectPubSubSubcommandMaxArgCount(
+  subcommand: string,
+  args: readonly Buffer[],
+  count: number,
+): void {
+  if (args.length > count) {
+    throw pubsubSubcommandError(subcommand)
+  }
+}
+
+function pubsubSubcommandError(subcommand: string): RedisCommandError {
+  return new RedisCommandError(
+    `unknown subcommand or wrong number of arguments for '${subcommand}'. Try PUBSUB HELP.`,
+  )
+}

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -5,6 +5,7 @@ import {
   RedisCommandError,
   RedisSyntaxError,
 } from '../core/redis-error'
+import { redisGlobMatch } from '../core/glob'
 import { RedisResult } from '../core/redis-result'
 import { RedisValue } from '../core/redis-value'
 import type { RedisDataTypeName } from '../state'
@@ -272,7 +273,7 @@ function matchesPattern(value: Buffer, pattern?: Buffer): boolean {
     return true
   }
 
-  return redisGlobMatch(pattern, 0, value, 0)
+  return redisGlobMatch(pattern, value)
 }
 
 function scanResult(
@@ -321,152 +322,4 @@ function normalizeScanCursor(cursor: bigint, itemCount: number): number {
   return Math.min(Number(cursor), itemCount)
 }
 
-function redisGlobMatch(
-  pattern: Buffer,
-  patternIndex: number,
-  value: Buffer,
-  valueIndex: number,
-): boolean {
-  let patternCursor = patternIndex
-  let valueCursor = valueIndex
-
-  while (patternCursor < pattern.length && valueCursor < value.length) {
-    const token = pattern[patternCursor]
-
-    if (token === STAR) {
-      while (pattern[patternCursor + 1] === STAR) {
-        patternCursor++
-      }
-
-      if (patternCursor + 1 === pattern.length) {
-        return true
-      }
-
-      for (
-        let nextValueCursor = valueCursor;
-        nextValueCursor < value.length;
-        nextValueCursor++
-      ) {
-        if (
-          redisGlobMatch(pattern, patternCursor + 1, value, nextValueCursor)
-        ) {
-          return true
-        }
-      }
-
-      return false
-    }
-
-    if (token === QUESTION_MARK) {
-      patternCursor++
-      valueCursor++
-      continue
-    }
-
-    if (token === OPEN_BRACKET) {
-      const characterClass = matchCharacterClass(
-        pattern,
-        patternCursor,
-        value[valueCursor],
-      )
-
-      if (!characterClass.matches) {
-        return false
-      }
-
-      patternCursor = characterClass.nextPatternIndex
-      valueCursor++
-      continue
-    }
-
-    if (token === BACKSLASH && patternCursor + 1 < pattern.length) {
-      patternCursor++
-    }
-
-    if (pattern[patternCursor] !== value[valueCursor]) {
-      return false
-    }
-
-    patternCursor++
-    valueCursor++
-  }
-
-  while (pattern[patternCursor] === STAR) {
-    patternCursor++
-  }
-
-  return patternCursor === pattern.length && valueCursor === value.length
-}
-
-function matchCharacterClass(
-  pattern: Buffer,
-  openBracketIndex: number,
-  value: number,
-): { matches: boolean; nextPatternIndex: number } {
-  let patternCursor = openBracketIndex + 1
-  let negated = false
-
-  if (pattern[patternCursor] === CARET) {
-    negated = true
-    patternCursor++
-  }
-
-  let matches = false
-
-  while (true) {
-    if (pattern[patternCursor] === CLOSE_BRACKET) {
-      break
-    }
-
-    if (patternCursor >= pattern.length) {
-      patternCursor--
-      break
-    }
-
-    if (
-      pattern[patternCursor] === BACKSLASH &&
-      patternCursor + 1 < pattern.length
-    ) {
-      patternCursor++
-      if (pattern[patternCursor] === value) {
-        matches = true
-      }
-    } else if (
-      patternCursor + 2 < pattern.length &&
-      pattern[patternCursor + 1] === DASH
-    ) {
-      let start = pattern[patternCursor]
-      let end = pattern[patternCursor + 2]
-
-      if (start > end) {
-        const previousStart = start
-        start = end
-        end = previousStart
-      }
-
-      if (value >= start && value <= end) {
-        matches = true
-      }
-
-      patternCursor += 2
-    } else if (pattern[patternCursor] === value) {
-      matches = true
-    }
-
-    patternCursor++
-  }
-
-  return {
-    matches: negated ? !matches : matches,
-    nextPatternIndex: patternCursor + 1,
-  }
-}
-
-const BACKSLASH = '\\'.charCodeAt(0)
-const CARET = '^'.charCodeAt(0)
-const CLOSE_BRACKET = ']'.charCodeAt(0)
 const DEFAULT_SCAN_COUNT = 10
-const DASH = '-'.charCodeAt(0)
-const OPEN_BRACKET = '['.charCodeAt(0)
-const QUESTION_MARK = '?'.charCodeAt(0)
-const STAR = '*'.charCodeAt(0)

--- a/src/core/client-session.ts
+++ b/src/core/client-session.ts
@@ -47,6 +47,11 @@ type WatchRegistration = {
   unsubscribe: Unsubscribe
 }
 
+type PubSubRegistration = {
+  value: Buffer
+  unsubscribe: Unsubscribe
+}
+
 /**
  * Per-connection server state and the concrete {@link RedisClientSession}.
  *
@@ -97,6 +102,11 @@ export class ClientSession implements RedisClientSession {
   private readonly watches = new Map<string, WatchRegistration>()
   /** Subset of watched keys mutated since WATCH — non-empty fails the next EXEC. */
   private readonly dirtyWatches = new Set<string>()
+  private readonly pubsubChannels = new Map<string, PubSubRegistration>()
+  private readonly pubsubPatterns = new Map<string, PubSubRegistration>()
+  private readonly pushQueue: RedisResult[] = []
+  private readonly pushWaiters = new Set<() => void>()
+  private pushQueueClosed = false
 
   constructor(options: ClientSessionOptions) {
     this.id = options.id ?? `client-${++ClientSession.nextId}`
@@ -135,6 +145,18 @@ export class ClientSession implements RedisClientSession {
 
   get isAuthenticated(): boolean {
     return this.authenticated
+  }
+
+  get pubsubChannelCount(): number {
+    return this.pubsubChannels.size
+  }
+
+  get pubsubPatternCount(): number {
+    return this.pubsubPatterns.size
+  }
+
+  get pubsubSubscriptionCount(): number {
+    return this.pubsubChannelCount + this.pubsubPatternCount
   }
 
   setAuthenticated(value: boolean): void {
@@ -355,6 +377,199 @@ export class ClientSession implements RedisClientSession {
     return this.dirtyWatches.size > 0
   }
 
+  subscribePubSubChannels(channels: readonly Buffer[]): RedisResult[] {
+    const frames: RedisResult[] = []
+
+    for (const channel of channels) {
+      const key = pubsubId(channel)
+      if (!this.pubsubChannels.has(key)) {
+        const subscribedChannel = Buffer.from(channel)
+        const unsubscribe = this.server.pubsubBroker.subscribe(
+          subscribedChannel,
+          message => {
+            this.enqueuePush(
+              pubsubFrame('message', [
+                RedisValue.bulkString(Buffer.from(message.channel)),
+                RedisValue.bulkString(Buffer.from(message.message)),
+              ]),
+            )
+          },
+        )
+
+        this.pubsubChannels.set(key, {
+          value: subscribedChannel,
+          unsubscribe,
+        })
+      }
+
+      this.refreshPubSubMode()
+      frames.push(
+        pubsubFrame('subscribe', [
+          RedisValue.bulkString(Buffer.from(channel)),
+          RedisValue.integer(this.pubsubSubscriptionCount),
+        ]),
+      )
+    }
+
+    return frames
+  }
+
+  unsubscribePubSubChannels(channels: readonly Buffer[]): RedisResult[] {
+    const targets =
+      channels.length > 0
+        ? channels
+        : Array.from(
+            this.pubsubChannels.values(),
+            entry => entry.value,
+          ).reverse()
+
+    if (targets.length === 0) {
+      this.refreshPubSubMode()
+      return [
+        pubsubFrame('unsubscribe', [
+          RedisValue.bulkString(null),
+          RedisValue.integer(this.pubsubSubscriptionCount),
+        ]),
+      ]
+    }
+
+    const frames: RedisResult[] = []
+    for (const channel of targets) {
+      const key = pubsubId(channel)
+      const existing = this.pubsubChannels.get(key)
+      if (existing) {
+        existing.unsubscribe()
+        this.pubsubChannels.delete(key)
+      }
+
+      this.refreshPubSubMode()
+      frames.push(
+        pubsubFrame('unsubscribe', [
+          RedisValue.bulkString(Buffer.from(channel)),
+          RedisValue.integer(this.pubsubSubscriptionCount),
+        ]),
+      )
+    }
+
+    return frames
+  }
+
+  subscribePubSubPatterns(patterns: readonly Buffer[]): RedisResult[] {
+    const frames: RedisResult[] = []
+
+    for (const pattern of patterns) {
+      const key = pubsubId(pattern)
+      if (!this.pubsubPatterns.has(key)) {
+        const subscribedPattern = Buffer.from(pattern)
+        const unsubscribe = this.server.pubsubBroker.psubscribe(
+          subscribedPattern,
+          message => {
+            this.enqueuePush(
+              pubsubFrame('pmessage', [
+                RedisValue.bulkString(Buffer.from(message.pattern)),
+                RedisValue.bulkString(Buffer.from(message.channel)),
+                RedisValue.bulkString(Buffer.from(message.message)),
+              ]),
+            )
+          },
+        )
+
+        this.pubsubPatterns.set(key, {
+          value: subscribedPattern,
+          unsubscribe,
+        })
+      }
+
+      this.refreshPubSubMode()
+      frames.push(
+        pubsubFrame('psubscribe', [
+          RedisValue.bulkString(Buffer.from(pattern)),
+          RedisValue.integer(this.pubsubSubscriptionCount),
+        ]),
+      )
+    }
+
+    return frames
+  }
+
+  unsubscribePubSubPatterns(patterns: readonly Buffer[]): RedisResult[] {
+    const targets =
+      patterns.length > 0
+        ? patterns
+        : Array.from(
+            this.pubsubPatterns.values(),
+            entry => entry.value,
+          ).reverse()
+
+    if (targets.length === 0) {
+      this.refreshPubSubMode()
+      return [
+        pubsubFrame('punsubscribe', [
+          RedisValue.bulkString(null),
+          RedisValue.integer(this.pubsubSubscriptionCount),
+        ]),
+      ]
+    }
+
+    const frames: RedisResult[] = []
+    for (const pattern of targets) {
+      const key = pubsubId(pattern)
+      const existing = this.pubsubPatterns.get(key)
+      if (existing) {
+        existing.unsubscribe()
+        this.pubsubPatterns.delete(key)
+      }
+
+      this.refreshPubSubMode()
+      frames.push(
+        pubsubFrame('punsubscribe', [
+          RedisValue.bulkString(Buffer.from(pattern)),
+          RedisValue.integer(this.pubsubSubscriptionCount),
+        ]),
+      )
+    }
+
+    return frames
+  }
+
+  resetPubSub(): void {
+    for (const subscription of this.pubsubChannels.values()) {
+      subscription.unsubscribe()
+    }
+    for (const subscription of this.pubsubPatterns.values()) {
+      subscription.unsubscribe()
+    }
+
+    this.pubsubChannels.clear()
+    this.pubsubPatterns.clear()
+    this.refreshPubSubMode()
+  }
+
+  enqueuePush(result: RedisResult): void {
+    if (this.pushQueueClosed || this.signal.aborted) {
+      return
+    }
+
+    this.pushQueue.push(result)
+    this.wakePushWaiters()
+  }
+
+  async *readPushes(signal: AbortSignal): AsyncIterable<RedisResult> {
+    while (!signal.aborted && !this.signal.aborted) {
+      const frame = this.pushQueue.shift()
+      if (frame) {
+        yield frame
+        continue
+      }
+
+      if (this.pushQueueClosed) {
+        return
+      }
+
+      await this.waitForPush(signal)
+    }
+  }
+
   /**
    * Public entry point for executing one client command.
    *
@@ -428,6 +643,8 @@ export class ClientSession implements RedisClientSession {
   close(): void {
     this.signalSource?.abort()
     this.unwatch()
+    this.resetPubSub()
+    this.closePushQueue()
     this.transactionPlans = []
     this.transactionDirty = false
     this.sessionMode = 'normal'
@@ -467,10 +684,63 @@ export class ClientSession implements RedisClientSession {
       return parkedValue
     }
   }
+
+  private refreshPubSubMode(): void {
+    if (this.pubsubSubscriptionCount > 0) {
+      this.sessionMode = 'subscribed'
+      return
+    }
+
+    if (this.sessionMode === 'subscribed') {
+      this.sessionMode = 'normal'
+    }
+  }
+
+  private waitForPush(signal: AbortSignal): Promise<void> {
+    if (signal.aborted || this.signal.aborted || this.pushQueueClosed) {
+      return Promise.resolve()
+    }
+
+    return new Promise(resolve => {
+      const cleanup = () => {
+        this.pushWaiters.delete(waiter)
+        signal.removeEventListener('abort', waiter)
+        this.signal.removeEventListener('abort', waiter)
+      }
+      const waiter = () => {
+        cleanup()
+        resolve()
+      }
+
+      this.pushWaiters.add(waiter)
+      signal.addEventListener('abort', waiter, { once: true })
+      this.signal.addEventListener('abort', waiter, { once: true })
+    })
+  }
+
+  private closePushQueue(): void {
+    this.pushQueueClosed = true
+    this.pushQueue.length = 0
+    this.wakePushWaiters()
+  }
+
+  private wakePushWaiters(): void {
+    for (const waiter of Array.from(this.pushWaiters)) {
+      waiter()
+    }
+  }
 }
 
 function watchId(database: number, key: Buffer): string {
   return `${database}:${key.toString('hex')}`
+}
+
+function pubsubId(value: Buffer): string {
+  return value.toString('hex')
+}
+
+function pubsubFrame(name: string, items: RedisValue[]): RedisResult {
+  return RedisResult.create(RedisValue.push(name, items))
 }
 
 function createAbortError(): Error {

--- a/src/core/client-session.ts
+++ b/src/core/client-session.ts
@@ -139,6 +139,10 @@ export class ClientSession implements RedisClientSession {
     return this.respVersion
   }
 
+  get usesSubscribedReplyMode(): boolean {
+    return this.sessionMode === 'subscribed' && this.respVersion === 2
+  }
+
   get clusterReadOnly(): boolean {
     return this.clusterReadOnlyMode
   }

--- a/src/core/execution-policies/index.ts
+++ b/src/core/execution-policies/index.ts
@@ -29,5 +29,6 @@ export interface ExecutionPolicy {
 
 export { createTransactionPolicy } from './transaction-policy'
 export { createAuthPolicy } from './auth-policy'
+export { createSubscribedModePolicy } from './subscribed-policy'
 export type { ClusterPolicyOptions } from './cluster-policy'
 export { createClusterPolicy } from './cluster-policy'

--- a/src/core/execution-policies/subscribed-policy.ts
+++ b/src/core/execution-policies/subscribed-policy.ts
@@ -5,7 +5,10 @@ export function createSubscribedModePolicy(): ExecutionPolicy {
   return {
     name: 'subscribed-mode',
     beforeExecute(plan, ctx) {
-      if (ctx.session.mode !== 'subscribed') {
+      if (
+        ctx.session.mode !== 'subscribed' ||
+        ctx.session.protocolVersion !== 2
+      ) {
         return
       }
 

--- a/src/core/execution-policies/subscribed-policy.ts
+++ b/src/core/execution-policies/subscribed-policy.ts
@@ -5,10 +5,7 @@ export function createSubscribedModePolicy(): ExecutionPolicy {
   return {
     name: 'subscribed-mode',
     beforeExecute(plan, ctx) {
-      if (
-        ctx.session.mode !== 'subscribed' ||
-        ctx.session.protocolVersion !== 2
-      ) {
+      if (!ctx.session.usesSubscribedReplyMode) {
         return
       }
 

--- a/src/core/execution-policies/subscribed-policy.ts
+++ b/src/core/execution-policies/subscribed-policy.ts
@@ -1,0 +1,22 @@
+import type { ExecutionPolicy } from './index'
+import { RedisResult } from '../redis-result'
+
+export function createSubscribedModePolicy(): ExecutionPolicy {
+  return {
+    name: 'subscribed-mode',
+    beforeExecute(plan, ctx) {
+      if (ctx.session.mode !== 'subscribed') {
+        return
+      }
+
+      if (plan.flags.includes('subscribed')) {
+        return
+      }
+
+      return RedisResult.error(
+        `Can't execute '${plan.definition.name}': only (P|S)SUBSCRIBE / (P|S)UNSUBSCRIBE / PING / QUIT / RESET are allowed in this context`,
+        'ERR',
+      )
+    },
+  }
+}

--- a/src/core/glob.ts
+++ b/src/core/glob.ts
@@ -1,0 +1,150 @@
+export function redisGlobMatch(pattern: Buffer, value: Buffer): boolean {
+  return matchGlob(pattern, 0, value, 0)
+}
+
+function matchGlob(
+  pattern: Buffer,
+  patternIndex: number,
+  value: Buffer,
+  valueIndex: number,
+): boolean {
+  let patternCursor = patternIndex
+  let valueCursor = valueIndex
+
+  while (patternCursor < pattern.length && valueCursor < value.length) {
+    const token = pattern[patternCursor]
+
+    if (token === STAR) {
+      while (pattern[patternCursor + 1] === STAR) {
+        patternCursor++
+      }
+
+      if (patternCursor + 1 === pattern.length) {
+        return true
+      }
+
+      for (
+        let nextValueCursor = valueCursor;
+        nextValueCursor < value.length;
+        nextValueCursor++
+      ) {
+        if (matchGlob(pattern, patternCursor + 1, value, nextValueCursor)) {
+          return true
+        }
+      }
+
+      return false
+    }
+
+    if (token === QUESTION_MARK) {
+      patternCursor++
+      valueCursor++
+      continue
+    }
+
+    if (token === OPEN_BRACKET) {
+      const characterClass = matchCharacterClass(
+        pattern,
+        patternCursor,
+        value[valueCursor],
+      )
+
+      if (!characterClass.matches) {
+        return false
+      }
+
+      patternCursor = characterClass.nextPatternIndex
+      valueCursor++
+      continue
+    }
+
+    if (token === BACKSLASH && patternCursor + 1 < pattern.length) {
+      patternCursor++
+    }
+
+    if (pattern[patternCursor] !== value[valueCursor]) {
+      return false
+    }
+
+    patternCursor++
+    valueCursor++
+  }
+
+  while (pattern[patternCursor] === STAR) {
+    patternCursor++
+  }
+
+  return patternCursor === pattern.length && valueCursor === value.length
+}
+
+function matchCharacterClass(
+  pattern: Buffer,
+  openBracketIndex: number,
+  value: number,
+): { matches: boolean; nextPatternIndex: number } {
+  let patternCursor = openBracketIndex + 1
+  let negated = false
+
+  if (pattern[patternCursor] === CARET) {
+    negated = true
+    patternCursor++
+  }
+
+  let matches = false
+
+  while (true) {
+    if (pattern[patternCursor] === CLOSE_BRACKET) {
+      break
+    }
+
+    if (patternCursor >= pattern.length) {
+      patternCursor--
+      break
+    }
+
+    if (
+      pattern[patternCursor] === BACKSLASH &&
+      patternCursor + 1 < pattern.length
+    ) {
+      patternCursor++
+      if (pattern[patternCursor] === value) {
+        matches = true
+      }
+    } else if (
+      patternCursor + 2 < pattern.length &&
+      pattern[patternCursor + 1] === DASH
+    ) {
+      let start = pattern[patternCursor]
+      let end = pattern[patternCursor + 2]
+
+      if (start > end) {
+        const previousStart = start
+        start = end
+        end = previousStart
+      }
+
+      if (value >= start && value <= end) {
+        matches = true
+      }
+
+      patternCursor += 2
+    } else if (pattern[patternCursor] === value) {
+      matches = true
+    }
+
+    patternCursor++
+  }
+
+  return {
+    matches: negated ? !matches : matches,
+    nextPatternIndex: patternCursor + 1,
+  }
+}
+
+const BACKSLASH = '\\'.charCodeAt(0)
+const CARET = '^'.charCodeAt(0)
+const CLOSE_BRACKET = ']'.charCodeAt(0)
+const DASH = '-'.charCodeAt(0)
+const OPEN_BRACKET = '['.charCodeAt(0)
+const QUESTION_MARK = '?'.charCodeAt(0)
+const STAR = '*'.charCodeAt(0)

--- a/src/core/redis-context.ts
+++ b/src/core/redis-context.ts
@@ -25,6 +25,7 @@ export interface RedisClientSession {
   readonly selectedDatabase: number
   readonly mode: ClientSessionMode
   readonly protocolVersion: RespVersion
+  readonly usesSubscribedReplyMode: boolean
   readonly clusterReadOnly: boolean
   readonly isAuthenticated: boolean
   setAuthenticated(value: boolean): void

--- a/src/core/redis-context.ts
+++ b/src/core/redis-context.ts
@@ -41,6 +41,14 @@ export interface RedisClientSession {
   watch(keys: readonly Buffer[]): void
   unwatch(): void
   isWatchDirty(): boolean
+  readonly pubsubChannelCount: number
+  readonly pubsubPatternCount: number
+  readonly pubsubSubscriptionCount: number
+  subscribePubSubChannels(channels: readonly Buffer[]): RedisResult[]
+  unsubscribePubSubChannels(channels: readonly Buffer[]): RedisResult[]
+  subscribePubSubPatterns(patterns: readonly Buffer[]): RedisResult[]
+  unsubscribePubSubPatterns(patterns: readonly Buffer[]): RedisResult[]
+  resetPubSub(): void
 }
 
 export interface RedisExecutionContext {

--- a/src/core/transports/resp2/session-adapter.ts
+++ b/src/core/transports/resp2/session-adapter.ts
@@ -26,6 +26,7 @@ export class Resp2SessionAdapter {
   private readonly session: ClientSession
   private readonly logger?: Pick<Logger, 'error'>
   private readonly encoder?: RespEncodeOptions
+  private writeChain: Promise<void> = Promise.resolve()
 
   constructor(options: Resp2SessionAdapterOptions) {
     this.transport = options.transport
@@ -35,6 +36,8 @@ export class Resp2SessionAdapter {
   }
 
   async run(): Promise<void> {
+    const pushWriter = this.writeSessionPushes()
+
     try {
       for await (const chunk of this.transport.read()) {
         const { frames, error } = this.decoder.push(chunk)
@@ -60,6 +63,7 @@ export class Resp2SessionAdapter {
       }
     } finally {
       this.session.close()
+      await pushWriter
     }
   }
 
@@ -84,15 +88,35 @@ export class Resp2SessionAdapter {
   }
 
   private async writeRedisResult(result: RedisResult): Promise<void> {
-    await this.transport.write(
-      encodeRedisResult(result, {
-        ...this.encoder,
-        version: this.session.protocolVersion,
-      }),
-    )
+    const write = async () => {
+      await this.transport.write(
+        encodeRedisResult(result, {
+          ...this.encoder,
+          version: this.session.protocolVersion,
+        }),
+      )
 
-    if (result.options?.close || result.options?.disconnect) {
-      this.transport.close('command requested close')
+      if (result.options?.close || result.options?.disconnect) {
+        this.transport.close('command requested close')
+      }
+    }
+
+    this.writeChain = this.writeChain.catch(() => {}).then(write)
+    await this.writeChain
+  }
+
+  private async writeSessionPushes(): Promise<void> {
+    try {
+      for await (const frame of this.session.readPushes(
+        this.transport.signal,
+      )) {
+        await this.writeRedisResult(frame)
+      }
+    } catch (err) {
+      if (!this.transport.signal.aborted) {
+        this.logger?.error(err)
+        this.transport.close('resp2 push writer error')
+      }
     }
   }
 

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -31,7 +31,13 @@ export { RedisKeyspace, WrongRedisTypeError } from './keyspace'
 
 export { RedisDatabase } from './database'
 export { RedisScriptCache } from './script-cache'
-export { RedisPubSubBroker } from './pubsub-broker'
+export {
+  RedisPubSubBroker,
+  type RedisPubSubMessage,
+  type RedisPubSubMessageListener,
+  type RedisPubSubPatternMessage,
+  type RedisPubSubPatternMessageListener,
+} from './pubsub-broker'
 export type { RedisClusterNode, RedisClusterNodeRole } from './cluster-topology'
 export {
   REDIS_CLUSTER_SLOT_COUNT,

--- a/src/state/pubsub-broker.ts
+++ b/src/state/pubsub-broker.ts
@@ -1,3 +1,4 @@
+import { redisGlobMatch } from '../core/glob'
 import type { Unsubscribe } from './mutation-events'
 
 export type RedisPubSubMessage = {
@@ -87,7 +88,7 @@ export class RedisPubSubBroker {
 
     for (const subscribers of Array.from(this.patterns.values())) {
       for (const subscriber of Array.from(subscribers.values())) {
-        if (!redisGlobMatch(subscriber.pattern, 0, channel, 0)) {
+        if (!redisGlobMatch(subscriber.pattern, channel)) {
           continue
         }
 
@@ -112,7 +113,7 @@ export class RedisPubSubBroker {
         continue
       }
 
-      if (pattern && !redisGlobMatch(pattern, 0, first.channel, 0)) {
+      if (pattern && !redisGlobMatch(pattern, first.channel)) {
         continue
       }
 
@@ -138,152 +139,3 @@ export class RedisPubSubBroker {
 function pubsubKey(value: Buffer): string {
   return value.toString('hex')
 }
-
-function redisGlobMatch(
-  pattern: Buffer,
-  patternIndex: number,
-  value: Buffer,
-  valueIndex: number,
-): boolean {
-  let patternCursor = patternIndex
-  let valueCursor = valueIndex
-
-  while (patternCursor < pattern.length && valueCursor < value.length) {
-    const token = pattern[patternCursor]
-
-    if (token === STAR) {
-      while (pattern[patternCursor + 1] === STAR) {
-        patternCursor++
-      }
-
-      if (patternCursor + 1 === pattern.length) {
-        return true
-      }
-
-      for (
-        let nextValueCursor = valueCursor;
-        nextValueCursor <= value.length;
-        nextValueCursor++
-      ) {
-        if (
-          redisGlobMatch(pattern, patternCursor + 1, value, nextValueCursor)
-        ) {
-          return true
-        }
-      }
-
-      return false
-    }
-
-    if (token === QUESTION_MARK) {
-      patternCursor++
-      valueCursor++
-      continue
-    }
-
-    if (token === OPEN_BRACKET) {
-      const characterClass = matchCharacterClass(
-        pattern,
-        patternCursor,
-        value[valueCursor],
-      )
-
-      if (!characterClass.matches) {
-        return false
-      }
-
-      patternCursor = characterClass.nextPatternIndex
-      valueCursor++
-      continue
-    }
-
-    if (token === BACKSLASH && patternCursor + 1 < pattern.length) {
-      patternCursor++
-    }
-
-    if (pattern[patternCursor] !== value[valueCursor]) {
-      return false
-    }
-
-    patternCursor++
-    valueCursor++
-  }
-
-  while (pattern[patternCursor] === STAR) {
-    patternCursor++
-  }
-
-  return patternCursor === pattern.length && valueCursor === value.length
-}
-
-function matchCharacterClass(
-  pattern: Buffer,
-  openBracketIndex: number,
-  value: number,
-): { matches: boolean; nextPatternIndex: number } {
-  let patternCursor = openBracketIndex + 1
-  let negated = false
-
-  if (pattern[patternCursor] === CARET) {
-    negated = true
-    patternCursor++
-  }
-
-  let matches = false
-
-  while (true) {
-    if (pattern[patternCursor] === CLOSE_BRACKET) {
-      break
-    }
-
-    if (patternCursor >= pattern.length) {
-      patternCursor--
-      break
-    }
-
-    if (
-      pattern[patternCursor] === BACKSLASH &&
-      patternCursor + 1 < pattern.length
-    ) {
-      patternCursor++
-      if (pattern[patternCursor] === value) {
-        matches = true
-      }
-    } else if (
-      patternCursor + 2 < pattern.length &&
-      pattern[patternCursor + 1] === DASH
-    ) {
-      let start = pattern[patternCursor]
-      let end = pattern[patternCursor + 2]
-
-      if (start > end) {
-        const previousStart = start
-        start = end
-        end = previousStart
-      }
-
-      if (value >= start && value <= end) {
-        matches = true
-      }
-
-      patternCursor += 2
-    } else if (pattern[patternCursor] === value) {
-      matches = true
-    }
-
-    patternCursor++
-  }
-
-  return {
-    matches: negated ? !matches : matches,
-    nextPatternIndex: patternCursor + 1,
-  }
-}
-
-const BACKSLASH = '\\'.charCodeAt(0)
-const CARET = '^'.charCodeAt(0)
-const CLOSE_BRACKET = ']'.charCodeAt(0)
-const DASH = '-'.charCodeAt(0)
-const OPEN_BRACKET = '['.charCodeAt(0)
-const QUESTION_MARK = '?'.charCodeAt(0)
-const STAR = '*'.charCodeAt(0)

--- a/src/state/pubsub-broker.ts
+++ b/src/state/pubsub-broker.ts
@@ -1,5 +1,289 @@
+import type { Unsubscribe } from './mutation-events'
+
+export type RedisPubSubMessage = {
+  channel: Buffer
+  message: Buffer
+}
+
+export type RedisPubSubPatternMessage = RedisPubSubMessage & {
+  pattern: Buffer
+}
+
+export type RedisPubSubMessageListener = (message: RedisPubSubMessage) => void
+
+export type RedisPubSubPatternMessageListener = (
+  message: RedisPubSubPatternMessage,
+) => void
+
+type ChannelSubscriber = {
+  channel: Buffer
+  listener: RedisPubSubMessageListener
+}
+
+type PatternSubscriber = {
+  pattern: Buffer
+  listener: RedisPubSubPatternMessageListener
+}
+
 export class RedisPubSubBroker {
-  publish(_channel: Buffer, _message: Buffer): number {
-    return 0
+  private readonly channels = new Map<string, Map<symbol, ChannelSubscriber>>()
+  private readonly patterns = new Map<string, Map<symbol, PatternSubscriber>>()
+
+  subscribe(
+    channel: Buffer,
+    listener: RedisPubSubMessageListener,
+  ): Unsubscribe {
+    const id = Symbol('channel-subscriber')
+    const key = pubsubKey(channel)
+    let subscribers = this.channels.get(key)
+    if (!subscribers) {
+      subscribers = new Map()
+      this.channels.set(key, subscribers)
+    }
+
+    subscribers.set(id, { channel: Buffer.from(channel), listener })
+    return () => {
+      subscribers?.delete(id)
+      if (subscribers?.size === 0) {
+        this.channels.delete(key)
+      }
+    }
+  }
+
+  psubscribe(
+    pattern: Buffer,
+    listener: RedisPubSubPatternMessageListener,
+  ): Unsubscribe {
+    const id = Symbol('pattern-subscriber')
+    const key = pubsubKey(pattern)
+    let subscribers = this.patterns.get(key)
+    if (!subscribers) {
+      subscribers = new Map()
+      this.patterns.set(key, subscribers)
+    }
+
+    subscribers.set(id, { pattern: Buffer.from(pattern), listener })
+    return () => {
+      subscribers?.delete(id)
+      if (subscribers?.size === 0) {
+        this.patterns.delete(key)
+      }
+    }
+  }
+
+  publish(channel: Buffer, message: Buffer): number {
+    let delivered = 0
+    const channelSubscribers = this.channels.get(pubsubKey(channel))
+
+    if (channelSubscribers) {
+      for (const subscriber of Array.from(channelSubscribers.values())) {
+        subscriber.listener({
+          channel: Buffer.from(channel),
+          message: Buffer.from(message),
+        })
+        delivered++
+      }
+    }
+
+    for (const subscribers of Array.from(this.patterns.values())) {
+      for (const subscriber of Array.from(subscribers.values())) {
+        if (!redisGlobMatch(subscriber.pattern, 0, channel, 0)) {
+          continue
+        }
+
+        subscriber.listener({
+          pattern: Buffer.from(subscriber.pattern),
+          channel: Buffer.from(channel),
+          message: Buffer.from(message),
+        })
+        delivered++
+      }
+    }
+
+    return delivered
+  }
+
+  channelsMatching(pattern?: Buffer): Buffer[] {
+    const channels: Buffer[] = []
+
+    for (const subscribers of this.channels.values()) {
+      const first = subscribers.values().next().value
+      if (!first) {
+        continue
+      }
+
+      if (pattern && !redisGlobMatch(pattern, 0, first.channel, 0)) {
+        continue
+      }
+
+      channels.push(Buffer.from(first.channel))
+    }
+
+    return channels
+  }
+
+  subscriberCount(channel: Buffer): number {
+    return this.channels.get(pubsubKey(channel))?.size ?? 0
+  }
+
+  patternSubscriptionCount(): number {
+    let count = 0
+    for (const subscribers of this.patterns.values()) {
+      count += subscribers.size
+    }
+    return count
   }
 }
+
+function pubsubKey(value: Buffer): string {
+  return value.toString('hex')
+}
+
+function redisGlobMatch(
+  pattern: Buffer,
+  patternIndex: number,
+  value: Buffer,
+  valueIndex: number,
+): boolean {
+  let patternCursor = patternIndex
+  let valueCursor = valueIndex
+
+  while (patternCursor < pattern.length && valueCursor < value.length) {
+    const token = pattern[patternCursor]
+
+    if (token === STAR) {
+      while (pattern[patternCursor + 1] === STAR) {
+        patternCursor++
+      }
+
+      if (patternCursor + 1 === pattern.length) {
+        return true
+      }
+
+      for (
+        let nextValueCursor = valueCursor;
+        nextValueCursor <= value.length;
+        nextValueCursor++
+      ) {
+        if (
+          redisGlobMatch(pattern, patternCursor + 1, value, nextValueCursor)
+        ) {
+          return true
+        }
+      }
+
+      return false
+    }
+
+    if (token === QUESTION_MARK) {
+      patternCursor++
+      valueCursor++
+      continue
+    }
+
+    if (token === OPEN_BRACKET) {
+      const characterClass = matchCharacterClass(
+        pattern,
+        patternCursor,
+        value[valueCursor],
+      )
+
+      if (!characterClass.matches) {
+        return false
+      }
+
+      patternCursor = characterClass.nextPatternIndex
+      valueCursor++
+      continue
+    }
+
+    if (token === BACKSLASH && patternCursor + 1 < pattern.length) {
+      patternCursor++
+    }
+
+    if (pattern[patternCursor] !== value[valueCursor]) {
+      return false
+    }
+
+    patternCursor++
+    valueCursor++
+  }
+
+  while (pattern[patternCursor] === STAR) {
+    patternCursor++
+  }
+
+  return patternCursor === pattern.length && valueCursor === value.length
+}
+
+function matchCharacterClass(
+  pattern: Buffer,
+  openBracketIndex: number,
+  value: number,
+): { matches: boolean; nextPatternIndex: number } {
+  let patternCursor = openBracketIndex + 1
+  let negated = false
+
+  if (pattern[patternCursor] === CARET) {
+    negated = true
+    patternCursor++
+  }
+
+  let matches = false
+
+  while (true) {
+    if (pattern[patternCursor] === CLOSE_BRACKET) {
+      break
+    }
+
+    if (patternCursor >= pattern.length) {
+      patternCursor--
+      break
+    }
+
+    if (
+      pattern[patternCursor] === BACKSLASH &&
+      patternCursor + 1 < pattern.length
+    ) {
+      patternCursor++
+      if (pattern[patternCursor] === value) {
+        matches = true
+      }
+    } else if (
+      patternCursor + 2 < pattern.length &&
+      pattern[patternCursor + 1] === DASH
+    ) {
+      let start = pattern[patternCursor]
+      let end = pattern[patternCursor + 2]
+
+      if (start > end) {
+        const previousStart = start
+        start = end
+        end = previousStart
+      }
+
+      if (value >= start && value <= end) {
+        matches = true
+      }
+
+      patternCursor += 2
+    } else if (pattern[patternCursor] === value) {
+      matches = true
+    }
+
+    patternCursor++
+  }
+
+  return {
+    matches: negated ? !matches : matches,
+    nextPatternIndex: patternCursor + 1,
+  }
+}
+
+const BACKSLASH = '\\'.charCodeAt(0)
+const CARET = '^'.charCodeAt(0)
+const CLOSE_BRACKET = ']'.charCodeAt(0)
+const DASH = '-'.charCodeAt(0)
+const OPEN_BRACKET = '['.charCodeAt(0)
+const QUESTION_MARK = '?'.charCodeAt(0)
+const STAR = '*'.charCodeAt(0)

--- a/tests-integration/ioredis/pubsub-integration.test.ts
+++ b/tests-integration/ioredis/pubsub-integration.test.ts
@@ -1,0 +1,143 @@
+import { after, before, describe, test } from 'node:test'
+import assert from 'node:assert'
+import { Redis } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+describe(`Pub/Sub integration (${testRunner.getBackendName()})`, () => {
+  let port: number
+  const clients: Redis[] = []
+
+  before(async () => {
+    port = await testRunner.setupRawStandalone()
+  })
+
+  after(async () => {
+    for (const client of clients) {
+      client.disconnect()
+    }
+    clients.length = 0
+    await testRunner.cleanup()
+  })
+
+  test('delivers channel messages and reports channel subscribers', async () => {
+    const publisher = await connect()
+    const subscriber = await connect()
+    const channel = `pubsub:${randomKey()}`
+    const missingChannel = `${channel}:missing`
+
+    assert.strictEqual(await subscriber.subscribe(channel), 1)
+    assert.deepStrictEqual(
+      await publisher.call('PUBSUB', 'NUMSUB', channel, missingChannel),
+      [channel, 1, missingChannel, 0],
+    )
+    assert.deepStrictEqual(
+      await publisher.call('PUBSUB', 'CHANNELS', channel),
+      [channel],
+    )
+
+    const message = waitForMessage(subscriber, channel)
+    assert.strictEqual(await publisher.publish(channel, 'hello'), 1)
+    assert.strictEqual(await message, 'hello')
+
+    await subscriber.unsubscribe(channel)
+    assert.strictEqual(await publisher.publish(channel, 'after'), 0)
+  })
+
+  test('delivers pattern messages and reports pattern subscribers', async () => {
+    const publisher = await connect()
+    const subscriber = await connect()
+    const prefix = `pubsub-pattern:${randomKey()}`
+    const pattern = `${prefix}:*`
+    const channel = `${prefix}:updates`
+
+    assert.strictEqual(await subscriber.psubscribe(pattern), 1)
+    assert.strictEqual(await publisher.call('PUBSUB', 'NUMPAT'), 1)
+
+    const message = waitForPatternMessage(subscriber, pattern, channel)
+    assert.strictEqual(await publisher.publish(channel, 'pattern-hit'), 1)
+    assert.strictEqual(await message, 'pattern-hit')
+
+    await subscriber.punsubscribe(pattern)
+    assert.strictEqual(await publisher.call('PUBSUB', 'NUMPAT'), 0)
+  })
+
+  test('reports empty shard Pub/Sub state', async () => {
+    const client = await connect()
+    const first = `pubsub-shard:${randomKey()}:1`
+    const second = `pubsub-shard:${randomKey()}:2`
+
+    assert.deepStrictEqual(await client.call('PUBSUB', 'SHARDCHANNELS'), [])
+    assert.deepStrictEqual(
+      await client.call('PUBSUB', 'SHARDNUMSUB', first, second),
+      [first, 0, second, 0],
+    )
+  })
+
+  async function connect(): Promise<Redis> {
+    const client = new Redis({ host: '127.0.0.1', port, lazyConnect: true })
+    await client.connect()
+    clients.push(client)
+    return client
+  }
+})
+
+function waitForMessage(client: Redis, channel: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup()
+      reject(new Error(`Timed out waiting for message on ${channel}`))
+    }, 1000)
+
+    const onMessage = (actualChannel: string, message: string) => {
+      if (actualChannel !== channel) {
+        return
+      }
+
+      cleanup()
+      resolve(message)
+    }
+
+    const cleanup = () => {
+      clearTimeout(timer)
+      client.off('message', onMessage)
+    }
+
+    client.on('message', onMessage)
+  })
+}
+
+function waitForPatternMessage(
+  client: Redis,
+  pattern: string,
+  channel: string,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup()
+      reject(new Error(`Timed out waiting for pattern message on ${channel}`))
+    }, 1000)
+
+    const onMessage = (
+      actualPattern: string,
+      actualChannel: string,
+      message: string,
+    ) => {
+      if (actualPattern !== pattern || actualChannel !== channel) {
+        return
+      }
+
+      cleanup()
+      resolve(message)
+    }
+
+    const cleanup = () => {
+      clearTimeout(timer)
+      client.off('pmessage', onMessage)
+    }
+
+    client.on('pmessage', onMessage)
+  })
+}

--- a/tests-integration/raw-tcp/pubsub-protocol.test.ts
+++ b/tests-integration/raw-tcp/pubsub-protocol.test.ts
@@ -88,6 +88,22 @@ describe(`Raw TCP Pub/Sub protocol (${testRunner.getBackendName()})`, () => {
     assert.deepStrictEqual(await subscriber.readFrame(), null)
   })
 
+  test('allows QUIT while subscribed', async () => {
+    const conn = await connect()
+    const channel = `raw-quit:${randomKey()}`
+
+    conn.write(commandFrame('SUBSCRIBE', channel))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'subscribe',
+      channel,
+      1,
+    ])
+
+    conn.write(commandFrame('QUIT'))
+    assert.deepStrictEqual(await conn.readRawFrame(), Buffer.from('+OK\r\n'))
+    assert.deepStrictEqual(await conn.readUntilClose(), Buffer.alloc(0))
+  })
+
   test('emits one acknowledgement per channel in multi-channel commands', async () => {
     const conn = await connect()
     const first = `raw-multi:${randomKey()}:1`

--- a/tests-integration/raw-tcp/pubsub-protocol.test.ts
+++ b/tests-integration/raw-tcp/pubsub-protocol.test.ts
@@ -1,0 +1,225 @@
+import { after, before, describe, test } from 'node:test'
+import assert from 'node:assert'
+import { TestRunner } from '../test-config'
+import { commandFrame, randomKey } from '../utils'
+import {
+  RawRedisConnection,
+  type RespWireValue,
+  respText,
+} from './raw-connection'
+
+const testRunner = new TestRunner()
+
+describe(`Raw TCP Pub/Sub protocol (${testRunner.getBackendName()})`, () => {
+  let port: number
+  const connections: RawRedisConnection[] = []
+
+  before(async () => {
+    port = await testRunner.setupRawStandalone()
+  })
+
+  after(async () => {
+    for (const connection of connections) {
+      connection.close()
+    }
+    connections.length = 0
+    await testRunner.cleanup()
+  })
+
+  async function connect(): Promise<RawRedisConnection> {
+    const connection = await RawRedisConnection.connect('127.0.0.1', port)
+    connections.push(connection)
+    return connection
+  }
+
+  test('allows subscribed-mode commands and rejects ordinary commands', async () => {
+    const conn = await connect()
+    const channel = `raw-pubsub:${randomKey()}`
+
+    conn.write(commandFrame('SUBSCRIBE', channel))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'subscribe',
+      channel,
+      1,
+    ])
+
+    conn.write(commandFrame('PING', 'hello'))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'pong',
+      'hello',
+    ])
+
+    conn.write(commandFrame('GET', 'blocked'))
+    assert.match(
+      respText(await conn.readFrame()),
+      /^ERR Can't execute 'get': only .* allowed in this context$/,
+    )
+
+    conn.write(commandFrame('UNSUBSCRIBE', channel))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'unsubscribe',
+      channel,
+      0,
+    ])
+
+    conn.write(commandFrame('SET', 'after-unsubscribe', 'ok'))
+    assert.deepStrictEqual(await conn.readFrame(), 'OK')
+  })
+
+  test('RESET exits subscribed mode and removes all subscriptions', async () => {
+    const subscriber = await connect()
+    const publisher = await connect()
+    const channel = `raw-reset:${randomKey()}`
+
+    subscriber.write(commandFrame('SUBSCRIBE', channel))
+    assert.deepStrictEqual(normalizeFrame(await subscriber.readFrame()), [
+      'subscribe',
+      channel,
+      1,
+    ])
+
+    subscriber.write(commandFrame('RESET'))
+    assert.deepStrictEqual(await subscriber.readFrame(), 'RESET')
+
+    publisher.write(commandFrame('PUBLISH', channel, 'dropped'))
+    assert.deepStrictEqual(await publisher.readFrame(), 0)
+
+    subscriber.write(commandFrame('GET', 'still-normal'))
+    assert.deepStrictEqual(await subscriber.readFrame(), null)
+  })
+
+  test('emits one acknowledgement per channel in multi-channel commands', async () => {
+    const conn = await connect()
+    const first = `raw-multi:${randomKey()}:1`
+    const second = `raw-multi:${randomKey()}:2`
+
+    conn.write(commandFrame('SUBSCRIBE', first, second))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'subscribe',
+      first,
+      1,
+    ])
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'subscribe',
+      second,
+      2,
+    ])
+
+    conn.write(commandFrame('UNSUBSCRIBE'))
+    const unsubscribeFrames = [
+      normalizeFrame(await conn.readFrame()),
+      normalizeFrame(await conn.readFrame()),
+    ]
+    assert.deepStrictEqual(
+      unsubscribeFrames.map(frame => {
+        assert.ok(Array.isArray(frame))
+        return frame[0]
+      }),
+      ['unsubscribe', 'unsubscribe'],
+    )
+    assert.deepStrictEqual(
+      unsubscribeFrames
+        .map(frame => {
+          assert.ok(Array.isArray(frame))
+          return frame[1]
+        })
+        .sort(),
+      [first, second].sort(),
+    )
+    assert.deepStrictEqual(
+      unsubscribeFrames.map(frame => {
+        assert.ok(Array.isArray(frame))
+        return frame[2]
+      }),
+      [1, 0],
+    )
+  })
+
+  test('rejects Pub/Sub arity errors with Redis errors', async () => {
+    const conn = await connect()
+
+    conn.write(commandFrame('SUBSCRIBE'))
+    assert.strictEqual(
+      respText(await conn.readFrame()),
+      "ERR wrong number of arguments for 'subscribe' command",
+    )
+
+    conn.write(commandFrame('PSUBSCRIBE'))
+    assert.strictEqual(
+      respText(await conn.readFrame()),
+      "ERR wrong number of arguments for 'psubscribe' command",
+    )
+
+    conn.write(commandFrame('PUBLISH', 'channel-only'))
+    assert.strictEqual(
+      respText(await conn.readFrame()),
+      "ERR wrong number of arguments for 'publish' command",
+    )
+
+    conn.write(commandFrame('PUBSUB', 'NUMPAT', 'extra'))
+    assert.strictEqual(
+      respText(await conn.readFrame()),
+      "ERR wrong number of arguments for 'pubsub|numpat' command",
+    )
+
+    conn.write(commandFrame('PUBSUB'))
+    assert.strictEqual(
+      respText(await conn.readFrame()),
+      "ERR wrong number of arguments for 'pubsub' command",
+    )
+
+    conn.write(commandFrame('PUBSUB', 'CHANNELS', '*', 'extra'))
+    assert.strictEqual(
+      respText(await conn.readFrame()),
+      "ERR unknown subcommand or wrong number of arguments for 'CHANNELS'. Try PUBSUB HELP.",
+    )
+
+    conn.write(commandFrame('PUBSUB', 'HELP', 'extra'))
+    assert.strictEqual(
+      respText(await conn.readFrame()),
+      "ERR wrong number of arguments for 'pubsub|help' command",
+    )
+
+    conn.write(commandFrame('PUBSUB', 'SHARDCHANNELS', '*', 'extra'))
+    assert.strictEqual(
+      respText(await conn.readFrame()),
+      "ERR unknown subcommand or wrong number of arguments for 'SHARDCHANNELS'. Try PUBSUB HELP.",
+    )
+  })
+
+  test('handles empty unsubscribe commands and unknown PUBSUB subcommands', async () => {
+    const conn = await connect()
+
+    conn.write(commandFrame('UNSUBSCRIBE'))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'unsubscribe',
+      null,
+      0,
+    ])
+
+    conn.write(commandFrame('PUNSUBSCRIBE'))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'punsubscribe',
+      null,
+      0,
+    ])
+
+    conn.write(commandFrame('PUBSUB', 'BOGUS'))
+    assert.strictEqual(
+      respText(await conn.readFrame()),
+      "ERR unknown subcommand 'BOGUS'. Try PUBSUB HELP.",
+    )
+  })
+})
+
+function normalizeFrame(value: RespWireValue): RespWireValue {
+  if (Buffer.isBuffer(value)) {
+    return value.toString()
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeFrame)
+  }
+
+  return value
+}

--- a/tests-integration/raw-tcp/pubsub-protocol.test.ts
+++ b/tests-integration/raw-tcp/pubsub-protocol.test.ts
@@ -5,6 +5,8 @@ import { commandFrame, randomKey } from '../utils'
 import {
   RawRedisConnection,
   type RespWireValue,
+  respMapGet,
+  respNumber,
   respText,
 } from './raw-connection'
 
@@ -64,6 +66,39 @@ describe(`Raw TCP Pub/Sub protocol (${testRunner.getBackendName()})`, () => {
 
     conn.write(commandFrame('SET', 'after-unsubscribe', 'ok'))
     assert.deepStrictEqual(await conn.readFrame(), 'OK')
+  })
+
+  test('RESP3 subscribed clients can run commands and use normal PING replies', async () => {
+    const conn = await connect()
+    const channel = `raw-resp3-pubsub:${randomKey()}`
+
+    conn.write(commandFrame('HELLO', '3'))
+    const hello = await conn.readFrame()
+    assert.ok(hello instanceof Map)
+    assert.strictEqual(respNumber(respMapGet(hello, 'proto')), 3)
+
+    conn.write(commandFrame('SUBSCRIBE', channel))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'subscribe',
+      channel,
+      1,
+    ])
+
+    conn.write(commandFrame('GET', 'missing'))
+    assert.strictEqual(await conn.readFrame(), null)
+
+    conn.write(commandFrame('PING'))
+    assert.strictEqual(await conn.readFrame(), 'PONG')
+
+    conn.write(commandFrame('PING', 'hello'))
+    assert.strictEqual(respText(await conn.readFrame()), 'hello')
+
+    conn.write(commandFrame('UNSUBSCRIBE', channel))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'unsubscribe',
+      channel,
+      0,
+    ])
   })
 
   test('RESET exits subscribed mode and removes all subscriptions', async () => {

--- a/tests/commands-foundation.test.ts
+++ b/tests/commands-foundation.test.ts
@@ -1,6 +1,7 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert'
 import {
+  connectionCommands,
   InMemoryConnectionTransport,
   RedisResult,
   RedisValue,
@@ -112,6 +113,34 @@ describe('new foundation commands', () => {
       await session.execute('client', [Buffer.from('GETNAME')]),
       RedisResult.create(RedisValue.bulkString(null)),
     )
+  })
+
+  test('reports Pub/Sub subscription counts in CLIENT INFO and LIST', () => {
+    const { session } = createSession()
+    const clientCommand = connectionCommands.find(command => {
+      return command.name === 'client'
+    })
+    assert.ok(clientCommand)
+
+    session.subscribePubSubChannels([Buffer.from('updates')])
+    session.subscribePubSubPatterns([Buffer.from('events:*')])
+
+    const ctx = session.createExecutionContext()
+    const info = clientCommand.execute({ subcommand: 'info', args: [] }, ctx)
+    assert.ok(info instanceof RedisResult)
+    assert.strictEqual(info.value.kind, 'bulk-string')
+    assert.notStrictEqual(info.value.value, null)
+    assert.match(info.value.value.toString(), /(?:^| )sub=1(?: |\n)/)
+    assert.match(info.value.value.toString(), /(?:^| )psub=1(?: |\n)/)
+
+    const list = clientCommand.execute({ subcommand: 'list', args: [] }, ctx)
+    assert.ok(list instanceof RedisResult)
+    assert.strictEqual(list.value.kind, 'bulk-string')
+    assert.notStrictEqual(list.value.value, null)
+    assert.match(list.value.value.toString(), /(?:^| )sub=1(?: |\n)/)
+    assert.match(list.value.value.toString(), /(?:^| )psub=1(?: |\n)/)
+
+    session.close()
   })
 
   test('implements SET condition, GET, expiration, and KEEPTTL options', async () => {

--- a/tests/commands-transactions.test.ts
+++ b/tests/commands-transactions.test.ts
@@ -119,7 +119,7 @@ describe('new transaction commands', () => {
 
   test('queues push-only commands in MULTI', async () => {
     const streamCommand = defineCommand({
-      name: 'subscribe',
+      name: 'fake-subscribe',
       schema: t.object({
         channel: t.bulk(),
       }),
@@ -136,7 +136,7 @@ describe('new transaction commands', () => {
 
     assert.deepStrictEqual(await session.execute('multi', []), RedisResult.ok())
     assert.deepStrictEqual(
-      await session.execute('subscribe', [Buffer.from('updates')]),
+      await session.execute('fake-subscribe', [Buffer.from('updates')]),
       queued(),
     )
   })

--- a/tests/core-command-executor.test.ts
+++ b/tests/core-command-executor.test.ts
@@ -26,6 +26,7 @@ function createContext(executor?: CommandExecutor): RedisExecutionContext {
       selectedDatabase: 0,
       mode: 'normal',
       protocolVersion: 2,
+      usesSubscribedReplyMode: false,
       clusterReadOnly: false,
       setProtocolVersion: () => {},
       setClusterReadOnly: () => {},

--- a/tests/core-glob.test.ts
+++ b/tests/core-glob.test.ts
@@ -1,0 +1,27 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import { redisGlobMatch } from '../src/core/glob'
+
+describe('redisGlobMatch', () => {
+  test('matches Redis glob wildcards and character classes', () => {
+    assert.strictEqual(matches('news.*', 'news.world'), true)
+    assert.strictEqual(matches('news.?', 'news.a'), true)
+    assert.strictEqual(matches('news.?', 'news.ab'), false)
+    assert.strictEqual(matches('h[ae]llo', 'hello'), true)
+    assert.strictEqual(matches('h[ae]llo', 'hillo'), false)
+    assert.strictEqual(matches('h[^i]llo', 'hello'), true)
+    assert.strictEqual(matches('h[^i]llo', 'hillo'), false)
+    assert.strictEqual(matches('item[3-1]', 'item2'), true)
+  })
+
+  test('handles escaped glob tokens literally', () => {
+    assert.strictEqual(matches('literal\\*', 'literal*'), true)
+    assert.strictEqual(matches('literal\\*', 'literal-value'), false)
+    assert.strictEqual(matches('file\\?', 'file?'), true)
+    assert.strictEqual(matches('file\\?', 'file1'), false)
+  })
+})
+
+function matches(pattern: string, value: string): boolean {
+  return redisGlobMatch(Buffer.from(pattern), Buffer.from(value))
+}


### PR DESCRIPTION
## Summary

- Add Redis Pub/Sub command support for `PUBLISH`, channel subscriptions, pattern subscriptions, and `PUBSUB` introspection.
- Track per-session subscription state, enforce Redis subscribed-mode command restrictions, and deliver server-initiated Pub/Sub frames through the RESP adapter.
- Document the implemented Pub/Sub surface and remaining shard subscription gap.

## Sub-Issues Covered

- Fixes #98: `SUBSCRIBE`/`UNSUBSCRIBE`/`PSUBSCRIBE`/`PUNSUBSCRIBE` and subscribed-mode session enforcement.
- Fixes #99: `PUBLISH` plus `RedisPubSubBroker` channel/pattern fan-out and `CLIENT INFO`/`CLIENT LIST` subscription counts.
- Fixes #100: `PUBSUB CHANNELS`, `NUMSUB`, `NUMPAT`, `SHARDCHANNELS`, and `SHARDNUMSUB` introspection.
- Fixes #92: subscribed-mode command gating for non-Pub/Sub commands.

## Root Cause

`RedisPubSubBroker` was a stub that always returned zero subscribers, and no Pub/Sub commands were registered. `ClientSession` had a `subscribed` mode type but no subscription lifecycle, outbound push queue, or subscribed-mode policy.

## Validation

- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/pubsub-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/pubsub-integration.test.ts`
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/raw-tcp/pubsub-protocol.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/raw-tcp/pubsub-protocol.test.ts`
- `npm run build`
- `npm test`
- `npm run lint` (passes with existing `src/types/respjs.d.ts` `no-explicit-any` warning)
- `npm run test:integration:mock`
- `npm run test:integration:real`

Fixes #17