### PR TITLE
Add stream consumer group commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ Commands are pure `(args, ctx) → RedisResult` — they never touch the transpo
 
 #### 4. Data Structures ([src/state/data-types.ts](src/state/data-types.ts))
 
-`RedisDataValue` is a typed union: `string`, `hash`, `list`, `set`, `zset`, `stream` (stream is currently a minimal stub — no entry storage, ID tracking, or consumer groups yet).
+`RedisDataValue` is a typed union: `string`, `hash`, `list`, `set`, `zset`, `stream` (stream values store entries, generated/deleted ID metadata, consumer groups, pending-entry lists, and consumer idle metadata).
 
 #### 5. Transaction Support (MULTI/EXEC/WATCH)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ Commands are pure `(args, ctx) → RedisResult` — they never touch the transpo
 
 #### 4. Data Structures ([src/state/data-types.ts](src/state/data-types.ts))
 
-`RedisDataValue` is a typed union: `string`, `hash`, `list`, `set`, `zset`, `stream` (stream is currently a minimal stub — no entry storage, ID tracking, or consumer groups yet).
+`RedisDataValue` is a typed union: `string`, `hash`, `list`, `set`, `zset`, `stream` (stream values store entries, generated/deleted ID metadata, consumer groups, pending-entry lists, and consumer idle metadata).
 
 #### 5. Transaction Support (MULTI/EXEC/WATCH)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -306,7 +306,9 @@ and the (currently stubbed) [`RedisPubSubBroker`](../src/state/pubsub-broker.ts)
 Each database wraps a [`RedisKeyspace`](../src/state/keyspace.ts#L34): a
 `Map<keyId, KeyspaceEntry>` holding byte-safe `Buffer` keys and typed
 [`RedisDataValue`](../src/state/data-types.ts)s (`string`, `hash`, `list`,
-`set`, `zset`, `stream`). Expiration is **lazy** — `getLiveEntry` calls
+`set`, `zset`, `stream`). Stream values store ordered entries plus consumer
+groups, per-group pending-entry lists, and consumer idle metadata. Expiration is
+**lazy** — `getLiveEntry` calls
 [`evictIfExpired`](../src/state/keyspace.ts#L207) on read, deleting and
 emitting an `evict` mutation event so `WATCH` observes expiry exactly like a
 real delete. Every mutation (`write`/`delete`/`expire`/`persist`/`evict`/`flush`)

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -261,21 +261,25 @@ with `GT` or `LT`.
 - [x] `XDEL key ID [ID ...]` - Remove entries by ID
 - [x] `XTRIM key MAXLEN|MINID [~] threshold` - Trim a stream to a size or minimum ID
 - [x] `XREAD [COUNT count] [BLOCK milliseconds] STREAMS key [key ...] id [id ...]` - Read entries, optionally blocking for new ones (RESP3 map / RESP2 array of stream-entry pairs)
+- [x] `XGROUP CREATE|SETID|DESTROY|CREATECONSUMER|DELCONSUMER ...` - Manage stream consumer groups and consumers
+- [x] `XREADGROUP GROUP group consumer [COUNT count] [BLOCK milliseconds] [NOACK] STREAMS key [key ...] id [id ...]` - Read entries through a consumer group and track pending delivery
+- [x] `XACK key group ID [ID ...]` - Acknowledge pending stream entries
+- [x] `XPENDING key group [[IDLE min-idle-time] start end count [consumer]]` - Inspect pending stream entries
+- [x] `XCLAIM key group consumer min-idle-time ID [ID ...] [IDLE ms] [TIME ms] [RETRYCOUNT count] [FORCE] [JUSTID] [LASTID id]` - Claim pending entries for another consumer
+- [x] `XAUTOCLAIM key group consumer min-idle-time start [COUNT count] [JUSTID]` - Claim idle pending entries automatically
+- [x] `XINFO STREAM key [FULL [COUNT count]]` - Inspect stream metadata, entries, groups, and PEL details
+- [x] `XINFO GROUPS key` - List stream consumer groups
+- [x] `XINFO CONSUMERS key group` - List consumers in a group
 
 #### Notes / gaps vs. real Redis
 
 - [ ] `XADD`/`XTRIM` trim specs do not support `LIMIT count`
-- [ ] `XREAD` does not support the `GROUP` consumer-group form
+- [ ] Stream radix-tree statistics in `XINFO STREAM` are approximated for mock compatibility rather than mirroring Redis internals
 
 #### Not implemented
 
-- [ ] Consumer groups: `XGROUP`, `XREADGROUP`, `XACK`, `XCLAIM`, `XAUTOCLAIM`, `XPENDING`
-- [ ] `XINFO STREAM|GROUPS|CONSUMERS`
 - [ ] `XSETID`
 - [ ] `XMSET` / `XCOPY`
-
-> `RedisStreamData` is currently a minimal stub - entries are stored, but
-> there is no consumer-group state.
 
 ## 10. Scan Family
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -194,6 +194,23 @@ export {
   scriptsCommands,
 } from './scripts'
 export {
+  xackCommand,
+  xaddCommand,
+  xautoclaimCommand,
+  xclaimCommand,
+  xdelCommand,
+  xgroupCommand,
+  xinfoCommand,
+  xlenCommand,
+  xpendingCommand,
+  xreadCommand,
+  xreadgroupCommand,
+  xrevrangeCommand,
+  xrangeCommand,
+  streamsCommands,
+  xtrimCommand,
+} from './streams'
+export {
   zsetsCommands,
   zaddCommand,
   zremCommand,

--- a/src/commands/streams.ts
+++ b/src/commands/streams.ts
@@ -294,6 +294,13 @@ function entryToReply(id: StreamId, fields: Buffer[]): RedisValue {
   ])
 }
 
+function deletedEntryToReply(id: StreamId): RedisValue {
+  return RedisValue.array([
+    RedisValue.bulkString(Buffer.from(formatStreamId(id))),
+    RedisValue.bulkString(null),
+  ])
+}
+
 type FieldList = Buffer[]
 
 // Parses the trailing `field value [field value ...]` of XADD into a flat
@@ -1108,8 +1115,11 @@ function readGroupEntries(
           if (compareStreamId(pending.id, id) <= 0) continue
 
           const entry = findEntry(stream, pending.id)
-          if (!entry) continue
-          replies.push(entryToReply(entry.id, entry.fields))
+          replies.push(
+            entry
+              ? entryToReply(entry.id, entry.fields)
+              : deletedEntryToReply(pending.id),
+          )
 
           if (count !== null && count > 0 && replies.length >= count) break
         }
@@ -1118,7 +1128,7 @@ function readGroupEntries(
       return replies
     })
 
-    if (entries.length > 0) {
+    if (entries.length > 0 || id !== '>') {
       results.push([bulkString(key), RedisValue.array(entries)])
     }
   }
@@ -1839,17 +1849,17 @@ function streamInfoReply(
     return fields
   }
 
-  const entryLimit = count ?? stream.entries.length
+  const fullCount = count ?? 10
   fields.push(
     RedisValue.array(
       Array.from(stream.groups.values(), group =>
-        fullGroupInfoReply(stream, group),
+        fullGroupInfoReply(stream, group, fullCount),
       ),
     ),
     bulkString('entries'),
     RedisValue.array(
       stream.entries
-        .slice(0, entryLimit)
+        .slice(0, fullCount)
         .map(entry => entryToReply(entry.id, entry.fields)),
     ),
   )
