### PR TITLE
feat: implement BLMOVE blocking list move command (#111)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -211,11 +211,11 @@ with `GT` or `LT`.
 - [x] `LPOS key element [RANK rank] [COUNT count] [MAXLEN maxlen]` - Return the index(es) of matching elements
 - [x] `BLPOP key [key ...] timeout` - Blocking left pop
 - [x] `BRPOP key [key ...] timeout` - Blocking right pop
+- [x] `BLMOVE source destination LEFT | RIGHT LEFT | RIGHT timeout` - Blocking variant of `LMOVE`
 
 #### Not implemented
 
 - [ ] `LINSERT`
-- [ ] `BLMOVE`
 - [ ] `LMPOP` / `BLMPOP`
 
 ## 7. Set Commands

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -144,6 +144,7 @@ export {
 } from './scan'
 export {
   listsCommands,
+  blmoveCommand,
   blpopCommand,
   brpopCommand,
   lindexCommand,

--- a/src/commands/lists.ts
+++ b/src/commands/lists.ts
@@ -11,6 +11,8 @@ import {
   NoSuchKeyError,
   PositiveCountError,
   RedisSyntaxError,
+  TimeoutNegativeError,
+  TimeoutNotFloatError,
   WrongNumberOfArgumentsError,
 } from '../core/redis-error'
 import type { RedisExecutionContext } from '../core/redis-context'
@@ -464,6 +466,38 @@ function moveDirection(): ReturnType<typeof t.custom<'left' | 'right'>> {
   })
 }
 
