### PR TITLE
Fix integer token leading-zero parsing

### DIFF
--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from '../core/command-definition'
-import { t, type ParseContext } from '../core/command-schema'
+import { isIntegerToken, t, type ParseContext } from '../core/command-schema'
 import {
   HashValueNotFloatError,
   HashValueNotIntegerError,
@@ -326,7 +326,7 @@ export const hincrbyCommand = defineCommand({
       let current = 0
       if (entry) {
         const raw = entry.value.toString()
-        if (!/^-?\d+$/.test(raw) || !Number.isSafeInteger(Number(raw))) {
+        if (!isIntegerToken(raw) || !Number.isSafeInteger(Number(raw))) {
           throw new HashValueNotIntegerError()
         }
         current = Number(raw)

--- a/src/commands/helpers.ts
+++ b/src/commands/helpers.ts
@@ -1,5 +1,6 @@
 import { RedisValue } from '../core/redis-value'
 import { RedisResult } from '../core/redis-result'
+import { isIntegerToken } from '../core/command-schema'
 import {
   ExpectedIntegerError,
   InvalidExpireTimeError,
@@ -66,7 +67,7 @@ export function ttlMilliseconds(expiresAt: number): number {
 
 export function parseIntegerToken(token: Buffer): number {
   const raw = token.toString()
-  if (!/^-?\d+$/.test(raw)) {
+  if (!isIntegerToken(raw)) {
     throw new ExpectedIntegerError()
   }
 

--- a/src/core/command-schema.ts
+++ b/src/core/command-schema.ts
@@ -32,6 +32,8 @@ type InferShape<TShape extends SchemaShape> = {
   [K in keyof TShape]: InferSchema<TShape[K]>
 }
 
+const INTEGER_TOKEN_PATTERN = /^(0|-?[1-9]\d*)$/
+
 class MissingInputError extends Error {
   constructor() {
     super('missing input')
@@ -82,6 +84,10 @@ function keywordMatches(actual: Buffer, expected: string): boolean {
   return actual.toString().toUpperCase() === expected.toUpperCase()
 }
 
+export function isIntegerToken(raw: string): boolean {
+  return INTEGER_TOKEN_PATTERN.test(raw)
+}
+
 function makeSchema<TValue>(
   parse: CommandSchema<TValue>['parse'],
 ): CommandSchema<TValue> {
@@ -114,7 +120,7 @@ export const t = {
   integer(options?: { min?: number; max?: number }): CommandSchema<number> {
     return makeSchema((input, index) => {
       const raw = readToken(input, index).toString()
-      if (!/^-?\d+$/.test(raw)) {
+      if (!isIntegerToken(raw)) {
         throw new ExpectedIntegerError()
       }
 
@@ -138,7 +144,7 @@ export const t = {
   bigInteger(options?: { min?: bigint; max?: bigint }): CommandSchema<bigint> {
     return makeSchema((input, index) => {
       const raw = readToken(input, index).toString()
-      if (!/^-?\d+$/.test(raw)) {
+      if (!isIntegerToken(raw)) {
         throw new ExpectedIntegerError()
       }
 

--- a/tests-integration/ioredis/hash-integration.test.ts
+++ b/tests-integration/ioredis/hash-integration.test.ts
@@ -364,7 +364,17 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
 
     try {
       await redisClient?.set(stringKey, 'value')
-      await redisClient?.hset(hashKey, 'integer', 'abc', 'float', 'abc')
+      await redisClient?.hset(
+        hashKey,
+        'integer',
+        'abc',
+        'float',
+        'abc',
+        'leading-zero',
+        '007',
+        'negative-zero',
+        '-0',
+      )
 
       await assert.rejects(
         () => redisClient?.hget(stringKey, 'field'),
@@ -381,7 +391,19 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
         errorWithMessage('ERR value is not an integer or out of range'),
       )
       await assert.rejects(
+        () => redisClient?.call('HINCRBY', hashKey, 'integer', '01'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
         () => redisClient?.hincrby(hashKey, 'integer', 1),
+        errorWithMessage('ERR hash value is not an integer'),
+      )
+      await assert.rejects(
+        () => redisClient?.hincrby(hashKey, 'leading-zero', 1),
+        errorWithMessage('ERR hash value is not an integer'),
+      )
+      await assert.rejects(
+        () => redisClient?.hincrby(hashKey, 'negative-zero', 1),
         errorWithMessage('ERR hash value is not an integer'),
       )
       await assert.rejects(

--- a/tests-integration/ioredis/string-integration.test.ts
+++ b/tests-integration/ioredis/string-integration.test.ts
@@ -378,17 +378,46 @@ describe(`String Commands Integration (${testRunner.getBackendName()})`, () => {
   test('String numeric and expiration errors match Redis', async () => {
     const tag = `{string-errors:${randomKey()}}`
     const stringKey = `${tag}:string`
+    const leadingZeroKey = `${tag}:leading-zero`
+    const negativeLeadingZeroKey = `${tag}:negative-leading-zero`
+    const zeroKey = `${tag}:zero`
+    const negativeZeroKey = `${tag}:negative-zero`
     const directClient = await connectToSlotOwner(redisClient!, stringKey)
 
     try {
       await directClient.set(stringKey, 'not-a-number')
+      await directClient.set(leadingZeroKey, '007')
+      await directClient.set(negativeLeadingZeroKey, '-01')
+      await directClient.set(zeroKey, '0')
+      await directClient.set(negativeZeroKey, '-0')
 
       await assert.rejects(
         () => directClient.incr(stringKey),
         errorWithMessage('ERR value is not an integer or out of range'),
       )
       await assert.rejects(
+        () => directClient.incr(leadingZeroKey),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () => directClient.decr(negativeLeadingZeroKey),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      assert.strictEqual(await directClient.incr(zeroKey), 1)
+      await assert.rejects(
+        () => directClient.incr(negativeZeroKey),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
         () => directClient.call('INCRBY', stringKey, 'abc'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () => directClient.call('INCRBY', stringKey, '01'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () => directClient.call('DECRBY', stringKey, '-01'),
         errorWithMessage('ERR value is not an integer or out of range'),
       )
       await assert.rejects(
@@ -404,6 +433,16 @@ describe(`String Commands Integration (${testRunner.getBackendName()})`, () => {
         errorWithMessage("ERR invalid expire time in 'setex' command"),
       )
       await assert.rejects(
+        () =>
+          directClient.call(
+            'SETEX',
+            `${tag}:setex-leading-zero`,
+            '01',
+            'value',
+          ),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
         () => directClient.call('PSETEX', `${tag}:psetex`, '0', 'value'),
         errorWithMessage("ERR invalid expire time in 'psetex' command"),
       )
@@ -416,7 +455,16 @@ describe(`String Commands Integration (${testRunner.getBackendName()})`, () => {
         errorWithMessage('ERR syntax error'),
       )
     } finally {
-      await directClient.del(stringKey, `${tag}:setex`, `${tag}:psetex`)
+      await directClient.del(
+        stringKey,
+        leadingZeroKey,
+        negativeLeadingZeroKey,
+        zeroKey,
+        negativeZeroKey,
+        `${tag}:setex`,
+        `${tag}:setex-leading-zero`,
+        `${tag}:psetex`,
+      )
       directClient.disconnect()
     }
   })


### PR DESCRIPTION
## Summary
- Reject Redis integer tokens with leading zeros through the shared schema parser and command helper path.
- Reuse the same token check for HINCRBY stored hash values while preserving the Redis hash-value error text.
- Add ioredis integration coverage for string and hash integer parsing, including 007, 01, -01, -0, and valid 0.

## Root Cause
The integer parsers accepted `/^-?\d+$/`, so values like 007 and -0 passed syntax validation and were coerced with Number before command execution. Real Redis rejects those tokens as invalid integers.

## Validation
- Focused mock string integration test failed before the fix at the new leading-zero rejection.
- Focused real string integration test passed after confirming Redis rejects -0 and reports SETEX 01 as ERR value is not an integer or out of range.
- TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/string-integration.test.ts
- TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/string-integration.test.ts
- TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/hash-integration.test.ts
- TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/hash-integration.test.ts
- npm run build
- npm test
- npm run test:integration:mock
- npm run test:integration:real
- npm run lint

## Docs
Checked README.md, docs/COMMANDS.md, and docs/ARCHITECTURE.md. No docs update was needed because command support and architecture did not change.

Fixes #69