@@ -1877,6 +1887,7 @@ function groupInfoReply(stream: RedisStreamData) {
 function fullGroupInfoReply(
   stream: RedisStreamData,
   group: RedisStreamConsumerGroup,
+  count: number,
 ): RedisValue {
   return RedisValue.array([
     bulkString('name'),
@@ -1891,17 +1902,19 @@ function fullGroupInfoReply(
     integerValue(group.pending.size),
     bulkString('pending'),
     RedisValue.array(
-      pendingEntriesSorted(group).map(pending =>
-        RedisValue.array([
-          streamIdValue(pending.id),
-          bulkString(
-            group.consumers.get(pending.consumerId)?.name ??
-              Buffer.from(pending.consumerId, 'hex'),
-          ),
-          integerValue(Math.max(0, Date.now() - pending.deliveredAt)),
-          integerValue(pending.deliveryCount),
-        ]),
-      ),
+      pendingEntriesSorted(group)
+        .slice(0, count)
+        .map(pending =>
+          RedisValue.array([
+            streamIdValue(pending.id),
+            bulkString(
+              group.consumers.get(pending.consumerId)?.name ??
+                Buffer.from(pending.consumerId, 'hex'),
+            ),
+            integerValue(Math.max(0, Date.now() - pending.deliveredAt)),
+            integerValue(pending.deliveryCount),
+          ]),
+        ),
     ),
     bulkString('consumers'),
     RedisValue.array(

--- a/src/commands/streams.ts
+++ b/src/commands/streams.ts
@@ -7,6 +7,8 @@ import {
 import {
   ExpectedIntegerError,
   InvalidStreamIdError,
+  NoSuchKeyError,
+  RedisCommandError,
   RedisSyntaxError,
   StreamElementTooLargeError,
   StreamIdExhaustedError,
@@ -17,8 +19,15 @@ import {
 import { RedisValue } from '../core/redis-value'
 import { RedisResult } from '../core/redis-result'
 import type { RedisExecutionContext } from '../core/redis-context'
-import type { RedisStreamData, StreamId } from '../state/data-types'
-import { array, bulk, integer } from './helpers'
+import type {
+  RedisStreamConsumer,
+  RedisStreamConsumerGroup,
+  RedisStreamData,
+  RedisStreamEntry,
+  RedisStreamPendingEntry,
+  StreamId,
+} from '../state/data-types'
+import { array, bulk, integer, ok } from './helpers'
 
 const MAX_UINT64 = (1n << 64n) - 1n
 const MIN_ID: StreamId = { ms: 0n, seq: 0n }
@@ -28,10 +37,157 @@ function formatStreamId(id: StreamId): string {
   return `${id.ms}-${id.seq}`
 }
 
+function streamIdKey(id: StreamId): string {
+  return formatStreamId(id)
+}
+
+function bufferId(value: Buffer): string {
+  return value.toString('hex')
+}
+
 function compareStreamId(a: StreamId, b: StreamId): number {
   if (a.ms !== b.ms) return a.ms < b.ms ? -1 : 1
   if (a.seq !== b.seq) return a.seq < b.seq ? -1 : 1
   return 0
+}
+
+function cloneStreamId(id: StreamId): StreamId {
+  return { ms: id.ms, seq: id.seq }
+}
+
+function maxStreamId(a: StreamId, b: StreamId): StreamId {
+  return compareStreamId(a, b) >= 0 ? a : b
+}
+
+function updateMaxDeletedId(stream: RedisStreamData, id: StreamId): void {
+  stream.maxDeletedEntryId = cloneStreamId(
+    maxStreamId(stream.maxDeletedEntryId, id),
+  )
+}
+
+function findEntry(
+  stream: RedisStreamData,
+  id: StreamId,
+): RedisStreamEntry | null {
+  return (
+    stream.entries.find(entry => compareStreamId(entry.id, id) === 0) ?? null
+  )
+}
+
+function ensureConsumer(
+  group: RedisStreamConsumerGroup,
+  name: Buffer,
+  now: number,
+): RedisStreamConsumer {
+  const id = bufferId(name)
+  const existing = group.consumers.get(id)
+  if (existing) {
+    existing.seenAt = now
+    return existing
+  }
+
+  const consumer: RedisStreamConsumer = {
+    name: Buffer.from(name),
+    seenAt: now,
+    activeAt: null,
+  }
+  group.consumers.set(id, consumer)
+  return consumer
+}
+
+function pendingEntriesSorted(
+  group: RedisStreamConsumerGroup,
+): RedisStreamPendingEntry[] {
+  return Array.from(group.pending.values()).sort((a, b) =>
+    compareStreamId(a.id, b.id),
+  )
+}
+
+function streamGroup(
+  stream: RedisStreamData,
+  groupName: Buffer,
+): RedisStreamConsumerGroup | null {
+  return stream.groups.get(bufferId(groupName)) ?? null
+}
+
+function requireStreamGroup(
+  stream: RedisStreamData | null,
+  key: Buffer,
+  groupName: Buffer,
+  commandName?: string,
+): RedisStreamConsumerGroup {
+  const group = stream ? streamGroup(stream, groupName) : null
+  if (!group) {
+    throw new NoSuchStreamGroupError(key, groupName, commandName)
+  }
+  return group
+}
+
+function streamLag(
+  stream: RedisStreamData,
+  group: RedisStreamConsumerGroup,
+): number {
+  let lag = 0
+  for (const entry of stream.entries) {
+    if (compareStreamId(entry.id, group.lastDeliveredId) > 0) {
+      lag++
+    }
+  }
+  return lag
+}
+
+function consumerPendingCount(
+  group: RedisStreamConsumerGroup,
+  consumerId: string,
+): number {
+  let count = 0
+  for (const pending of group.pending.values()) {
+    if (pending.consumerId === consumerId) count++
+  }
+  return count
+}
+
+function bulkString(value: string | Buffer): RedisValue {
+  return RedisValue.bulkString(
+    typeof value === 'string' ? Buffer.from(value) : value,
+  )
+}
+
+function nullBulk(): RedisValue {
+  return RedisValue.bulkString(null)
+}
+
+function integerValue(value: number | bigint): RedisValue {
+  return RedisValue.integer(value)
+}
+
+function streamIdValue(id: StreamId): RedisValue {
+  return bulkString(formatStreamId(id))
+}
+
+class BusyStreamGroupError extends RedisCommandError {
+  constructor() {
+    super('Consumer Group name already exists', 'BUSYGROUP')
+  }
+}
+
+class NoSuchStreamGroupError extends RedisCommandError {
+  constructor(key: Buffer, group: Buffer, commandName?: string) {
+    const suffix =
+      commandName === 'XREADGROUP' ? ' in XREADGROUP with GROUP option' : ''
+    super(
+      `No such key '${key.toString()}' or consumer group '${group.toString()}'${suffix}`,
+      'NOGROUP',
+    )
+  }
+}
+
+class XgroupCreateMissingKeyError extends RedisCommandError {
+  constructor() {
+    super(
+      'The XGROUP subcommand requires the key to exist. Note that for CREATE you may want to use the MKSTREAM option to create an empty stream automatically.',
+    )
+  }
 }
 
 function parseUint64(token: string): bigint | null {
@@ -212,6 +368,9 @@ function applyTrim(stream: RedisStreamData, spec: TrimSpec): number {
   if (spec.strategy === 'maxlen') {
     const removeCount = stream.entries.length - Number(spec.count)
     if (removeCount <= 0) return 0
+    for (const entry of stream.entries.slice(0, removeCount)) {
+      updateMaxDeletedId(stream, entry.id)
+    }
     stream.entries.splice(0, removeCount)
     return removeCount
   } else {
@@ -223,6 +382,9 @@ function applyTrim(stream: RedisStreamData, spec: TrimSpec): number {
       i++
     }
     if (i === 0) return 0
+    for (const entry of stream.entries.slice(0, i)) {
+      updateMaxDeletedId(stream, entry.id)
+    }
     stream.entries.splice(0, i)
     return i
   }
@@ -259,6 +421,7 @@ export const xaddCommand = defineCommand({
 
       stream.entries.push({ id: next, fields: args.fields })
       stream.lastId = next
+      stream.entriesAdded++
 
       if (args.trim !== undefined) {
         applyTrim(stream, args.trim)
@@ -385,6 +548,7 @@ export const xdelCommand = defineCommand({
           entry => compareStreamId(entry.id, target) === 0,
         )
         if (idx !== -1) {
+          updateMaxDeletedId(stream, stream.entries[idx].id)
           stream.entries.splice(idx, 1)
           count++
         }
@@ -589,6 +753,1200 @@ export const xreadCommand = defineCommand({
   },
 })
 
+type XgroupArgs =
+  | {
+      subcommand: 'create'
+      key: Buffer
+      group: Buffer
+      id: StreamId | '$'
+      mkstream: boolean
+      entriesRead: number | null
+    }
+  | {
+      subcommand: 'setid'
+      key: Buffer
+      group: Buffer
+      id: StreamId | '$'
+      entriesRead: number | null
+    }
+  | { subcommand: 'destroy'; key: Buffer; group: Buffer }
+  | {
+      subcommand: 'createconsumer'
+      key: Buffer
+      group: Buffer
+      consumer: Buffer
+    }
+  | { subcommand: 'delconsumer'; key: Buffer; group: Buffer; consumer: Buffer }
+
+function createXgroupSchema() {
+  return t.custom<XgroupArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const subcommand = input[index]?.toString().toUpperCase()
+      if (!subcommand) throw new WrongNumberOfArgumentsError(ctx.commandName)
+
+      if (subcommand === 'CREATE' || subcommand === 'SETID') {
+        const key = input[index + 1]
+        const group = input[index + 2]
+        const rawId = input[index + 3]?.toString()
+        if (!key || !group || rawId === undefined) {
+          throw new WrongNumberOfArgumentsError(ctx.commandName)
+        }
+
+        let cursor = index + 4
+        let mkstream = false
+        let entriesRead: number | null = null
+        while (cursor < input.length) {
+          const option = input[cursor].toString().toUpperCase()
+          if (subcommand === 'CREATE' && option === 'MKSTREAM') {
+            mkstream = true
+            cursor++
+            continue
+          }
+
+          if (option === 'ENTRIESREAD') {
+            const rawEntriesRead = input[cursor + 1]
+            if (!rawEntriesRead) {
+              throw new WrongNumberOfArgumentsError(ctx.commandName)
+            }
+            entriesRead = parseNonNegativeInteger(rawEntriesRead)
+            cursor += 2
+            continue
+          }
+
+          throw new RedisSyntaxError()
+        }
+
+        return {
+          value: {
+            subcommand: subcommand === 'CREATE' ? 'create' : 'setid',
+            key,
+            group,
+            id: rawId === '$' ? '$' : parseExactId(rawId),
+            mkstream,
+            entriesRead,
+          },
+          nextIndex: input.length,
+        }
+      }
+
+      if (subcommand === 'DESTROY') {
+        const key = input[index + 1]
+        const group = input[index + 2]
+        if (!key || !group || input.length !== index + 3) {
+          throw new WrongNumberOfArgumentsError(ctx.commandName)
+        }
+        return {
+          value: { subcommand: 'destroy', key, group },
+          nextIndex: input.length,
+        }
+      }
+
+      if (subcommand === 'CREATECONSUMER' || subcommand === 'DELCONSUMER') {
+        const key = input[index + 1]
+        const group = input[index + 2]
+        const consumer = input[index + 3]
+        if (!key || !group || !consumer || input.length !== index + 4) {
+          throw new WrongNumberOfArgumentsError(ctx.commandName)
+        }
+        return {
+          value: {
+            subcommand:
+              subcommand === 'CREATECONSUMER'
+                ? 'createconsumer'
+                : 'delconsumer',
+            key,
+            group,
+            consumer,
+          },
+          nextIndex: input.length,
+        }
+      }
+
+      throw new RedisCommandError(
+        `Unknown subcommand or wrong number of arguments for '${subcommand}'. Try XGROUP HELP.`,
+      )
+    },
+  )
+}
+
+export const xgroupCommand = defineCommand({
+  name: 'xgroup',
+  schema: t.object({ args: createXgroupSchema() }),
+  flags: ['write'],
+  keys: args => [args.args.key],
+  execute: (args, ctx) => {
+    const command = args.args
+
+    if (command.subcommand === 'create') {
+      const type = ctx.db.getType(command.key)
+      if (type === null && !command.mkstream) {
+        throw new XgroupCreateMissingKeyError()
+      }
+
+      const lastDeliveredId =
+        command.id === '$'
+          ? (ctx.db.getStream(command.key)?.lastId ?? MIN_ID)
+          : command.id
+
+      ctx.db.updateStream(command.key, stream => {
+        const groupId = bufferId(command.group)
+        if (stream.groups.has(groupId)) {
+          throw new BusyStreamGroupError()
+        }
+
+        stream.groups.set(groupId, {
+          name: Buffer.from(command.group),
+          lastDeliveredId: cloneStreamId(lastDeliveredId),
+          entriesRead: command.entriesRead,
+          consumers: new Map(),
+          pending: new Map(),
+        })
+      })
+      return ok()
+    }
+
+    if (command.subcommand === 'setid') {
+      requireStreamGroup(
+        ctx.db.getStream(command.key),
+        command.key,
+        command.group,
+      )
+      ctx.db.updateStream(command.key, stream => {
+        const group = requireStreamGroup(stream, command.key, command.group)
+        group.lastDeliveredId =
+          command.id === '$'
+            ? cloneStreamId(stream.lastId)
+            : cloneStreamId(command.id)
+        group.entriesRead = command.entriesRead
+      })
+      return ok()
+    }
+
+    if (command.subcommand === 'destroy') {
+      const stream = ctx.db.getStream(command.key)
+      if (!stream) return integer(0)
+
+      const removed = ctx.db.updateStream(command.key, writable =>
+        writable.groups.delete(bufferId(command.group)),
+      )
+      return integer(removed ? 1 : 0)
+    }
+
+    if (command.subcommand === 'createconsumer') {
+      requireStreamGroup(
+        ctx.db.getStream(command.key),
+        command.key,
+        command.group,
+      )
+      const created = ctx.db.updateStream(command.key, stream => {
+        const group = requireStreamGroup(stream, command.key, command.group)
+        const consumerId = bufferId(command.consumer)
+        if (group.consumers.has(consumerId)) return false
+
+        group.consumers.set(consumerId, {
+          name: Buffer.from(command.consumer),
+          seenAt: Date.now(),
+          activeAt: null,
+        })
+        return true
+      })
+      return integer(created ? 1 : 0)
+    }
+
+    requireStreamGroup(
+      ctx.db.getStream(command.key),
+      command.key,
+      command.group,
+    )
+    const deleted = ctx.db.updateStream(command.key, stream => {
+      const group = requireStreamGroup(stream, command.key, command.group)
+      const consumerId = bufferId(command.consumer)
+      if (!group.consumers.delete(consumerId)) return 0
+
+      let removedPending = 0
+      for (const [pendingId, pending] of Array.from(group.pending)) {
+        if (pending.consumerId !== consumerId) continue
+        group.pending.delete(pendingId)
+        removedPending++
+      }
+      return removedPending
+    })
+    return integer(deleted)
+  },
+})
+
+type XreadGroupStream = { key: Buffer; id: StreamId | '>' }
+
+function createXreadGroupSchema() {
+  return t.custom<{
+    group: Buffer
+    consumer: Buffer
+    count: number | null
+    blockMs: number | null
+    noack: boolean
+    streams: XreadGroupStream[]
+  }>((input: readonly Buffer[], index: number, ctx: ParseContext) => {
+    if (input[index]?.toString().toUpperCase() !== 'GROUP') {
+      throw new WrongNumberOfArgumentsError(ctx.commandName)
+    }
+
+    const group = input[index + 1]
+    const consumer = input[index + 2]
+    if (!group || !consumer) {
+      throw new WrongNumberOfArgumentsError(ctx.commandName)
+    }
+
+    let cursor = index + 3
+    let count: number | null = null
+    let blockMs: number | null = null
+    let noack = false
+
+    while (cursor < input.length) {
+      const token = input[cursor].toString().toUpperCase()
+      if (token === 'COUNT') {
+        const raw = input[cursor + 1]
+        if (!raw) throw new WrongNumberOfArgumentsError(ctx.commandName)
+        count = parseNonNegativeInteger(raw)
+        cursor += 2
+        continue
+      }
+
+      if (token === 'BLOCK') {
+        const raw = input[cursor + 1]
+        if (!raw) throw new WrongNumberOfArgumentsError(ctx.commandName)
+        blockMs = parseNonNegativeInteger(raw)
+        cursor += 2
+        continue
+      }
+
+      if (token === 'NOACK') {
+        noack = true
+        cursor++
+        continue
+      }
+
+      break
+    }
+
+    if (
+      cursor >= input.length ||
+      input[cursor].toString().toUpperCase() !== 'STREAMS'
+    ) {
+      throw new WrongNumberOfArgumentsError(ctx.commandName)
+    }
+    cursor++
+
+    const remaining = input.length - cursor
+    if (remaining === 0 || remaining % 2 !== 0) {
+      throw new WrongNumberOfArgumentsError(ctx.commandName)
+    }
+
+    const half = remaining / 2
+    const streams: XreadGroupStream[] = []
+    for (let i = 0; i < half; i++) {
+      const key = input[cursor + i]
+      const rawId = input[cursor + half + i].toString()
+      streams.push({
+        key,
+        id: rawId === '>' ? '>' : parseExactId(rawId),
+      })
+    }
+
+    return {
+      value: { group, consumer, count, blockMs, noack, streams },
+      nextIndex: input.length,
+    }
+  })
+}
+
+function readGroupEntries(
+  groupName: Buffer,
+  consumerName: Buffer,
+  streams: XreadGroupStream[],
+  count: number | null,
+  noack: boolean,
+  ctx: RedisExecutionContext,
+): RedisResult | null {
+  const now = Date.now()
+  const results: [RedisValue, RedisValue][] = []
+
+  for (const { key } of streams) {
+    requireStreamGroup(ctx.db.getStream(key), key, groupName, 'XREADGROUP')
+  }
+
+  for (const { key, id } of streams) {
+    const entries = ctx.db.updateStream(key, stream => {
+      const group = requireStreamGroup(stream, key, groupName, 'XREADGROUP')
+      const consumer = ensureConsumer(group, consumerName, now)
+      consumer.activeAt = now
+
+      const consumerId = bufferId(consumerName)
+      const replies: RedisValue[] = []
+
+      if (id === '>') {
+        for (const entry of stream.entries) {
+          if (compareStreamId(entry.id, group.lastDeliveredId) <= 0) continue
+
+          replies.push(entryToReply(entry.id, entry.fields))
+          group.lastDeliveredId = cloneStreamId(entry.id)
+          group.entriesRead = (group.entriesRead ?? 0) + 1
+
+          if (!noack) {
+            group.pending.set(streamIdKey(entry.id), {
+              id: cloneStreamId(entry.id),
+              consumerId,
+              deliveredAt: now,
+              deliveryCount: 1,
+            })
+          }
+
+          if (count !== null && count > 0 && replies.length >= count) break
+        }
+      } else {
+        for (const pending of pendingEntriesSorted(group)) {
+          if (pending.consumerId !== consumerId) continue
+          if (compareStreamId(pending.id, id) <= 0) continue
+
+          const entry = findEntry(stream, pending.id)
+          if (!entry) continue
+          replies.push(entryToReply(entry.id, entry.fields))
+
+          if (count !== null && count > 0 && replies.length >= count) break
+        }
+      }
+
+      return replies
+    })
+
+    if (entries.length > 0) {
+      results.push([bulkString(key), RedisValue.array(entries)])
+    }
+  }
+
+  return results.length > 0
+    ? RedisResult.create(RedisValue.mapPairs(results))
+    : null
+}
+
+async function blockingXreadGroup(
+  groupName: Buffer,
+  consumerName: Buffer,
+  streams: XreadGroupStream[],
+  count: number | null,
+  noack: boolean,
+  blockMs: number,
+  ctx: RedisExecutionContext,
+): Promise<RedisResult> {
+  const timeoutMs = blockMs === 0 ? undefined : blockMs
+  const deadline = timeoutMs !== undefined ? Date.now() + timeoutMs : undefined
+  const keys = streams.map(s => s.key)
+
+  while (true) {
+    const remaining =
+      deadline !== undefined ? Math.max(0, deadline - Date.now()) : undefined
+    if (remaining === 0) return bulk(null)
+
+    let wake!: (v: true) => void
+    const waitFor = new Promise<true>(resolve => {
+      wake = () => resolve(true)
+    })
+
+    const unsubs = keys.map(key =>
+      ctx.db.subscribeKey(key, event => {
+        if (event.type === 'write') wake(true)
+      }),
+    )
+
+    let woken: boolean | null
+    try {
+      woken = await ctx.park({
+        waitFor,
+        timeoutMs: remaining,
+        signal: ctx.signal,
+      })
+    } finally {
+      for (const unsub of unsubs) {
+        try {
+          unsub()
+        } catch {
+          // ignore errors from individual unsubscribers so all are attempted
+        }
+      }
+    }
+
+    if (woken === null) return bulk(null)
+
+    const result = readGroupEntries(
+      groupName,
+      consumerName,
+      streams,
+      count,
+      noack,
+      ctx,
+    )
+    if (result) return result
+  }
+}
+
+export const xreadgroupCommand = defineCommand({
+  name: 'xreadgroup',
+  schema: t.object({ args: createXreadGroupSchema() }),
+  flags: ['write', 'blocking'],
+  capabilities: { blocking: true },
+  keys: args => args.args.streams.map(s => s.key),
+  execute: (args, ctx) => {
+    const { group, consumer, streams, count, blockMs, noack } = args.args
+    const immediate = readGroupEntries(
+      group,
+      consumer,
+      streams,
+      count,
+      noack,
+      ctx,
+    )
+    if (
+      immediate ||
+      blockMs === null ||
+      streams.some(stream => stream.id !== '>')
+    ) {
+      return immediate ?? bulk(null)
+    }
+
+    return blockingXreadGroup(
+      group,
+      consumer,
+      streams,
+      count,
+      noack,
+      blockMs,
+      ctx,
+    )
+  },
+})
+
+export const xackCommand = defineCommand({
+  name: 'xack',
+  schema: t.object({
+    key: t.key(),
+    group: t.bulk(),
+    ids: t.variadic(t.string(), { min: 1 }),
+  }),
+  flags: ['write', 'fast'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const ids = args.ids.map(parseExactId)
+    requireStreamGroup(ctx.db.getStream(args.key), args.key, args.group)
+    const acknowledged = ctx.db.updateStream(args.key, stream => {
+      const group = requireStreamGroup(stream, args.key, args.group)
+      let count = 0
+      for (const id of ids) {
+        if (group.pending.delete(streamIdKey(id))) count++
+      }
+      return count
+    })
+    return integer(acknowledged)
+  },
+})
+
+type XpendingArgs =
+  | { mode: 'summary'; key: Buffer; group: Buffer }
+  | {
+      mode: 'range'
+      key: Buffer
+      group: Buffer
+      minIdleMs: number | null
+      start: RangeBound
+      end: RangeBound
+      count: number
+      consumer: Buffer | null
+    }
+
+function createXpendingSchema() {
+  return t.custom<XpendingArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const key = input[index]
+      const group = input[index + 1]
+      if (!key || !group) throw new WrongNumberOfArgumentsError(ctx.commandName)
+
+      if (input.length === index + 2) {
+        return {
+          value: { mode: 'summary', key, group },
+          nextIndex: input.length,
+        }
+      }
+
+      let cursor = index + 2
+      let minIdleMs: number | null = null
+      if (input[cursor]?.toString().toUpperCase() === 'IDLE') {
+        const raw = input[cursor + 1]
+        if (!raw) throw new WrongNumberOfArgumentsError(ctx.commandName)
+        minIdleMs = parseNonNegativeInteger(raw)
+        cursor += 2
+      }
+
+      const startToken = input[cursor]?.toString()
+      const endToken = input[cursor + 1]?.toString()
+      const rawCount = input[cursor + 2]
+      if (startToken === undefined || endToken === undefined || !rawCount) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+      cursor += 3
+
+      const consumer = input[cursor] ?? null
+      if (cursor + (consumer ? 1 : 0) !== input.length) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      return {
+        value: {
+          mode: 'range',
+          key,
+          group,
+          minIdleMs,
+          start: parseRangeId(startToken, true),
+          end: parseRangeId(endToken, false),
+          count: parseNonNegativeInteger(rawCount),
+          consumer,
+        },
+        nextIndex: input.length,
+      }
+    },
+  )
+}
+
+export const xpendingCommand = defineCommand({
+  name: 'xpending',
+  schema: t.object({ args: createXpendingSchema() }),
+  flags: ['readonly'],
+  keys: args => [args.args.key],
+  execute: (args, ctx) => {
+    const command = args.args
+    const stream = ctx.db.getStream(command.key)
+    const group = requireStreamGroup(stream, command.key, command.group)
+
+    if (command.mode === 'summary') {
+      const pending = pendingEntriesSorted(group)
+      if (pending.length === 0) {
+        return array([
+          integerValue(0),
+          nullBulk(),
+          nullBulk(),
+          RedisValue.array([]),
+        ])
+      }
+
+      const counts = new Map<string, number>()
+      for (const entry of pending) {
+        counts.set(entry.consumerId, (counts.get(entry.consumerId) ?? 0) + 1)
+      }
+
+      return array([
+        integerValue(pending.length),
+        streamIdValue(pending[0].id),
+        streamIdValue(pending[pending.length - 1].id),
+        RedisValue.array(
+          Array.from(counts, ([consumerId, count]) => {
+            const consumer = group.consumers.get(consumerId)
+            return RedisValue.array([
+              bulkString(consumer?.name ?? Buffer.from(consumerId, 'hex')),
+              integerValue(count),
+            ])
+          }),
+        ),
+      ])
+    }
+
+    const now = Date.now()
+    const consumerId = command.consumer ? bufferId(command.consumer) : null
+    const replies: RedisValue[] = []
+    for (const pending of pendingEntriesSorted(group)) {
+      if (
+        !exclusiveAware(
+          compareStreamId(pending.id, command.start.id),
+          command.start.exclusive,
+          true,
+        )
+      ) {
+        continue
+      }
+      if (
+        !exclusiveAware(
+          compareStreamId(pending.id, command.end.id),
+          command.end.exclusive,
+          false,
+        )
+      ) {
+        continue
+      }
+      if (consumerId !== null && pending.consumerId !== consumerId) continue
+
+      const idleMs = Math.max(0, now - pending.deliveredAt)
+      if (command.minIdleMs !== null && idleMs < command.minIdleMs) continue
+
+      const consumer = group.consumers.get(pending.consumerId)
+      replies.push(
+        RedisValue.array([
+          streamIdValue(pending.id),
+          bulkString(consumer?.name ?? Buffer.from(pending.consumerId, 'hex')),
+          integerValue(idleMs),
+          integerValue(pending.deliveryCount),
+        ]),
+      )
+      if (replies.length >= command.count) break
+    }
+
+    return array(replies)
+  },
+})
+
+type XclaimArgs = {
+  key: Buffer
+  group: Buffer
+  consumer: Buffer
+  minIdleMs: number
+  ids: StreamId[]
+  idleMs: number | null
+  timeMs: number | null
+  retryCount: number | null
+  force: boolean
+  justId: boolean
+  lastId: StreamId | null
+}
+
+function createXclaimSchema() {
+  return t.custom<XclaimArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const key = input[index]
+      const group = input[index + 1]
+      const consumer = input[index + 2]
+      const rawMinIdle = input[index + 3]
+      if (!key || !group || !consumer || !rawMinIdle) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      let cursor = index + 4
+      const ids: StreamId[] = []
+      while (cursor < input.length && !isXclaimOption(input[cursor])) {
+        ids.push(parseExactId(input[cursor].toString()))
+        cursor++
+      }
+      if (ids.length === 0)
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+
+      let idleMs: number | null = null
+      let timeMs: number | null = null
+      let retryCount: number | null = null
+      let force = false
+      let justId = false
+      let lastId: StreamId | null = null
+
+      while (cursor < input.length) {
+        const option = input[cursor].toString().toUpperCase()
+        if (option === 'IDLE' || option === 'TIME' || option === 'RETRYCOUNT') {
+          const rawValue = input[cursor + 1]
+          if (!rawValue) throw new WrongNumberOfArgumentsError(ctx.commandName)
+          const value = parseNonNegativeInteger(rawValue)
+          if (option === 'IDLE') idleMs = value
+          if (option === 'TIME') timeMs = value
+          if (option === 'RETRYCOUNT') retryCount = value
+          cursor += 2
+          continue
+        }
+
+        if (option === 'FORCE') {
+          force = true
+          cursor++
+          continue
+        }
+
+        if (option === 'JUSTID') {
+          justId = true
+          cursor++
+          continue
+        }
+
+        if (option === 'LASTID') {
+          const rawValue = input[cursor + 1]
+          if (!rawValue) throw new WrongNumberOfArgumentsError(ctx.commandName)
+          lastId = parseExactId(rawValue.toString())
+          cursor += 2
+          continue
+        }
+
+        throw new RedisSyntaxError()
+      }
+
+      return {
+        value: {
+          key,
+          group,
+          consumer,
+          minIdleMs: parseNonNegativeInteger(rawMinIdle),
+          ids,
+          idleMs,
+          timeMs,
+          retryCount,
+          force,
+          justId,
+          lastId,
+        },
+        nextIndex: input.length,
+      }
+    },
+  )
+}
+
+function isXclaimOption(token: Buffer): boolean {
+  const option = token.toString().toUpperCase()
+  return (
+    option === 'IDLE' ||
+    option === 'TIME' ||
+    option === 'RETRYCOUNT' ||
+    option === 'FORCE' ||
+    option === 'JUSTID' ||
+    option === 'LASTID'
+  )
+}
+
+export const xclaimCommand = defineCommand({
+  name: 'xclaim',
+  schema: t.object({ args: createXclaimSchema() }),
+  flags: ['write'],
+  keys: args => [args.args.key],
+  execute: (args, ctx) => {
+    const command = args.args
+    const now = Date.now()
+    requireStreamGroup(
+      ctx.db.getStream(command.key),
+      command.key,
+      command.group,
+    )
+    const claimed = ctx.db.updateStream(command.key, stream => {
+      const group = requireStreamGroup(stream, command.key, command.group)
+      ensureConsumer(group, command.consumer, now).activeAt = now
+      const consumerId = bufferId(command.consumer)
+      if (command.lastId) group.lastDeliveredId = cloneStreamId(command.lastId)
+
+      const replies: RedisValue[] = []
+      for (const id of command.ids) {
+        const pendingId = streamIdKey(id)
+        const entry = findEntry(stream, id)
+        let pending = group.pending.get(pendingId)
+
+        if (!pending && command.force && entry) {
+          pending = {
+            id: cloneStreamId(id),
+            consumerId,
+            deliveredAt: now,
+            deliveryCount: 0,
+          }
+          group.pending.set(pendingId, pending)
+        }
+
+        if (!pending) continue
+        if (!entry) {
+          group.pending.delete(pendingId)
+          continue
+        }
+
+        const idleTime = Math.max(0, now - pending.deliveredAt)
+        if (idleTime < command.minIdleMs) continue
+
+        pending.consumerId = consumerId
+        pending.deliveredAt =
+          command.timeMs ??
+          (command.idleMs !== null ? now - command.idleMs : now)
+        if (command.retryCount !== null) {
+          pending.deliveryCount = command.retryCount
+        } else if (!command.justId) {
+          pending.deliveryCount++
+        }
+
+        replies.push(
+          command.justId
+            ? streamIdValue(entry.id)
+            : entryToReply(entry.id, entry.fields),
+        )
+      }
+      return replies
+    })
+
+    return array(claimed)
+  },
+})
+
+type XautoclaimArgs = {
+  key: Buffer
+  group: Buffer
+  consumer: Buffer
+  minIdleMs: number
+  start: StreamId
+  count: number
+  justId: boolean
+}
+
+function createXautoclaimSchema() {
+  return t.custom<XautoclaimArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const key = input[index]
+      const group = input[index + 1]
+      const consumer = input[index + 2]
+      const rawMinIdle = input[index + 3]
+      const rawStart = input[index + 4]
+      if (!key || !group || !consumer || !rawMinIdle || !rawStart) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      let cursor = index + 5
+      let count = 100
+      let justId = false
+      while (cursor < input.length) {
+        const option = input[cursor].toString().toUpperCase()
+        if (option === 'COUNT') {
+          const rawCount = input[cursor + 1]
+          if (!rawCount) throw new WrongNumberOfArgumentsError(ctx.commandName)
+          count = parseNonNegativeInteger(rawCount)
+          cursor += 2
+          continue
+        }
+
+        if (option === 'JUSTID') {
+          justId = true
+          cursor++
+          continue
+        }
+
+        throw new RedisSyntaxError()
+      }
+
+      return {
+        value: {
+          key,
+          group,
+          consumer,
+          minIdleMs: parseNonNegativeInteger(rawMinIdle),
+          start: parseExactId(rawStart.toString()),
+          count,
+          justId,
+        },
+        nextIndex: input.length,
+      }
+    },
+  )
+}
+
+export const xautoclaimCommand = defineCommand({
+  name: 'xautoclaim',
+  schema: t.object({ args: createXautoclaimSchema() }),
+  flags: ['write'],
+  keys: args => [args.args.key],
+  execute: (args, ctx) => {
+    const command = args.args
+    const now = Date.now()
+    requireStreamGroup(
+      ctx.db.getStream(command.key),
+      command.key,
+      command.group,
+    )
+    const result = ctx.db.updateStream(command.key, stream => {
+      const group = requireStreamGroup(stream, command.key, command.group)
+      ensureConsumer(group, command.consumer, now).activeAt = now
+      const consumerId = bufferId(command.consumer)
+      const claimed: RedisValue[] = []
+      const deleted: RedisValue[] = []
+      let nextStartId: StreamId = MIN_ID
+
+      for (const pending of pendingEntriesSorted(group)) {
+        if (compareStreamId(pending.id, command.start) < 0) continue
+
+        const entry = findEntry(stream, pending.id)
+        if (!entry) {
+          group.pending.delete(streamIdKey(pending.id))
+          deleted.push(streamIdValue(pending.id))
+          continue
+        }
+
+        const idleTime = Math.max(0, now - pending.deliveredAt)
+        if (idleTime < command.minIdleMs) continue
+
+        pending.consumerId = consumerId
+        pending.deliveredAt = now
+        if (!command.justId) pending.deliveryCount++
+        claimed.push(
+          command.justId
+            ? streamIdValue(entry.id)
+            : entryToReply(entry.id, entry.fields),
+        )
+
+        if (claimed.length >= command.count) {
+          const next = pendingEntriesSorted(group).find(
+            item => compareStreamId(item.id, pending.id) > 0,
+          )
+          nextStartId = next ? cloneStreamId(next.id) : MIN_ID
+          break
+        }
+      }
+
+      return { nextStartId, claimed, deleted }
+    })
+
+    return array([
+      streamIdValue(result.nextStartId),
+      RedisValue.array(result.claimed),
+      RedisValue.array(result.deleted),
+    ])
+  },
+})
+
+type XinfoArgs =
+  | { subcommand: 'stream'; key: Buffer; full: boolean; count: number | null }
+  | { subcommand: 'groups'; key: Buffer }
+  | { subcommand: 'consumers'; key: Buffer; group: Buffer }
+
+function createXinfoSchema() {
+  return t.custom<XinfoArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const subcommand = input[index]?.toString().toUpperCase()
+      if (!subcommand) throw new WrongNumberOfArgumentsError(ctx.commandName)
+
+      if (subcommand === 'STREAM') {
+        const key = input[index + 1]
+        if (!key) throw new WrongNumberOfArgumentsError(ctx.commandName)
+        let cursor = index + 2
+        let full = false
+        let count: number | null = null
+
+        if (cursor < input.length) {
+          if (input[cursor].toString().toUpperCase() !== 'FULL') {
+            throw new RedisSyntaxError()
+          }
+          full = true
+          cursor++
+        }
+
+        if (cursor < input.length) {
+          if (input[cursor].toString().toUpperCase() !== 'COUNT') {
+            throw new RedisSyntaxError()
+          }
+          const rawCount = input[cursor + 1]
+          if (!rawCount) throw new WrongNumberOfArgumentsError(ctx.commandName)
+          count = parseNonNegativeInteger(rawCount)
+          cursor += 2
+        }
+
+        if (cursor !== input.length) {
+          throw new WrongNumberOfArgumentsError(ctx.commandName)
+        }
+
+        return {
+          value: { subcommand: 'stream', key, full, count },
+          nextIndex: input.length,
+        }
+      }
+
+      if (subcommand === 'GROUPS') {
+        const key = input[index + 1]
+        if (!key || input.length !== index + 2) {
+          throw new WrongNumberOfArgumentsError(ctx.commandName)
+        }
+        return {
+          value: { subcommand: 'groups', key },
+          nextIndex: input.length,
+        }
+      }
+
+      if (subcommand === 'CONSUMERS') {
+        const key = input[index + 1]
+        const group = input[index + 2]
+        if (!key || !group || input.length !== index + 3) {
+          throw new WrongNumberOfArgumentsError(ctx.commandName)
+        }
+        return {
+          value: { subcommand: 'consumers', key, group },
+          nextIndex: input.length,
+        }
+      }
+
+      throw new RedisCommandError(
+        `unknown subcommand '${subcommand}'. Try XINFO HELP.`,
+      )
+    },
+  )
+}
+
+export const xinfoCommand = defineCommand({
+  name: 'xinfo',
+  schema: t.object({ args: createXinfoSchema() }),
+  flags: ['readonly'],
+  keys: args => [args.args.key],
+  execute: (args, ctx) => {
+    const command = args.args
+    const stream = ctx.db.getStream(command.key)
+    if (!stream) throw new NoSuchKeyError()
+
+    if (command.subcommand === 'stream') {
+      return array(streamInfoReply(stream, command.full, command.count))
+    }
+
+    if (command.subcommand === 'groups') {
+      return array(Array.from(stream.groups.values(), groupInfoReply(stream)))
+    }
+
+    const group = requireStreamGroup(stream, command.key, command.group)
+    const now = Date.now()
+    return array(
+      Array.from(group.consumers.entries()).map(([consumerId, consumer]) =>
+        consumerInfoReply(group, consumerId, consumer, now),
+      ),
+    )
+  },
+})
+
+function streamInfoReply(
+  stream: RedisStreamData,
+  full: boolean,
+  count: number | null,
+): RedisValue[] {
+  const firstEntry = stream.entries[0] ?? null
+  const lastEntry = stream.entries[stream.entries.length - 1] ?? null
+
+  const fields: RedisValue[] = [
+    bulkString('length'),
+    integerValue(stream.entries.length),
+    bulkString('radix-tree-keys'),
+    integerValue(stream.entries.length > 0 ? 1 : 0),
+    bulkString('radix-tree-nodes'),
+    integerValue(stream.entries.length > 0 ? 2 : 1),
+    bulkString('last-generated-id'),
+    streamIdValue(stream.lastId),
+    bulkString('max-deleted-entry-id'),
+    streamIdValue(stream.maxDeletedEntryId),
+    bulkString('entries-added'),
+    integerValue(stream.entriesAdded),
+    bulkString('recorded-first-entry-id'),
+    firstEntry ? streamIdValue(firstEntry.id) : bulkString('0-0'),
+    bulkString('groups'),
+  ]
+
+  if (!full) {
+    fields.push(
+      integerValue(stream.groups.size),
+      bulkString('first-entry'),
+      firstEntry ? entryToReply(firstEntry.id, firstEntry.fields) : nullBulk(),
+      bulkString('last-entry'),
+      lastEntry ? entryToReply(lastEntry.id, lastEntry.fields) : nullBulk(),
+    )
+    return fields
+  }
+
+  const entryLimit = count ?? stream.entries.length
+  fields.push(
+    RedisValue.array(
+      Array.from(stream.groups.values(), group =>
+        fullGroupInfoReply(stream, group),
+      ),
+    ),
+    bulkString('entries'),
+    RedisValue.array(
+      stream.entries
+        .slice(0, entryLimit)
+        .map(entry => entryToReply(entry.id, entry.fields)),
+    ),
+  )
+  return fields
+}
+
+function groupInfoReply(stream: RedisStreamData) {
+  return (group: RedisStreamConsumerGroup): RedisValue =>
+    RedisValue.array([
+      bulkString('name'),
+      bulkString(group.name),
+      bulkString('consumers'),
+      integerValue(group.consumers.size),
+      bulkString('pending'),
+      integerValue(group.pending.size),
+      bulkString('last-delivered-id'),
+      streamIdValue(group.lastDeliveredId),
+      bulkString('entries-read'),
+      group.entriesRead === null ? nullBulk() : integerValue(group.entriesRead),
+      bulkString('lag'),
+      integerValue(streamLag(stream, group)),
+    ])
+}
+
+function fullGroupInfoReply(
+  stream: RedisStreamData,
+  group: RedisStreamConsumerGroup,
+): RedisValue {
+  return RedisValue.array([
+    bulkString('name'),
+    bulkString(group.name),
+    bulkString('last-delivered-id'),
+    streamIdValue(group.lastDeliveredId),
+    bulkString('entries-read'),
+    group.entriesRead === null ? nullBulk() : integerValue(group.entriesRead),
+    bulkString('lag'),
+    integerValue(streamLag(stream, group)),
+    bulkString('pel-count'),
+    integerValue(group.pending.size),
+    bulkString('pending'),
+    RedisValue.array(
+      pendingEntriesSorted(group).map(pending =>
+        RedisValue.array([
+          streamIdValue(pending.id),
+          bulkString(
+            group.consumers.get(pending.consumerId)?.name ??
+              Buffer.from(pending.consumerId, 'hex'),
+          ),
+          integerValue(Math.max(0, Date.now() - pending.deliveredAt)),
+          integerValue(pending.deliveryCount),
+        ]),
+      ),
+    ),
+    bulkString('consumers'),
+    RedisValue.array(
+      Array.from(group.consumers.entries()).map(([consumerId, consumer]) =>
+        consumerInfoReply(group, consumerId, consumer, Date.now()),
+      ),
+    ),
+  ])
+}
+
+function consumerInfoReply(
+  group: RedisStreamConsumerGroup,
+  consumerId: string,
+  consumer: RedisStreamConsumer,
+  now: number,
+): RedisValue {
+  const idle = Math.max(0, now - consumer.seenAt)
+  const inactive =
+    consumer.activeAt === null ? idle : Math.max(0, now - consumer.activeAt)
+  return RedisValue.array([
+    bulkString('name'),
+    bulkString(consumer.name),
+    bulkString('pending'),
+    integerValue(consumerPendingCount(group, consumerId)),
+    bulkString('idle'),
+    integerValue(idle),
+    bulkString('inactive'),
+    integerValue(inactive),
+  ])
+}
+
+function parseNonNegativeInteger(token: Buffer): number {
+  const raw = token.toString()
+  if (!/^\d+$/.test(raw)) {
+    throw new ExpectedIntegerError()
+  }
+
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value)) {
+    throw new ExpectedIntegerError()
+  }
+
+  return value
+}
+
 // Optional `COUNT <n>` tail for XRANGE/XREVRANGE. Returns null when absent.
 function createCountSchema() {
   return t.custom<number | null>(
@@ -620,4 +1978,11 @@ export const streamsCommands = [
   xdelCommand,
   xtrimCommand,
   xreadCommand,
+  xgroupCommand,
+  xreadgroupCommand,
+  xackCommand,
+  xpendingCommand,
+  xclaimCommand,
+  xautoclaimCommand,
+  xinfoCommand,
 ]

--- a/src/state/data-types.ts
+++ b/src/state/data-types.ts
@@ -52,12 +52,36 @@ export type RedisStreamEntry = {
   fields: Buffer[]
 }
 
+export type RedisStreamConsumer = {
+  name: Buffer
+  seenAt: number
+  activeAt: number | null
+}
+
+export type RedisStreamPendingEntry = {
+  id: StreamId
+  consumerId: string
+  deliveredAt: number
+  deliveryCount: number
+}
+
+export type RedisStreamConsumerGroup = {
+  name: Buffer
+  lastDeliveredId: StreamId
+  entriesRead: number | null
+  consumers: Map<string, RedisStreamConsumer>
+  pending: Map<string, RedisStreamPendingEntry>
+}
+
 export type RedisStreamData = {
   type: 'stream'
   // Entries kept in ascending id order (append-only; ids are monotonic).
   entries: RedisStreamEntry[]
   // Highest id ever added; drives `*` / `ms-*` id generation. 0-0 when empty.
   lastId: StreamId
+  entriesAdded: number
+  maxDeletedEntryId: StreamId
+  groups: Map<string, RedisStreamConsumerGroup>
 }
 
 export type RedisDataValue =
@@ -121,6 +145,45 @@ export function cloneRedisDataValue(value: RedisDataValue): RedisDataValue {
           fields: entry.fields.map(part => Buffer.from(part)),
         })),
         lastId: { ms: value.lastId.ms, seq: value.lastId.seq },
+        entriesAdded: value.entriesAdded,
+        maxDeletedEntryId: {
+          ms: value.maxDeletedEntryId.ms,
+          seq: value.maxDeletedEntryId.seq,
+        },
+        groups: new Map(
+          Array.from(value.groups, ([id, group]) => [
+            id,
+            {
+              name: Buffer.from(group.name),
+              lastDeliveredId: {
+                ms: group.lastDeliveredId.ms,
+                seq: group.lastDeliveredId.seq,
+              },
+              entriesRead: group.entriesRead,
+              consumers: new Map(
+                Array.from(group.consumers, ([consumerId, consumer]) => [
+                  consumerId,
+                  {
+                    name: Buffer.from(consumer.name),
+                    seenAt: consumer.seenAt,
+                    activeAt: consumer.activeAt,
+                  },
+                ]),
+              ),
+              pending: new Map(
+                Array.from(group.pending, ([pendingId, pending]) => [
+                  pendingId,
+                  {
+                    id: { ms: pending.id.ms, seq: pending.id.seq },
+                    consumerId: pending.consumerId,
+                    deliveredAt: pending.deliveredAt,
+                    deliveryCount: pending.deliveryCount,
+                  },
+                ]),
+              ),
+            },
+          ]),
+        ),
       }
   }
 }
