### PR TITLE
fix: add SMISMEMBER command

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -208,6 +208,7 @@ with `GT` or `LT`.
 - [x] `SCARD key` - Get the number of members in a set
 - [x] `SMEMBERS key` - Get all members in a set
 - [x] `SISMEMBER key member` - Determine if a value is a member of a set
+- [x] `SMISMEMBER key member [member ...]` - Determine membership for multiple values
 - [x] `SPOP key [count]` - Remove and return one or more random members
 - [x] `SRANDMEMBER key [count]` - Get one or more random members without removing them
 - [x] `SMOVE source destination member` - Move a member between sets
@@ -218,7 +219,6 @@ with `GT` or `LT`.
 
 #### Not implemented
 
-- [ ] `SMISMEMBER key member [member ...]`
 - [ ] `SINTERCARD`
 
 ## 8. Sorted Set Commands

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -192,6 +192,7 @@ export {
   sinterCommand,
   sinterstoreCommand,
   sismemberCommand,
+  smismemberCommand,
   smembersCommand,
   smoveCommand,
   spopCommand,

--- a/src/commands/sets.ts
+++ b/src/commands/sets.ts
@@ -167,6 +167,26 @@ export const sismemberCommand = defineCommand({
 })
 
 // ---------------------------------------------------------------------------
+// SMISMEMBER key member [member ...]
+// ---------------------------------------------------------------------------
+
+export const smismemberCommand = defineCommand({
+  name: 'smismember',
+  schema: t.object({ key: t.key(), members: t.variadic(t.key(), { min: 1 }) }),
+  flags: ['readonly', 'fast'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const set = ctx.db.getSet(args.key)
+
+    return array(
+      args.members.map(member =>
+        RedisValue.integer(set?.members.has(member.toString('hex')) ? 1 : 0),
+      ),
+    )
+  },
+})
+
+// ---------------------------------------------------------------------------
 // SPOP key [count]
 // ---------------------------------------------------------------------------
 
@@ -458,6 +478,7 @@ export const setsCommands = [
   scardCommand,
   smembersCommand,
   sismemberCommand,
+  smismemberCommand,
   spopCommand,
   srandmemberCommand,
   sdiffCommand,

--- a/tests-integration/ioredis/set-commands-integration.test.ts
+++ b/tests-integration/ioredis/set-commands-integration.test.ts
@@ -1,8 +1,8 @@
 import { test, describe, before, after } from 'node:test'
 import assert from 'node:assert'
-import { Cluster } from 'ioredis'
+import { Cluster, Redis } from 'ioredis'
 import { TestRunner } from '../test-config'
-import { errorWithMessage, randomKey } from '../utils'
+import { connectToSlotOwner, errorWithMessage, randomKey } from '../utils'
 
 const testRunner = new TestRunner()
 
@@ -60,6 +60,62 @@ describe(`Set Commands Integration (${testRunner.getBackendName()})`, () => {
 
     const is2 = await redisClient?.sismember('set3', 'nonexistent')
     assert.strictEqual(is2, 0)
+  })
+
+  test('SMISMEMBER command matches Redis', async () => {
+    const tag = `{smismember:${randomKey()}}`
+    const setKey = `${tag}:set`
+    const missingKey = `${tag}:missing`
+    const stringKey = `${tag}:string`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, setKey)
+      await directClient.sadd(setKey, 'member1', 'member2')
+
+      const result = await directClient.call(
+        'SMISMEMBER',
+        setKey,
+        'member1',
+        'missing',
+        'member2',
+        'member1',
+      )
+      assert.deepStrictEqual(result, [1, 0, 1, 1])
+
+      const missing = await directClient.call(
+        'SMISMEMBER',
+        missingKey,
+        'member1',
+        'member2',
+      )
+      assert.deepStrictEqual(missing, [0, 0])
+
+      await directClient.set(stringKey, 'value')
+      await assert.rejects(
+        () => directClient?.call('SMISMEMBER', stringKey, 'member1'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+
+      await assert.rejects(
+        () => directClient?.call('SMISMEMBER'),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'smismember' command",
+        ),
+      )
+      await assert.rejects(
+        () => directClient?.call('SMISMEMBER', setKey),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'smismember' command",
+        ),
+      )
+    } finally {
+      await directClient?.del(setKey, missingKey, stringKey)
+      directClient?.disconnect()
+    }
   })
 
   test('SREM command', async () => {


### PR DESCRIPTION
## Summary

- Add `SMISMEMBER key member [member ...]` as a read-only set command.
- Cover Redis-compatible responses for existing members, missing members, duplicate requested members, missing keys, wrong types, and wrong arity.
- Mark `SMISMEMBER` as implemented in `docs/COMMANDS.md`.

## Root Cause

`SMISMEMBER` was listed as planned but had no command definition or registry export, so clients received an unknown-command error.

## Validation

- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test-name-pattern "SMISMEMBER" --test ./tests-integration/ioredis/set-commands-integration.test.ts`
- `npm run clean:redis && TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test-name-pattern "SMISMEMBER" --test ./tests-integration/ioredis/set-commands-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run clean:redis && npm run test:integration:real`
- `npm run lint` (passes with existing `src/types/respjs.d.ts` warning)

Fixes #114

Part of #27; #113 and #115 remain open.