### PR TITLE
feat: add ZRANGEBYLEX/ZREVRANGEBYLEX/ZLEXCOUNT/ZREMRANGEBYLEX (#105)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -233,6 +233,10 @@ with `GT` or `LT`.
 - [x] `ZRANGEBYSCORE key min max` - Return members with scores between min and max (`-inf`, `+inf`, and exclusive `(score` bounds supported)
 - [x] `ZREMRANGEBYSCORE key min max` - Remove members with scores between min and max (`-inf`, `+inf`, and exclusive `(score` bounds supported)
 - [x] `ZCOUNT key min max` - Count members with scores between min and max (`-inf`, `+inf`, and exclusive `(score` bounds supported)
+- [x] `ZRANGEBYLEX key min max [LIMIT offset count]` - Return members within a lexicographic range (`-`, `+`, and inclusive `[member`/exclusive `(member` bounds supported)
+- [x] `ZREVRANGEBYLEX key max min [LIMIT offset count]` - Return members within a lexicographic range, high to low
+- [x] `ZLEXCOUNT key min max` - Count members within a lexicographic range
+- [x] `ZREMRANGEBYLEX key min max` - Remove members within a lexicographic range
 - [x] `ZPOPMIN key [count]` - Remove and return members with the lowest scores
 - [x] `ZPOPMAX key [count]` - Remove and return members with the highest scores
 - [x] `ZSCAN key cursor [MATCH pattern] [COUNT count]` - Incrementally iterate members and scores (see [Scan Family](#10-scan-family))
@@ -246,7 +250,7 @@ with `GT` or `LT`.
 
 #### Not implemented
 
-- [ ] `ZRANGEBYLEX` / `ZREVRANGEBYSCORE` / `ZREVRANGEBYLEX` / `ZLEXCOUNT` / `ZREMRANGEBYRANK` / `ZREMRANGEBYLEX`
+- [ ] `ZREVRANGEBYSCORE` / `ZREMRANGEBYRANK`
 - [ ] `ZUNIONSTORE` / `ZINTERSTORE` / `ZDIFFSTORE` / `ZUNION` / `ZINTER` / `ZDIFF` / `ZINTERCARD`
 - [ ] `ZMSCORE` / `ZRANDMEMBER` / `ZRANGESTORE` / `ZMPOP` / `BZPOPMIN` / `BZPOPMAX` / `BZMPOP`
 

--- a/src/commands/zsets.ts
+++ b/src/commands/zsets.ts
@@ -2,8 +2,11 @@ import { defineCommand } from '../core/command-definition'
 import { t, type ParseContext } from '../core/command-schema'
 import {
   ExpectedFloatError,
+  ExpectedIntegerError,
+  InvalidLexRangeError,
   MinMaxNotFloatError,
   PositiveCountError,
+  RedisSyntaxError,
   ResultingScoreNaNError,
   WrongNumberOfArgumentsError,
   ZaddGtLtNxConflictError,
@@ -64,6 +67,118 @@ function scoreWithinBounds(score: number, min: ScoreBound, max: ScoreBound) {
   if (min.exclusive ? score <= min.value : score < min.value) return false
   if (max.exclusive ? score >= max.value : score > max.value) return false
   return true
+}
+
+// Lexicographic range bounds — used by ZRANGEBYLEX/ZREVRANGEBYLEX/ZLEXCOUNT/
+// ZREMRANGEBYLEX. All members are assumed to share the same score, so ordering
+// is by raw byte comparison (not localeCompare — see #41).
+type LexBound =
+  | { kind: 'min' } // `-` negative infinity
+  | { kind: 'max' } // `+` positive infinity
+  | { kind: 'value'; value: Buffer; exclusive: boolean }
+
+function parseLexBoundArg(token: Buffer): LexBound {
+  if (token.length === 1) {
+    if (token[0] === 0x2d /* - */) return { kind: 'min' }
+    if (token[0] === 0x2b /* + */) return { kind: 'max' }
+  }
+
+  const prefix = token[0]
+  if (prefix === 0x5b /* [ */) {
+    return { kind: 'value', value: token.subarray(1), exclusive: false }
+  }
+  if (prefix === 0x28 /* ( */) {
+    return { kind: 'value', value: token.subarray(1), exclusive: true }
+  }
+
+  throw new InvalidLexRangeError()
+}
+
+function lexMemberWithinBounds(
+  member: Buffer,
+  min: LexBound,
+  max: LexBound,
+): boolean {
+  if (min.kind === 'max') return false
+  if (min.kind === 'value') {
+    const cmp = Buffer.compare(member, min.value)
+    if (min.exclusive ? cmp <= 0 : cmp < 0) return false
+  }
+
+  if (max.kind === 'min') return false
+  if (max.kind === 'value') {
+    const cmp = Buffer.compare(member, max.value)
+    if (max.exclusive ? cmp >= 0 : cmp > 0) return false
+  }
+
+  return true
+}
+
+function getLexSortedMembers(zset: RedisSortedSetData): RedisSortedSetMember[] {
+  return Array.from(zset.members.values()).sort((a, b) =>
+    a.score !== b.score
+      ? a.score - b.score
+      : Buffer.compare(a.member, b.member),
+  )
+}
+
+type LexLimit = { offset: number; count: number }
+
+type LexRangeArgs = {
+  key: Buffer
+  first: Buffer
+  second: Buffer
+  limit?: LexLimit
+}
+
+function parseLexLimitInt(token: Buffer): number {
+  const raw = token.toString()
+  if (!/^-?\d+$/.test(raw)) throw new ExpectedIntegerError()
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value)) throw new ExpectedIntegerError()
+  return value
+}
+
+// ZRANGEBYLEX key min max [LIMIT offset count]
+// ZREVRANGEBYLEX key max min [LIMIT offset count] — caller maps first/second.
+function createLexRangeSchema() {
+  return t.custom<LexRangeArgs>((input, index, ctx) => {
+    const key = input[index]
+    const first = input[index + 1]
+    const second = input[index + 2]
+    if (!key || !first || !second) {
+      throw new WrongNumberOfArgumentsError(ctx.commandName)
+    }
+
+    let cursor = index + 3
+    let limit: LexLimit | undefined
+    if (cursor < input.length) {
+      if (input[cursor]!.toString().toUpperCase() !== 'LIMIT') {
+        throw new RedisSyntaxError()
+      }
+      const offsetTok = input[cursor + 1]
+      const countTok = input[cursor + 2]
+      if (!offsetTok || !countTok) throw new RedisSyntaxError()
+      limit = {
+        offset: parseLexLimitInt(offsetTok),
+        count: parseLexLimitInt(countTok),
+      }
+      cursor += 3
+      if (cursor < input.length) throw new RedisSyntaxError()
+    }
+
+    return { value: { key, first, second, limit }, nextIndex: cursor }
+  })
+}
+
+function applyLexLimit(
+  members: RedisSortedSetMember[],
+  limit: LexLimit | undefined,
+): RedisSortedSetMember[] {
+  if (!limit) return members
+  if (limit.offset < 0) return []
+  const end = limit.count < 0 ? members.length : limit.offset + limit.count
+  return members.slice(limit.offset, end)
 }
 
 function parsePopCountArg(s: string): number {
@@ -491,6 +606,88 @@ export const zcountCommand = defineCommand({
   },
 })
 
+export const zrangebylexCommand = defineCommand({
+  name: 'zrangebylex',
+  schema: createLexRangeSchema(),
+  flags: ['readonly'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const min = parseLexBoundArg(args.first)
+    const max = parseLexBoundArg(args.second)
+    const zset = ctx.db.getSortedSet(args.key)
+    if (!zset) return array([])
+    const matched = getLexSortedMembers(zset).filter(m =>
+      lexMemberWithinBounds(m.member, min, max),
+    )
+    const limited = applyLexLimit(matched, args.limit)
+    return array(limited.map(m => RedisValue.bulkString(m.member)))
+  },
+})
+
+export const zrevrangebylexCommand = defineCommand({
+  name: 'zrevrangebylex',
+  schema: createLexRangeSchema(),
+  flags: ['readonly'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    // ZREVRANGEBYLEX takes bounds as `max min`.
+    const max = parseLexBoundArg(args.first)
+    const min = parseLexBoundArg(args.second)
+    const zset = ctx.db.getSortedSet(args.key)
+    if (!zset) return array([])
+    const matched = getLexSortedMembers(zset)
+      .filter(m => lexMemberWithinBounds(m.member, min, max))
+      .reverse()
+    const limited = applyLexLimit(matched, args.limit)
+    return array(limited.map(m => RedisValue.bulkString(m.member)))
+  },
+})
+
+export const zlexcountCommand = defineCommand({
+  name: 'zlexcount',
+  schema: t.object({ key: t.key(), min: t.bulk(), max: t.bulk() }),
+  flags: ['readonly', 'fast'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const min = parseLexBoundArg(args.min)
+    const max = parseLexBoundArg(args.max)
+    const zset = ctx.db.getSortedSet(args.key)
+    if (!zset) return integer(0)
+    let count = 0
+    for (const entry of zset.members.values()) {
+      if (lexMemberWithinBounds(entry.member, min, max)) count++
+    }
+    return integer(count)
+  },
+})
+
+export const zremrangebylexCommand = defineCommand({
+  name: 'zremrangebylex',
+  schema: t.object({ key: t.key(), min: t.bulk(), max: t.bulk() }),
+  flags: ['write'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const min = parseLexBoundArg(args.min)
+    const max = parseLexBoundArg(args.max)
+    let removed = 0
+    ctx.db.updateSortedSet(args.key, zset => {
+      for (const [hex, entry] of zset.members) {
+        if (lexMemberWithinBounds(entry.member, min, max)) {
+          zset.members.delete(hex)
+          removed++
+        }
+      }
+    })
+    if (
+      removed > 0 &&
+      (ctx.db.getSortedSet(args.key)?.members.size ?? 0) === 0
+    ) {
+      ctx.db.delete(args.key)
+    }
+    return integer(removed)
+  },
+})
+
 export const zpopminCommand = defineCommand({
   name: 'zpopmin',
   schema: t.object({ key: t.key(), count: t.optional(zpopCountSchema()) }),
@@ -576,6 +773,10 @@ export const zsetsCommands = [
   zrangebyscoreCommand,
   zremrangebyscoreCommand,
   zcountCommand,
+  zrangebylexCommand,
+  zrevrangebylexCommand,
+  zlexcountCommand,
+  zremrangebylexCommand,
   zpopminCommand,
   zpopmaxCommand,
 ]

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -208,6 +208,12 @@ export class LimitCantBeNegativeError extends RedisCommandError {
   }
 }
 
+export class InvalidLexRangeError extends RedisCommandError {
+  constructor() {
+    super('min or max not valid string range item')
+  }
+}
+
 export class NoScriptError extends RedisCommandError {
   constructor() {
     super('No matching script. Please use EVAL.', 'NOSCRIPT')

--- a/tests-integration/ioredis/zset-lex-integration.test.ts
+++ b/tests-integration/ioredis/zset-lex-integration.test.ts
@@ -1,0 +1,277 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { errorWithMessage, randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+describe(`Sorted Set Lex Range Commands Integration (${testRunner.getBackendName()})`, () => {
+  let redisClient: Cluster | undefined
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster('zset-lex-integration')
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  async function seed(members: string[]): Promise<string> {
+    const key = `{lex:${randomKey()}}`
+    const args: (string | number)[] = []
+    for (const m of members) {
+      args.push(0, m)
+    }
+    await redisClient?.zadd(key, ...(args as [number, string]))
+    return key
+  }
+
+  test('ZRANGEBYLEX returns members within lex bounds', async () => {
+    const key = await seed(['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+    try {
+      assert.deepStrictEqual(await redisClient?.zrangebylex(key, '-', '+'), [
+        'a',
+        'b',
+        'c',
+        'd',
+        'e',
+        'f',
+        'g',
+      ])
+      // `[aaa` is inclusive of "aaa" which sorts after "a", so "a" is excluded
+      assert.deepStrictEqual(
+        await redisClient?.zrangebylex(key, '[aaa', '(g'),
+        ['b', 'c', 'd', 'e', 'f'],
+      )
+      assert.deepStrictEqual(await redisClient?.zrangebylex(key, '(b', '(f'), [
+        'c',
+        'd',
+        'e',
+      ])
+      assert.deepStrictEqual(await redisClient?.zrangebylex(key, '-', '[c'), [
+        'a',
+        'b',
+        'c',
+      ])
+      // min > max returns empty
+      assert.deepStrictEqual(await redisClient?.zrangebylex(key, '+', '-'), [])
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGEBYLEX honors LIMIT offset count', async () => {
+    const key = await seed(['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+    try {
+      assert.deepStrictEqual(
+        await redisClient?.zrangebylex(key, '-', '+', 'LIMIT', 2, 3),
+        ['c', 'd', 'e'],
+      )
+      // negative count returns all remaining from offset
+      assert.deepStrictEqual(
+        await redisClient?.zrangebylex(key, '-', '+', 'LIMIT', 2, -1),
+        ['c', 'd', 'e', 'f', 'g'],
+      )
+      // offset beyond length returns empty
+      assert.deepStrictEqual(
+        await redisClient?.zrangebylex(key, '-', '+', 'LIMIT', 10, 3),
+        [],
+      )
+      // count 0 returns empty
+      assert.deepStrictEqual(
+        await redisClient?.zrangebylex(key, '-', '+', 'LIMIT', 0, 0),
+        [],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZREVRANGEBYLEX returns members in reverse lex order (max then min)', async () => {
+    const key = await seed(['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+    try {
+      assert.deepStrictEqual(await redisClient?.zrevrangebylex(key, '+', '-'), [
+        'g',
+        'f',
+        'e',
+        'd',
+        'c',
+        'b',
+        'a',
+      ])
+      assert.deepStrictEqual(
+        await redisClient?.zrevrangebylex(key, '[c', '-'),
+        ['c', 'b', 'a'],
+      )
+      assert.deepStrictEqual(
+        await redisClient?.zrevrangebylex(key, '+', '-', 'LIMIT', 1, 2),
+        ['f', 'e'],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZLEXCOUNT counts members within lex bounds', async () => {
+    const key = await seed(['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+    try {
+      assert.strictEqual(await redisClient?.zlexcount(key, '-', '+'), 7)
+      assert.strictEqual(await redisClient?.zlexcount(key, '(b', '[d'), 2)
+      assert.strictEqual(await redisClient?.zlexcount(key, '[z', '+'), 0)
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZREMRANGEBYLEX removes members within lex bounds and returns count', async () => {
+    const key = await seed(['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+    try {
+      assert.strictEqual(await redisClient?.zremrangebylex(key, '(b', '[d'), 2)
+      assert.deepStrictEqual(await redisClient?.zrangebylex(key, '-', '+'), [
+        'a',
+        'b',
+        'e',
+        'f',
+        'g',
+      ])
+      // removing all remaining members deletes the key
+      assert.strictEqual(await redisClient?.zremrangebylex(key, '-', '+'), 5)
+      assert.strictEqual(await redisClient?.exists(key), 0)
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('lex ordering uses raw byte comparison, not locale', async () => {
+    const key = await seed(['B', 'a', 'A', 'b'])
+    try {
+      // raw byte order: 'A'(65) 'B'(66) 'a'(97) 'b'(98)
+      assert.deepStrictEqual(await redisClient?.zrangebylex(key, '-', '+'), [
+        'A',
+        'B',
+        'a',
+        'b',
+      ])
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('lex commands on a missing key return empty/zero', async () => {
+    const key = `{lex:${randomKey()}}`
+    assert.deepStrictEqual(await redisClient?.zrangebylex(key, '-', '+'), [])
+    assert.deepStrictEqual(await redisClient?.zrevrangebylex(key, '+', '-'), [])
+    assert.strictEqual(await redisClient?.zlexcount(key, '-', '+'), 0)
+    assert.strictEqual(await redisClient?.zremrangebylex(key, '-', '+'), 0)
+  })
+
+  test('invalid lex bound returns "not valid string range item" error', async () => {
+    const key = await seed(['a', 'b', 'c'])
+    const msg = 'ERR min or max not valid string range item'
+    try {
+      await assert.rejects(
+        () => redisClient?.zrangebylex(key, 'g', '+'),
+        errorWithMessage(msg),
+      )
+      await assert.rejects(
+        () => redisClient?.zrangebylex(key, '-', 'g'),
+        errorWithMessage(msg),
+      )
+      await assert.rejects(
+        () => redisClient?.zrangebylex(key, '', '+'),
+        errorWithMessage(msg),
+      )
+      await assert.rejects(
+        () => redisClient?.zrevrangebylex(key, 'g', '-'),
+        errorWithMessage(msg),
+      )
+      await assert.rejects(
+        () => redisClient?.zlexcount(key, 'g', '+'),
+        errorWithMessage(msg),
+      )
+      await assert.rejects(
+        () => redisClient?.zremrangebylex(key, 'g', '+'),
+        errorWithMessage(msg),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('lex commands on a wrong-type key return WRONGTYPE', async () => {
+    const key = `{lex:${randomKey()}}`
+    await redisClient?.set(key, 'notazset')
+    const msg =
+      'WRONGTYPE Operation against a key holding the wrong kind of value'
+    try {
+      await assert.rejects(
+        () => redisClient?.zrangebylex(key, '-', '+'),
+        errorWithMessage(msg),
+      )
+      await assert.rejects(
+        () => redisClient?.zrevrangebylex(key, '+', '-'),
+        errorWithMessage(msg),
+      )
+      await assert.rejects(
+        () => redisClient?.zlexcount(key, '-', '+'),
+        errorWithMessage(msg),
+      )
+      await assert.rejects(
+        () => redisClient?.zremrangebylex(key, '-', '+'),
+        errorWithMessage(msg),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('lex commands reject wrong arity', async () => {
+    const key = await seed(['a', 'b', 'c'])
+    try {
+      await assert.rejects(
+        () => redisClient?.call('zrangebylex', key, '-'),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'zrangebylex' command",
+        ),
+      )
+      // ZLEXCOUNT does not accept LIMIT
+      await assert.rejects(
+        () => redisClient?.call('zlexcount', key, '-', '+', 'LIMIT', '0', '1'),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'zlexcount' command",
+        ),
+      )
+      await assert.rejects(
+        () => redisClient?.call('zremrangebylex', key, '-', '+', 'extra'),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'zremrangebylex' command",
+        ),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGEBYLEX validates LIMIT clause', async () => {
+    const key = await seed(['a', 'b', 'c'])
+    try {
+      await assert.rejects(
+        () =>
+          redisClient?.call('zrangebylex', key, '-', '+', 'LIMIT', 'x', 'y'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.call('zrangebylex', key, '-', '+', 'LIMIX', '0', '1'),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => redisClient?.call('zrangebylex', key, '-', '+', 'LIMIT', '0'),
+        errorWithMessage('ERR syntax error'),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Implements the four sorted-set lexicographic range commands (issue #105): `ZRANGEBYLEX`, `ZREVRANGEBYLEX`, `ZLEXCOUNT`, `ZREMRANGEBYLEX` — previously unimplemented.
- Lex bound syntax: `-`/`+` (neg/pos infinity), inclusive `[member`, exclusive `(member`; invalid bound → `ERR min or max not valid string range item` (new `InvalidLexRangeError`).
- Ordering uses **raw byte comparison** (`Buffer.compare`), not `localeCompare` — per #41.
- `ZRANGEBYLEX`/`ZREVRANGEBYLEX` support `LIMIT offset count` (negative count = all remaining; offset beyond length / count 0 = empty).
- Bound parsing runs **before** the key lookup, so an invalid bound on a wrong-type key returns the bound error rather than `WRONGTYPE`, matching real Redis. Removing all members deletes the key.
- All behaviors verified against real Redis 7.x (standalone :6399) before asserting.

Closes #105

## Test plan
- [x] New test `tests-integration/ioredis/zset-lex-integration.test.ts` (11 cases) reproduces the gap — red on mock before the fix (11/11 fail, commands missing)
- [x] Test passes against real Redis (mock-only gap confirmed)
- [x] Fix makes the test pass on mock too (11/11)
- [x] Covers error/edge paths: invalid bounds, WRONGTYPE, wrong arity, LIMIT validation (non-integer / bad keyword / missing count), byte-order ordering, missing key, key auto-delete
- [x] `npm run build` + `npm run lint` clean
- [x] `npm run test:all` passes (unit 137, mock 297, real 297)