+// Non-blocking LMOVE core. Returns a bulk-string result on success, or `null`
+// when the source is empty/missing (the caller decides whether to block).
+function tryListMove(
+  source: Buffer,
+  destination: Buffer,
+  fromDirection: 'left' | 'right',
+  toDirection: 'left' | 'right',
+  db: RedisDatabase,
+): RedisResult | null {
+  const sourceList = db.getList(source)
+  if (!sourceList || sourceList.values.length === 0) return null
+
+  // Validate destination type before mutating the source
+  db.getList(destination)
+
+  const popped = db.updateList(source, list => {
+    const value =
+      (fromDirection === 'left' ? list.values.shift() : list.values.pop()) ??
+      null
+    return { value, empty: list.values.length === 0 }
+  })
+  if (popped.empty) db.delete(source)
+  if (popped.value === null) return null
+
+  db.updateList(destination, list => {
+    if (toDirection === 'left') list.values.unshift(popped.value!)
+    else list.values.push(popped.value!)
+  })
+
+  return bulk(popped.value)
+}
+
 export const lmoveCommand = defineCommand({
   name: 'lmove',
   schema: t.object({
@@ -474,30 +508,14 @@ export const lmoveCommand = defineCommand({
   }),
   flags: ['write', 'denyoom'],
   keys: args => [args.source, args.destination],
-  execute: (args, ctx) => {
-    const sourceList = ctx.db.getList(args.source)
-    if (!sourceList || sourceList.values.length === 0) return bulk(null)
-
-    // Validate destination type before mutating the source
-    ctx.db.getList(args.destination)
-
-    const popped = ctx.db.updateList(args.source, list => {
-      const value =
-        (args.fromDirection === 'left'
-          ? list.values.shift()
-          : list.values.pop()) ?? null
-      return { value, empty: list.values.length === 0 }
-    })
-    if (popped.empty) ctx.db.delete(args.source)
-    if (popped.value === null) return bulk(null)
-
-    ctx.db.updateList(args.destination, list => {
-      if (args.toDirection === 'left') list.values.unshift(popped.value!)
-      else list.values.push(popped.value!)
-    })
-
-    return bulk(popped.value)
-  },
+  execute: (args, ctx) =>
+    tryListMove(
+      args.source,
+      args.destination,
+      args.fromDirection,
+      args.toDirection,
+      ctx.db,
+    ) ?? bulk(null),
 })
 
 function tryListPop(
@@ -612,6 +630,123 @@ export const brpopCommand = defineCommand({
   },
 })
 
+function parseMoveDirection(token: Buffer | undefined): 'left' | 'right' {
+  if (!token) throw new RedisSyntaxError()
+  const direction = token.toString().toUpperCase()
+  if (direction === 'LEFT') return 'left'
+  if (direction === 'RIGHT') return 'right'
+  throw new RedisSyntaxError()
+}
+
+function parseTimeout(token: Buffer): number {
+  const value = Number(token.toString())
+  if (isNaN(value)) throw new TimeoutNotFloatError()
+  if (value < 0) throw new TimeoutNegativeError()
+  return value
+}
+
+async function blockingListMove(
+  source: Buffer,
+  destination: Buffer,
+  fromDirection: 'left' | 'right',
+  toDirection: 'left' | 'right',
+  timeoutSecs: number,
+  ctx: RedisExecutionContext,
+): Promise<RedisResult> {
+  const timeoutMs =
+    timeoutSecs === 0 ? undefined : Math.ceil(timeoutSecs * 1000)
+  const deadline = timeoutMs !== undefined ? Date.now() + timeoutMs : undefined
+
+  while (true) {
+    const remaining =
+      deadline !== undefined ? Math.max(0, deadline - Date.now()) : undefined
+    // BLMOVE/BRPOPLPUSH reply with a null array (`*-1`) on timeout, unlike the
+    // bulk-string reply on success.
+    if (remaining === 0) return RedisResult.create(RedisValue.nullArray())
+
+    let wake!: (v: true) => void
+    const waitFor = new Promise<true>(resolve => {
+      wake = () => resolve(true)
+    })
+
+    const unsub = ctx.db.subscribeKey(source, event => {
+      if (event.type === 'write') wake(true)
+    })
+
+    let woken: boolean | null
+    try {
+      woken = await ctx.park({
+        waitFor,
+        timeoutMs: remaining,
+        signal: ctx.signal,
+      })
+    } finally {
+      try {
+        unsub()
+      } catch {
+        // ignore unsubscribe errors so cleanup always completes
+      }
+    }
+
+    if (woken === null) return RedisResult.create(RedisValue.nullArray())
+
+    const result = tryListMove(
+      source,
+      destination,
+      fromDirection,
+      toDirection,
+      ctx.db,
+    )
+    if (result) return result
+  }
+}
+
+type BlmoveArgs = {
+  source: Buffer
+  destination: Buffer
+  fromDirection: 'left' | 'right'
+  toDirection: 'left' | 'right'
+  timeout: number
+}
+
+export const blmoveCommand = defineCommand({
+  name: 'blmove',
+  schema: t.custom<BlmoveArgs>((input, index, ctx) => {
+    if (input.length - index !== 5) {
+      throw new WrongNumberOfArgumentsError(ctx.commandName)
+    }
+    const source = input[index]
+    const destination = input[index + 1]
+    const fromDirection = parseMoveDirection(input[index + 2])
+    const toDirection = parseMoveDirection(input[index + 3])
+    const timeout = parseTimeout(input[index + 4])
+    return {
+      value: { source, destination, fromDirection, toDirection, timeout },
+      nextIndex: input.length,
+    }
+  }),
+  flags: ['write', 'noscript'],
+  keys: args => [args.source, args.destination],
+  execute: (args, ctx) => {
+    const immediate = tryListMove(
+      args.source,
+      args.destination,
+      args.fromDirection,
+      args.toDirection,
+      ctx.db,
+    )
+    if (immediate) return immediate
+    return blockingListMove(
+      args.source,
+      args.destination,
+      args.fromDirection,
+      args.toDirection,
+      args.timeout,
+      ctx,
+    )
+  },
+})
+
 export const listsCommands = [
   lpushCommand,
   rpushCommand,
@@ -628,6 +763,7 @@ export const listsCommands = [
   rpoplpushCommand,
   lposCommand,
   lmoveCommand,
+  blmoveCommand,
   blpopCommand,
   brpopCommand,
 ]

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -93,6 +93,18 @@ export class LposMaxlenNegativeError extends RedisCommandError {
   }
 }
 
+export class TimeoutNotFloatError extends RedisCommandError {
+  constructor() {
+    super('timeout is not a float or out of range')
+  }
+}
+
+export class TimeoutNegativeError extends RedisCommandError {
+  constructor() {
+    super('timeout is negative')
+  }
+}
+
 export class ZaddNxXxConflictError extends RedisCommandError {
   constructor() {
     super('XX and NX options at the same time are not compatible')

--- a/tests-integration/ioredis/blmove-integration.test.ts
+++ b/tests-integration/ioredis/blmove-integration.test.ts
@@ -1,0 +1,151 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { errorWithMessage, randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+// Give a blocking command time to park before the waker fires.
+function waitForPark(ms = 80): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe(`BLMOVE Integration (${testRunner.getBackendName()})`, () => {
+  let client1: Cluster | undefined
+  let client2: Cluster | undefined
+
+  before(async () => {
+    // No keyPrefix so raw key names round-trip; randomKey() isolates per test.
+    client1 = await testRunner.setupIoredisCluster()
+    client2 = await testRunner.setupIoredisCluster()
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  test('BLMOVE returns immediately when source is non-empty', async () => {
+    const tag = `{${randomKey()}}`
+    const src = `${tag}:src`
+    const dst = `${tag}:dst`
+
+    await client1!.del(src, dst)
+    await client1!.rpush(src, 'a', 'b', 'c') // [a,b,c]
+
+    // pop LEFT of src ('a'), push RIGHT of dst
+    assert.strictEqual(
+      await client1!.call('BLMOVE', src, dst, 'LEFT', 'RIGHT', '1'),
+      'a',
+    )
+    assert.deepStrictEqual(await client1!.lrange(src, 0, -1), ['b', 'c'])
+    assert.deepStrictEqual(await client1!.lrange(dst, 0, -1), ['a'])
+
+    // pop RIGHT of src ('c'), push LEFT of dst
+    assert.strictEqual(
+      await client1!.call('BLMOVE', src, dst, 'RIGHT', 'LEFT', '1'),
+      'c',
+    )
+    assert.deepStrictEqual(await client1!.lrange(src, 0, -1), ['b'])
+    assert.deepStrictEqual(await client1!.lrange(dst, 0, -1), ['c', 'a'])
+  })
+
+  test('BLMOVE blocks then returns when a push arrives on source', async () => {
+    const tag = `{${randomKey()}}`
+    const src = `${tag}:src`
+    const dst = `${tag}:dst`
+    await client1!.del(src, dst)
+
+    const blockPromise = client1!.call('BLMOVE', src, dst, 'LEFT', 'RIGHT', '5')
+    await waitForPark()
+    await client2!.rpush(src, 'world')
+
+    assert.strictEqual(await blockPromise, 'world')
+    assert.deepStrictEqual(await client1!.lrange(dst, 0, -1), ['world'])
+    assert.strictEqual(await client1!.exists(src), 0)
+  })
+
+  test('BLMOVE timeout returns null', async () => {
+    const tag = `{${randomKey()}}`
+    const src = `${tag}:src`
+    const dst = `${tag}:dst`
+    await client1!.del(src, dst)
+
+    const result = await client1!.call(
+      'BLMOVE',
+      src,
+      dst,
+      'LEFT',
+      'RIGHT',
+      '0.1',
+    )
+    assert.strictEqual(result, null)
+    // timed-out BLMOVE must not create the destination
+    assert.strictEqual(await client1!.exists(dst), 0)
+  })
+
+  test('BLMOVE rotates a list onto itself', async () => {
+    const tag = `{${randomKey()}}`
+    const key = `${tag}:list`
+    await client1!.del(key)
+    await client1!.rpush(key, '1', '2', '3')
+
+    // pop RIGHT ('3'), push LEFT -> [3,1,2]
+    assert.strictEqual(
+      await client1!.call('BLMOVE', key, key, 'RIGHT', 'LEFT', '1'),
+      '3',
+    )
+    assert.deepStrictEqual(await client1!.lrange(key, 0, -1), ['3', '1', '2'])
+  })
+
+  test('BLMOVE error paths match Redis', async () => {
+    const tag = `{${randomKey()}}`
+    const src = `${tag}:src`
+    const dst = `${tag}:dst`
+    const stringKey = `${tag}:string`
+    await client1!.del(src, dst, stringKey)
+    await client1!.rpush(src, 'x')
+
+    // invalid direction keyword -> syntax error
+    await assert.rejects(
+      () => client1!.call('BLMOVE', src, dst, 'UP', 'LEFT', '1'),
+      errorWithMessage('ERR syntax error'),
+    )
+
+    // too few arguments
+    await assert.rejects(
+      () => client1!.call('BLMOVE', src, dst, 'LEFT', 'RIGHT'),
+      errorWithMessage("ERR wrong number of arguments for 'blmove' command"),
+    )
+
+    // negative timeout
+    await assert.rejects(
+      () => client1!.call('BLMOVE', src, dst, 'LEFT', 'RIGHT', '-1'),
+      errorWithMessage('ERR timeout is negative'),
+    )
+
+    // non-float timeout
+    await assert.rejects(
+      () => client1!.call('BLMOVE', src, dst, 'LEFT', 'RIGHT', 'abc'),
+      errorWithMessage('ERR timeout is not a float or out of range'),
+    )
+
+    // wrong type source
+    await client1!.set(stringKey, 'value')
+    await assert.rejects(
+      () => client1!.call('BLMOVE', stringKey, dst, 'LEFT', 'RIGHT', '1'),
+      errorWithMessage(
+        'WRONGTYPE Operation against a key holding the wrong kind of value',
+      ),
+    )
+
+    // wrong type destination -> source left unchanged
+    await assert.rejects(
+      () => client1!.call('BLMOVE', src, stringKey, 'LEFT', 'RIGHT', '1'),
+      errorWithMessage(
+        'WRONGTYPE Operation against a key holding the wrong kind of value',
+      ),
+    )
+    assert.deepStrictEqual(await client1!.lrange(src, 0, -1), ['x'])
+  })
+})


### PR DESCRIPTION
## Summary
- Implements **BLMOVE** `source destination LEFT|RIGHT LEFT|RIGHT timeout` — the blocking variant of `LMOVE` (was the only remaining unimplemented child of #26 besides LMPOP/BLMPOP).
- Tries a non-blocking move first; when the source is empty it parks on the source key (`ctx.park` + `subscribeKey`) and retries on wake, mirroring the existing `BLPOP`/`BRPOP` pattern.
- **Non-obvious semantics matched against real Redis:** BLMOVE replies with a **null array** (`*-1`) on timeout — the same quirk as `BRPOPLPUSH` — even though the success reply is a bulk string. Verified against a real `redis-server`.
- Extracted a shared `tryListMove()` helper and refactored synchronous `LMOVE` onto it (behavior unchanged).
- Added `TimeoutNotFloatError` / `TimeoutNegativeError` so BLMOVE's timeout parsing returns the exact Redis errors (`ERR timeout is not a float or out of range`, `ERR timeout is negative`).
- Destination type is validated before the source is mutated (WRONGTYPE leaves the source untouched), matching real Redis.
- Marked BLMOVE as implemented in `docs/COMMANDS.md`.

Closes #111

## Test plan
- [x] New `tests-integration/ioredis/blmove-integration.test.ts` reproduces the gap (red on mock before fix: 5/5 fail — unknown command)
- [x] Tests pass against real Redis before the fix (mock-only gap confirmed)
- [x] Fix makes the suite green on mock too
- [x] Covers: immediate move, block-then-wake on push, timeout → null (no dest created), self-rotation, and error paths (arity, bad direction, negative/non-float timeout, WRONGTYPE source & dest)
- [x] `npm run build`, `npm run lint` clean
- [x] `npm run test:all` passes (unit 145, mock integ 319, real integ 319)