### PR TITLE
fix: centralize empty-collection cleanup in keyspace.update (#124)

### DIFF
--- a/src/state/keyspace.ts
+++ b/src/state/keyspace.ts
@@ -134,21 +134,37 @@ export class RedisKeyspace {
     createValue: () => TValue,
     mutator: (value: TValue) => TResult,
   ): TResult {
-    let entry = this.getLiveEntry(key)
+    const existing = this.getLiveEntry(key)
 
-    if (!entry) {
-      entry = {
-        key: Buffer.from(key),
-        value: createValue(),
-      }
-      this.entries.set(keyId(key), entry)
+    if (existing && existing.value.type !== expectedType) {
+      throw new WrongRedisTypeError(expectedType, existing.value.type)
     }
 
-    if (entry.value.type !== expectedType) {
-      throw new WrongRedisTypeError(expectedType, entry.value.type)
+    // For a new key, mutate a not-yet-committed entry: if the mutator throws,
+    // the keyspace is left untouched (no ghost empty collection persists).
+    const entry: KeyspaceEntry = existing ?? {
+      key: Buffer.from(key),
+      value: createValue(),
     }
 
     const result = mutator(entry.value as TValue)
+    const id = keyId(key)
+
+    // Centralized "delete the key when its collection is empty" rule, so each
+    // command no longer has to remember to clean up emptied hashes/lists/etc.
+    if (isEmptyCollection(entry.value)) {
+      if (existing) {
+        this.entries.delete(id)
+        this.mutations.emit({
+          type: 'delete',
+          database: this.database,
+          key: entry.key,
+        })
+      }
+      return result
+    }
+
+    this.entries.set(id, entry)
     this.emitWrite(entry)
     return result
   }
@@ -231,4 +247,23 @@ export class RedisKeyspace {
 
 function keyId(key: Buffer): string {
   return key.toString('hex')
+}
+
+// A collection-typed value is "empty" when it holds no elements; such keys are
+// deleted from the keyspace (matching real Redis). Strings are always a real
+// value (even ""), and empty streams persist (e.g. XGROUP CREATE MKSTREAM), so
+// neither is ever auto-deleted here.
+function isEmptyCollection(value: RedisDataValue): boolean {
+  switch (value.type) {
+    case 'hash':
+      return value.fields.size === 0
+    case 'list':
+      return value.values.length === 0
+    case 'set':
+    case 'zset':
+      return value.members.size === 0
+    case 'string':
+    case 'stream':
+      return false
+  }
 }

--- a/tests-integration/ioredis/keyspace-empty-cleanup.test.ts
+++ b/tests-integration/ioredis/keyspace-empty-cleanup.test.ts
@@ -1,0 +1,114 @@
+import { Cluster } from 'ioredis'
+import { after, before, describe, it } from 'node:test'
+import assert from 'node:assert'
+import { TestRunner } from '../test-config'
+
+const testRunner = new TestRunner()
+
+// Issue #124: the "delete a key when its collection becomes empty" and
+// "don't create a ghost key for a no-op mutation" rules used to live in each
+// command (HDEL/SREM/... pre-check existence and self-delete) rather than in
+// RedisKeyspace.update(). The root-cause fix centralizes both rules in
+// update(). These wire-level tests guard that the centralized behavior matches
+// real Redis end-to-end: no-op mutations on a missing key don't disturb a
+// WATCH, emptying a key removes it, and a real emptying still dirties a WATCH.
+// (The latent update() footguns themselves — ghost entry on mutator throw,
+// spurious write event — are covered directly in tests/keyspace-update.test.ts,
+// since every shipped command currently masks them.)
+describe('Empty-collection cleanup / no-op mutations (#124)', () => {
+  let redisClient: Cluster | undefined
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster()
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  it('no-op HDEL on a non-existent key must not invalidate a WATCH on that key', async () => {
+    const anotherClient = await testRunner.setupIoredisCluster()
+    const key = 'ghost:hdel'
+
+    try {
+      // Ensure the key does not exist.
+      await redisClient!.del(key)
+
+      // Watch the (non-existent) key.
+      await redisClient!.watch(key)
+
+      // No-op mutation from another client: HDEL on a missing key removes
+      // nothing and must not touch the keyspace.
+      assert.strictEqual(await anotherClient.hdel(key, 'field'), 0)
+
+      // The watched key never changed, so the transaction must run.
+      const multi = redisClient!.multi()
+      multi.set(key, 'value')
+      const result = await multi.exec()
+
+      assert.notStrictEqual(result, null)
+      assert.ok(Array.isArray(result))
+      assert.strictEqual(result![0][1], 'OK')
+    } finally {
+      await anotherClient.quit()
+    }
+  })
+
+  it('no-op SREM on a non-existent key must not invalidate a WATCH on that key', async () => {
+    const anotherClient = await testRunner.setupIoredisCluster()
+    const key = 'ghost:srem'
+
+    try {
+      await redisClient!.del(key)
+      await redisClient!.watch(key)
+
+      assert.strictEqual(await anotherClient.srem(key, 'member'), 0)
+
+      const multi = redisClient!.multi()
+      multi.set(key, 'value')
+      const result = await multi.exec()
+
+      assert.notStrictEqual(result, null)
+      assert.ok(Array.isArray(result))
+      assert.strictEqual(result![0][1], 'OK')
+    } finally {
+      await anotherClient.quit()
+    }
+  })
+
+  it('emptying a hash via HDEL deletes the key (no phantom empty hash persists)', async () => {
+    const key = 'cleanup:hash'
+
+    await redisClient!.del(key)
+    await redisClient!.hset(key, 'f', 'v')
+    assert.strictEqual(await redisClient!.exists(key), 1)
+
+    await redisClient!.hdel(key, 'f')
+
+    assert.strictEqual(await redisClient!.exists(key), 0)
+    assert.strictEqual(await redisClient!.type(key), 'none')
+  })
+
+  it('emptying an EXISTING watched collection still invalidates the WATCH', async () => {
+    const anotherClient = await testRunner.setupIoredisCluster()
+    const key = 'cleanup:watch:existing'
+
+    try {
+      await redisClient!.del(key)
+      await redisClient!.sadd(key, 'm') // key now exists as a set
+      await redisClient!.watch(key)
+
+      // Removing the last member empties (and thus deletes) the key — a real
+      // mutation that must still dirty the WATCH.
+      assert.strictEqual(await anotherClient.srem(key, 'm'), 1)
+
+      const multi = redisClient!.multi()
+      multi.set(key, 'value')
+      const result = await multi.exec()
+
+      assert.strictEqual(result, null)
+    } finally {
+      await anotherClient.quit()
+    }
+  })
+})

--- a/tests-integration/ioredis/keyspace-empty-cleanup.test.ts
+++ b/tests-integration/ioredis/keyspace-empty-cleanup.test.ts
@@ -1,5 +1,5 @@
 import { Cluster } from 'ioredis'
-import { after, before, describe, it } from 'node:test'
+import { after, before, describe, test } from 'node:test'
 import assert from 'node:assert'
 import { TestRunner } from '../test-config'
 
@@ -26,7 +26,7 @@ describe('Empty-collection cleanup / no-op mutations (#124)', () => {
     await testRunner.cleanup()
   })
 
-  it('no-op HDEL on a non-existent key must not invalidate a WATCH on that key', async () => {
+  test('no-op HDEL on a non-existent key must not invalidate a WATCH on that key', async () => {
     const anotherClient = await testRunner.setupIoredisCluster()
     const key = 'ghost:hdel'
 
@@ -54,7 +54,7 @@ describe('Empty-collection cleanup / no-op mutations (#124)', () => {
     }
   })
 
-  it('no-op SREM on a non-existent key must not invalidate a WATCH on that key', async () => {
+  test('no-op SREM on a non-existent key must not invalidate a WATCH on that key', async () => {
     const anotherClient = await testRunner.setupIoredisCluster()
     const key = 'ghost:srem'
 
@@ -76,7 +76,7 @@ describe('Empty-collection cleanup / no-op mutations (#124)', () => {
     }
   })
 
-  it('emptying a hash via HDEL deletes the key (no phantom empty hash persists)', async () => {
+  test('emptying a hash via HDEL deletes the key (no phantom empty hash persists)', async () => {
     const key = 'cleanup:hash'
 
     await redisClient!.del(key)
@@ -89,7 +89,7 @@ describe('Empty-collection cleanup / no-op mutations (#124)', () => {
     assert.strictEqual(await redisClient!.type(key), 'none')
   })
 
-  it('emptying an EXISTING watched collection still invalidates the WATCH', async () => {
+  test('emptying an EXISTING watched collection still invalidates the WATCH', async () => {
     const anotherClient = await testRunner.setupIoredisCluster()
     const key = 'cleanup:watch:existing'
 

--- a/tests/keyspace-update.test.ts
+++ b/tests/keyspace-update.test.ts
@@ -1,0 +1,120 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert'
+import { RedisKeyspace } from '../src/state/keyspace'
+import {
+  RedisMutationBus,
+  type RedisMutationEvent,
+} from '../src/state/mutation-events'
+import {
+  createHashData,
+  createSetData,
+  createStreamData,
+  createStringData,
+  type RedisHashData,
+  type RedisSetData,
+  type RedisStreamData,
+  type RedisStringData,
+} from '../src/state/data-types'
+
+function setup() {
+  const bus = new RedisMutationBus()
+  const events: RedisMutationEvent[] = []
+  bus.subscribe(event => events.push(event))
+  const keyspace = new RedisKeyspace(0, bus)
+  return { keyspace, events }
+}
+
+describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#124)', () => {
+  test('mutator throwing on a fresh key leaves no ghost entry and emits no event', () => {
+    const { keyspace, events } = setup()
+    const key = Buffer.from('h')
+
+    assert.throws(() => {
+      keyspace.update<RedisHashData, void>(key, 'hash', createHashData, () => {
+        throw new Error('boom')
+      })
+    }, /boom/)
+
+    assert.strictEqual(keyspace.get(key), null)
+    assert.strictEqual(keyspace.getType(key), null)
+    assert.strictEqual(events.length, 0)
+  })
+
+  test('a mutation that leaves a freshly-created collection empty creates no key and emits no event', () => {
+    const { keyspace, events } = setup()
+    const key = Buffer.from('h')
+
+    // e.g. HDEL on a non-existent key: there is nothing to remove, the
+    // collection stays empty, so the key must never appear.
+    keyspace.update<RedisHashData, void>(key, 'hash', createHashData, () => {})
+
+    assert.strictEqual(keyspace.get(key), null)
+    assert.strictEqual(keyspace.getType(key), null)
+    assert.strictEqual(events.length, 0)
+  })
+
+  test('emptying an existing collection deletes the key and emits a single delete event', () => {
+    const { keyspace, events } = setup()
+    const key = Buffer.from('h')
+
+    keyspace.update<RedisHashData, void>(key, 'hash', createHashData, hash => {
+      hash.fields.set('f', { field: Buffer.from('f'), value: Buffer.from('v') })
+    })
+    assert.strictEqual(keyspace.getType(key), 'hash')
+    events.length = 0
+
+    keyspace.update<RedisHashData, void>(key, 'hash', createHashData, hash => {
+      hash.fields.delete('f')
+    })
+
+    assert.strictEqual(keyspace.get(key), null)
+    assert.strictEqual(keyspace.getType(key), null)
+    assert.strictEqual(events.length, 1)
+    assert.strictEqual(events[0]!.type, 'delete')
+  })
+
+  test('a populating mutation emits a write event and keeps the key', () => {
+    const { keyspace, events } = setup()
+    const key = Buffer.from('s')
+
+    keyspace.update<RedisSetData, void>(key, 'set', createSetData, set => {
+      set.members.set('m', Buffer.from('m'))
+    })
+
+    assert.strictEqual(keyspace.getType(key), 'set')
+    assert.strictEqual(events.length, 1)
+    assert.strictEqual(events[0]!.type, 'write')
+  })
+
+  test('an empty string value is a real value and is never auto-deleted', () => {
+    const { keyspace } = setup()
+    const key = Buffer.from('str')
+
+    keyspace.update<RedisStringData, void>(
+      key,
+      'string',
+      () => createStringData(Buffer.alloc(0)),
+      str => {
+        str.value = Buffer.alloc(0)
+      },
+    )
+
+    assert.strictEqual(keyspace.getType(key), 'string')
+  })
+
+  test('an empty stream is preserved (matches real Redis keeping empty streams)', () => {
+    const { keyspace } = setup()
+    const key = Buffer.from('stream')
+
+    keyspace.update<RedisStreamData, void>(
+      key,
+      'stream',
+      createStreamData,
+      () => {
+        // Create the stream without adding entries (e.g. XGROUP CREATE MKSTREAM).
+      },
+    )
+
+    assert.strictEqual(keyspace.getType(key), 'stream')
+  })
+})

--- a/tests/keyspace-update.test.ts
+++ b/tests/keyspace-update.test.ts
@@ -7,11 +7,15 @@ import {
 } from '../src/state/mutation-events'
 import {
   createHashData,
+  createListData,
   createSetData,
+  createSortedSetData,
   createStreamData,
   createStringData,
   type RedisHashData,
+  type RedisListData,
   type RedisSetData,
+  type RedisSortedSetData,
   type RedisStreamData,
   type RedisStringData,
 } from '../src/state/data-types'
@@ -66,6 +70,58 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
     keyspace.update<RedisHashData, void>(key, 'hash', createHashData, hash => {
       hash.fields.delete('f')
     })
+
+    assert.strictEqual(keyspace.get(key), null)
+    assert.strictEqual(keyspace.getType(key), null)
+    assert.strictEqual(events.length, 1)
+    assert.strictEqual(events[0]!.type, 'delete')
+  })
+
+  test('emptying an existing list deletes the key and emits a single delete event', () => {
+    const { keyspace, events } = setup()
+    const key = Buffer.from('l')
+
+    keyspace.update<RedisListData, void>(key, 'list', createListData, list => {
+      list.values.push(Buffer.from('a'))
+    })
+    assert.strictEqual(keyspace.getType(key), 'list')
+    events.length = 0
+
+    // e.g. LTRIM that removes every element
+    keyspace.update<RedisListData, void>(key, 'list', createListData, list => {
+      list.values.length = 0
+    })
+
+    assert.strictEqual(keyspace.get(key), null)
+    assert.strictEqual(keyspace.getType(key), null)
+    assert.strictEqual(events.length, 1)
+    assert.strictEqual(events[0]!.type, 'delete')
+  })
+
+  test('emptying an existing zset deletes the key and emits a single delete event', () => {
+    const { keyspace, events } = setup()
+    const key = Buffer.from('z')
+
+    keyspace.update<RedisSortedSetData, void>(
+      key,
+      'zset',
+      createSortedSetData,
+      zset => {
+        zset.members.set('m', { member: Buffer.from('m'), score: 1 })
+      },
+    )
+    assert.strictEqual(keyspace.getType(key), 'zset')
+    events.length = 0
+
+    // e.g. ZREM that removes the last member
+    keyspace.update<RedisSortedSetData, void>(
+      key,
+      'zset',
+      createSortedSetData,
+      zset => {
+        zset.members.delete('m')
+      },
+    )
 
     assert.strictEqual(keyspace.get(key), null)
     assert.strictEqual(keyspace.getType(key), null)


### PR DESCRIPTION
## Summary
- `RedisKeyspace.update()` inserted a freshly-created entry into the keyspace **before** running the mutator and always emitted a `write` event. Two latent bugs:
  1. **Ghost on throw** — if the mutator threw, the empty collection from `createValue()` was already committed, leaving a key `EXISTS`/`TYPE`/`KEYS` could see, that `WATCH` never observed appearing.
  2. **No auto-delete of emptied collections** — every command had to remember to call `db.delete(key)` after emptying a hash/list/set/zset (HDEL, SREM, ZREM, LTRIM, ...). Scattered, inconsistent cleanup; root cause behind #38.
- Fix centralizes both rules in `update()`:
  - New keys mutate a **not-yet-committed** entry → a throwing mutator rolls back for free (no ghost).
  - After a successful mutation, if the collection is empty, delete the key and emit a single `delete` event.
  - Strings (`""` is a real value) and empty streams (`XGROUP CREATE MKSTREAM`) are never auto-deleted.
- Per-command self-delete calls become harmless no-ops (`db.delete` on an already-gone key returns false, emits nothing) — left in place to keep this change minimal.

Closes #124

## Test plan
- [x] `tests/keyspace-update.test.ts` (unit) reproduces both facets directly — red before the fix (every shipped command masks them at the wire level, so this is the meaningful repro), green after.
- [x] `tests-integration/ioredis/keyspace-empty-cleanup.test.ts` guards wire behavior end-to-end (no-op mutation on a missing key doesn't disturb a WATCH; emptying a key removes it; a real emptying still dirties a WATCH) — green on mock **and** real Redis.
- [x] `npm run build` + `npm run lint` clean.
- [x] `npm run test:all` passes — 132 unit / 262 mock / 262 real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)