@@ -146,5 +209,12 @@ export function createSortedSetData(): RedisSortedSetData {
 }
 
 export function createStreamData(): RedisStreamData {
-  return { type: 'stream', entries: [], lastId: { ms: 0n, seq: 0n } }
+  return {
+    type: 'stream',
+    entries: [],
+    lastId: { ms: 0n, seq: 0n },
+    entriesAdded: 0,
+    maxDeletedEntryId: { ms: 0n, seq: 0n },
+    groups: new Map(),
+  }
 }

--- a/tests-integration/ioredis/stream-integration.test.ts
+++ b/tests-integration/ioredis/stream-integration.test.ts
@@ -708,6 +708,75 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
     }
   })
 
+  test('XREADGROUP history keeps deleted pending entries visible', async () => {
+    const key = randomKey()
+    const node = await connectToSlotOwner(redisClient!, key)
+    try {
+      await node.xadd(key, '1-1', 'f', '1')
+      await node.xadd(key, '2-2', 'f', '2')
+      await node.call('XGROUP', 'CREATE', key, 'workers', '0')
+      await node.call(
+        'XREADGROUP',
+        'GROUP',
+        'workers',
+        'alice',
+        'COUNT',
+        '10',
+        'STREAMS',
+        key,
+        '>',
+      )
+      assert.strictEqual(await node.xdel(key, '1-1'), 1)
+
+      assert.deepStrictEqual(
+        await node.call(
+          'XREADGROUP',
+          'GROUP',
+          'workers',
+          'alice',
+          'STREAMS',
+          key,
+          '0',
+        ),
+        [
+          [
+            key,
+            [
+              ['1-1', null],
+              ['2-2', ['f', '2']],
+            ],
+          ],
+        ],
+      )
+    } finally {
+      node.disconnect()
+    }
+  })
+
+  test('XREADGROUP history returns an empty per-key list for consumers with no pending entries', async () => {
+    const key = randomKey()
+    const node = await connectToSlotOwner(redisClient!, key)
+    try {
+      await node.xadd(key, '1-1', 'f', '1')
+      await node.call('XGROUP', 'CREATE', key, 'workers', '0')
+
+      assert.deepStrictEqual(
+        await node.call(
+          'XREADGROUP',
+          'GROUP',
+          'workers',
+          'alice',
+          'STREAMS',
+          key,
+          '0',
+        ),
+        [[key, []]],
+      )
+    } finally {
+      node.disconnect()
+    }
+  })
+
   test('XINFO reports stream, group, and consumer metadata', async () => {
     const key = randomKey()
     const node = await connectToSlotOwner(redisClient!, key)
@@ -761,6 +830,47 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
       assert.strictEqual(consumersInfo.length, 1)
       assert.strictEqual(kvArrayGet(consumersInfo[0], 'name'), 'alice')
       assert.strictEqual(kvArrayGet(consumersInfo[0], 'pending'), 1)
+    } finally {
+      node.disconnect()
+    }
+  })
+
+  test('XINFO STREAM FULL defaults to 10 stream entries and PEL rows', async () => {
+    const key = randomKey()
+    const node = await connectToSlotOwner(redisClient!, key)
+    try {
+      for (let i = 1; i <= 12; i++) {
+        await node.xadd(key, `${i}-0`, 'f', `${i}`)
+      }
+      await node.call('XGROUP', 'CREATE', key, 'workers', '0')
+      await node.call(
+        'XREADGROUP',
+        'GROUP',
+        'workers',
+        'alice',
+        'COUNT',
+        '12',
+        'STREAMS',
+        key,
+        '>',
+      )
+
+      const streamInfo = (await node.call(
+        'XINFO',
+        'STREAM',
+        key,
+        'FULL',
+      )) as unknown[]
+      const entries = kvArrayGet(streamInfo, 'entries') as unknown[][]
+      assert.strictEqual(entries.length, 10)
+      assert.strictEqual(entries[0][0], '1-0')
+      assert.strictEqual(entries[9][0], '10-0')
+
+      const groups = kvArrayGet(streamInfo, 'groups') as unknown[][]
+      const pending = kvArrayGet(groups[0], 'pending') as unknown[][]
+      assert.strictEqual(pending.length, 10)
+      assert.strictEqual(pending[0][0], '1-0')
+      assert.strictEqual(pending[9][0], '10-0')
     } finally {
       node.disconnect()
     }

--- a/tests-integration/ioredis/stream-integration.test.ts
+++ b/tests-integration/ioredis/stream-integration.test.ts
@@ -18,6 +18,12 @@ import {
 const testRunner = new TestRunner()
 const MAX_UINT64 = '18446744073709551615'
 
+function kvArrayGet(items: unknown[], key: string): unknown {
+  const index = items.indexOf(key)
+  assert.notStrictEqual(index, -1, `expected ${key} field`)
+  return items[index + 1]
+}
+
 describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
   let redisClient: Cluster | undefined
 
@@ -487,6 +493,324 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
       )) as [string, [string, string[]][]][]
       assert.ok(Array.isArray(result))
       assert.strictEqual(result.length, 2)
+    } finally {
+      node.disconnect()
+    }
+  })
+
+  // Stream consumer groups
+
+  test('XGROUP creates, mutates, and destroys consumer groups', async () => {
+    const key = randomKey()
+    const node = await connectToSlotOwner(redisClient!, key)
+    try {
+      await node.xadd(key, '1-0', 'f', '1')
+      await node.xadd(key, '2-0', 'f', '2')
+
+      assert.strictEqual(
+        await node.call('XGROUP', 'CREATE', key, 'workers', '0'),
+        'OK',
+      )
+      assert.strictEqual(
+        await node.call('XGROUP', 'CREATECONSUMER', key, 'workers', 'alice'),
+        1,
+      )
+      assert.strictEqual(
+        await node.call('XGROUP', 'CREATECONSUMER', key, 'workers', 'alice'),
+        0,
+      )
+
+      const read = (await node.call(
+        'XREADGROUP',
+        'GROUP',
+        'workers',
+        'alice',
+        'COUNT',
+        '2',
+        'STREAMS',
+        key,
+        '>',
+      )) as [string, [string, string[]][]][]
+      assert.deepStrictEqual(read, [
+        [
+          key,
+          [
+            ['1-0', ['f', '1']],
+            ['2-0', ['f', '2']],
+          ],
+        ],
+      ])
+
+      const pendingSummary = (await node.call(
+        'XPENDING',
+        key,
+        'workers',
+      )) as unknown[]
+      assert.strictEqual(pendingSummary[0], 2)
+      assert.strictEqual(pendingSummary[1], '1-0')
+      assert.strictEqual(pendingSummary[2], '2-0')
+      assert.ok(Array.isArray(pendingSummary[3]))
+
+      assert.strictEqual(await node.call('XACK', key, 'workers', '1-0'), 1)
+      const pendingDetails = (await node.call(
+        'XPENDING',
+        key,
+        'workers',
+        '-',
+        '+',
+        '10',
+      )) as unknown[][]
+      assert.strictEqual(pendingDetails.length, 1)
+      assert.strictEqual(pendingDetails[0][0], '2-0')
+      assert.strictEqual(pendingDetails[0][1], 'alice')
+      assert.strictEqual(pendingDetails[0][3], 1)
+
+      const consumers = (await node.call(
+        'XINFO',
+        'CONSUMERS',
+        key,
+        'workers',
+      )) as unknown[][]
+      const alice = consumers.find(item => kvArrayGet(item, 'name') === 'alice')
+      assert.ok(alice)
+      assert.strictEqual(kvArrayGet(alice, 'pending'), 1)
+
+      assert.strictEqual(
+        await node.call('XGROUP', 'DELCONSUMER', key, 'workers', 'alice'),
+        1,
+      )
+      assert.strictEqual(
+        await node.call('XGROUP', 'DESTROY', key, 'workers'),
+        1,
+      )
+      assert.strictEqual(
+        await node.call('XGROUP', 'DESTROY', key, 'workers'),
+        0,
+      )
+    } finally {
+      node.disconnect()
+    }
+  })
+
+  test('XGROUP MKSTREAM and SETID control group delivery position', async () => {
+    const key = randomKey()
+    const node = await connectToSlotOwner(redisClient!, key)
+    try {
+      assert.strictEqual(
+        await node.call('XGROUP', 'CREATE', key, 'workers', '$', 'MKSTREAM'),
+        'OK',
+      )
+      assert.strictEqual(await node.xlen(key), 0)
+
+      await node.xadd(key, '1-0', 'f', '1')
+      await node.xadd(key, '2-0', 'f', '2')
+      assert.deepStrictEqual(
+        await node.call(
+          'XREADGROUP',
+          'GROUP',
+          'workers',
+          'alice',
+          'STREAMS',
+          key,
+          '>',
+        ),
+        [
+          [
+            key,
+            [
+              ['1-0', ['f', '1']],
+              ['2-0', ['f', '2']],
+            ],
+          ],
+        ],
+      )
+
+      assert.strictEqual(
+        await node.call('XGROUP', 'SETID', key, 'workers', '$'),
+        'OK',
+      )
+      await node.xadd(key, '3-0', 'f', '3')
+      assert.deepStrictEqual(
+        await node.call(
+          'XREADGROUP',
+          'GROUP',
+          'workers',
+          'bob',
+          'STREAMS',
+          key,
+          '>',
+        ),
+        [[key, [['3-0', ['f', '3']]]]],
+      )
+    } finally {
+      node.disconnect()
+    }
+  })
+
+  test('XCLAIM and XAUTOCLAIM transfer pending stream entries', async () => {
+    const key = randomKey()
+    const node = await connectToSlotOwner(redisClient!, key)
+    try {
+      await node.xadd(key, '1-0', 'f', '1')
+      await node.xadd(key, '2-0', 'f', '2')
+      await node.call('XGROUP', 'CREATE', key, 'workers', '0')
+      await node.call(
+        'XREADGROUP',
+        'GROUP',
+        'workers',
+        'alice',
+        'COUNT',
+        '2',
+        'STREAMS',
+        key,
+        '>',
+      )
+
+      assert.deepStrictEqual(
+        await node.call('XCLAIM', key, 'workers', 'bob', '0', '1-0'),
+        [['1-0', ['f', '1']]],
+      )
+
+      const claimed = (await node.call(
+        'XAUTOCLAIM',
+        key,
+        'workers',
+        'carol',
+        '0',
+        '0-0',
+        'COUNT',
+        '10',
+      )) as [string, [string, string[]][], string[]]
+      assert.strictEqual(claimed[0], '0-0')
+      assert.deepStrictEqual(
+        claimed[1].map(entry => entry[0]),
+        ['1-0', '2-0'],
+      )
+      assert.deepStrictEqual(claimed[2], [])
+
+      const pendingDetails = (await node.call(
+        'XPENDING',
+        key,
+        'workers',
+        '-',
+        '+',
+        '10',
+      )) as unknown[][]
+      assert.deepStrictEqual(
+        pendingDetails.map(item => [item[0], item[1]]),
+        [
+          ['1-0', 'carol'],
+          ['2-0', 'carol'],
+        ],
+      )
+    } finally {
+      node.disconnect()
+    }
+  })
+
+  test('XINFO reports stream, group, and consumer metadata', async () => {
+    const key = randomKey()
+    const node = await connectToSlotOwner(redisClient!, key)
+    try {
+      await node.xadd(key, '1-0', 'f', '1')
+      await node.xadd(key, '2-0', 'f', '2')
+      await node.call('XGROUP', 'CREATE', key, 'workers', '0')
+      await node.call(
+        'XREADGROUP',
+        'GROUP',
+        'workers',
+        'alice',
+        'COUNT',
+        '1',
+        'STREAMS',
+        key,
+        '>',
+      )
+
+      const streamInfo = (await node.call(
+        'XINFO',
+        'STREAM',
+        key,
+        'FULL',
+        'COUNT',
+        '1',
+      )) as unknown[]
+      assert.strictEqual(kvArrayGet(streamInfo, 'length'), 2)
+      assert.strictEqual(kvArrayGet(streamInfo, 'last-generated-id'), '2-0')
+      assert.deepStrictEqual(kvArrayGet(streamInfo, 'entries'), [
+        ['1-0', ['f', '1']],
+      ])
+      assert.ok(Array.isArray(kvArrayGet(streamInfo, 'groups')))
+
+      const groupsInfo = (await node.call(
+        'XINFO',
+        'GROUPS',
+        key,
+      )) as unknown[][]
+      assert.strictEqual(groupsInfo.length, 1)
+      assert.strictEqual(kvArrayGet(groupsInfo[0], 'name'), 'workers')
+      assert.strictEqual(kvArrayGet(groupsInfo[0], 'consumers'), 1)
+      assert.strictEqual(kvArrayGet(groupsInfo[0], 'pending'), 1)
+
+      const consumersInfo = (await node.call(
+        'XINFO',
+        'CONSUMERS',
+        key,
+        'workers',
+      )) as unknown[][]
+      assert.strictEqual(consumersInfo.length, 1)
+      assert.strictEqual(kvArrayGet(consumersInfo[0], 'name'), 'alice')
+      assert.strictEqual(kvArrayGet(consumersInfo[0], 'pending'), 1)
+    } finally {
+      node.disconnect()
+    }
+  })
+
+  test('stream consumer group commands report Redis-compatible errors', async () => {
+    const tag = randomKey()
+    const key = `{${tag}}:stream`
+    const node = await connectToSlotOwner(redisClient!, key)
+    try {
+      await assert.rejects(
+        () => node.call('XGROUP', 'CREATE', key, 'workers', '0'),
+        errorWithMessage(
+          'ERR The XGROUP subcommand requires the key to exist. Note that for CREATE you may want to use the MKSTREAM option to create an empty stream automatically.',
+        ),
+      )
+
+      await node.xadd(key, '1-0', 'f', '1')
+      assert.strictEqual(
+        await node.call('XGROUP', 'CREATE', key, 'workers', '0'),
+        'OK',
+      )
+      await assert.rejects(
+        () => node.call('XGROUP', 'CREATE', key, 'workers', '0'),
+        errorWithMessage('BUSYGROUP Consumer Group name already exists'),
+      )
+      await assert.rejects(
+        () =>
+          node.call(
+            'XREADGROUP',
+            'GROUP',
+            'missing',
+            'alice',
+            'STREAMS',
+            key,
+            '>',
+          ),
+        errorWithMessage(
+          `NOGROUP No such key '${key}' or consumer group 'missing' in XREADGROUP with GROUP option`,
+        ),
+      )
+
+      const stringKey = `{${tag}}:string`
+      await node.set(stringKey, 'value')
+      await assert.rejects(
+        () => node.call('XINFO', 'GROUPS', stringKey),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
     } finally {
       node.disconnect()
     }


### PR DESCRIPTION
## Summary
- Add stream consumer-group state to `RedisStreamData`, including groups, consumers, pending entries, delivery counts, and stream metadata for `XINFO`.
- Implement `XGROUP`, `XREADGROUP`, `XACK`, `XPENDING`, `XCLAIM`, `XAUTOCLAIM`, and `XINFO STREAM|GROUPS|CONSUMERS` through the existing command executor pipeline.
- Add Redis-validated ioredis integration coverage for group lifecycle, delivery/acknowledgement, pending inspection, claim/autoclaim, introspection, and representative error paths.
- Update stream command documentation and architecture/guidance notes for the new state model.

## Root Cause
Issue #19 was caused by the stream data model only tracking entries and generated IDs; there was no durable consumer-group or pending-entry-list state for stream group commands to operate on.

## Validation
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/stream-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/stream-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint` (passes with existing `src/types/respjs.d.ts` no-explicit-any warning)

Fixes #19
