### PR TITLE
Fix stream trim LIMIT parsing

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -272,12 +272,12 @@ with `GT` or `LT`.
 
 ## 9. Stream Commands
 
-- [x] `XADD key [NOMKSTREAM] [MAXLEN|MINID [~] threshold] <ID|*> field value [field value ...]` - Append an entry to a stream
+- [x] `XADD key [NOMKSTREAM] [MAXLEN|MINID [~] threshold [LIMIT count]] <ID|*> field value [field value ...]` - Append an entry to a stream
 - [x] `XLEN key` - Return the number of entries
 - [x] `XRANGE key start end [COUNT count]` - Return entries in ascending ID order
 - [x] `XREVRANGE key end start [COUNT count]` - Return entries in descending ID order
 - [x] `XDEL key ID [ID ...]` - Remove entries by ID
-- [x] `XTRIM key MAXLEN|MINID [~] threshold` - Trim a stream to a size or minimum ID
+- [x] `XTRIM key MAXLEN|MINID [~] threshold [LIMIT count]` - Trim a stream to a size or minimum ID
 - [x] `XREAD [COUNT count] [BLOCK milliseconds] STREAMS key [key ...] id [id ...]` - Read entries, optionally blocking for new ones (RESP3 map / RESP2 array of stream-entry pairs)
 - [x] `XGROUP CREATE|SETID|DESTROY|CREATECONSUMER|DELCONSUMER ...` - Manage stream consumer groups and consumers
 - [x] `XREADGROUP GROUP group consumer [COUNT count] [BLOCK milliseconds] [NOACK] STREAMS key [key ...] id [id ...]` - Read entries through a consumer group and track pending delivery
@@ -291,7 +291,7 @@ with `GT` or `LT`.
 
 #### Notes / gaps vs. real Redis
 
-- [ ] `XADD`/`XTRIM` trim specs do not support `LIMIT count`
+- `LIMIT count` is accepted on approximate (`~`) `XADD`/`XTRIM` trim specs for Redis-compatible parsing; the mock treats it as a trimming hint.
 - [ ] Stream radix-tree statistics in `XINFO STREAM` are approximated for mock compatibility rather than mirroring Redis internals
 
 #### Not implemented

--- a/src/commands/streams.ts
+++ b/src/commands/streams.ts
@@ -10,6 +10,8 @@ import {
   NoSuchKeyError,
   RedisCommandError,
   RedisSyntaxError,
+  StreamLimitNegativeError,
+  StreamLimitRequiresApproxError,
   StreamElementTooLargeError,
   StreamIdExhaustedError,
   StreamIdEqualOrSmallerError,
@@ -329,8 +331,31 @@ function createStreamFieldsSchema() {
 
 // Trim specification shared by XADD and XTRIM.
 type TrimSpec =
-  | { strategy: 'maxlen'; count: bigint; approximate: boolean }
-  | { strategy: 'minid'; minId: StreamId; approximate: boolean }
+  | {
+      strategy: 'maxlen'
+      count: bigint
+      approximate: boolean
+      limit: bigint | null
+    }
+  | {
+      strategy: 'minid'
+      minId: StreamId
+      approximate: boolean
+      limit: bigint | null
+    }
+
+function parseTrimLimit(raw: string): bigint {
+  if (/^-\d+$/.test(raw)) {
+    throw new StreamLimitNegativeError()
+  }
+
+  const value = parseUint64(raw)
+  if (value === null) {
+    throw new ExpectedIntegerError()
+  }
+
+  return value
+}
 
 function createTrimSpecSchema() {
   return t.custom<TrimSpec>(
@@ -353,20 +378,35 @@ function createTrimSpecSchema() {
         throw new WrongNumberOfArgumentsError(ctx.commandName)
       cursor++
 
+      let trim: TrimSpec
       if (keyword === 'MAXLEN') {
         const count = parseUint64(rawValue)
         if (count === null) throw new RedisSyntaxError()
-        return {
-          value: { strategy: 'maxlen', count, approximate },
-          nextIndex: cursor,
-        }
+        trim = { strategy: 'maxlen', count, approximate, limit: null }
       } else {
         const minId = parseExactId(rawValue)
-        return {
-          value: { strategy: 'minid', minId, approximate },
-          nextIndex: cursor,
-        }
+        trim = { strategy: 'minid', minId, approximate, limit: null }
       }
+
+      while (cursor < input.length) {
+        if (input[cursor]!.toString().toUpperCase() !== 'LIMIT') {
+          break
+        }
+
+        if (!approximate) {
+          throw new StreamLimitRequiresApproxError()
+        }
+
+        const rawLimit = input[cursor + 1]?.toString()
+        if (rawLimit === undefined) {
+          throw new RedisSyntaxError()
+        }
+
+        trim.limit = parseTrimLimit(rawLimit)
+        cursor += 2
+      }
+
+      return { value: trim, nextIndex: cursor }
     },
   )
 }

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -240,6 +240,18 @@ export class LimitCantBeNegativeError extends RedisCommandError {
   }
 }
 
+export class StreamLimitRequiresApproxError extends RedisCommandError {
+  constructor() {
+    super('syntax error, LIMIT cannot be used without the special ~ option')
+  }
+}
+
+export class StreamLimitNegativeError extends RedisCommandError {
+  constructor() {
+    super('The LIMIT argument must be >= 0.')
+  }
+}
+
 export class InvalidLexRangeError extends RedisCommandError {
   constructor() {
     super('min or max not valid string range item')

--- a/tests-integration/ioredis/stream-integration.test.ts
+++ b/tests-integration/ioredis/stream-integration.test.ts
@@ -280,6 +280,72 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
     }
   })
 
+  test('XTRIM MAXLEN with ~ accepts LIMIT count', async () => {
+    const key = randomKey()
+    const node = await connectToSlotOwner(redisClient!, key)
+    try {
+      await node.xadd(key, '1-1', 'f', 'v')
+      await node.xadd(key, '2-1', 'f', 'v')
+      await node.xadd(key, '3-1', 'f', 'v')
+
+      const removed = (await node.call(
+        'XTRIM',
+        key,
+        'MAXLEN',
+        '~',
+        '2',
+        'LIMIT',
+        '1',
+      )) as number
+      assert.ok(typeof removed === 'number' && removed >= 0)
+    } finally {
+      node.disconnect()
+    }
+  })
+
+  test('XTRIM LIMIT validates approximate trim syntax', async () => {
+    const key = randomKey()
+    const node = await connectToSlotOwner(redisClient!, key)
+    try {
+      await node.xadd(key, '1-1', 'f', 'v')
+      await node.xadd(key, '2-1', 'f', 'v')
+      await node.xadd(key, '3-1', 'f', 'v')
+
+      await assert.rejects(
+        () => node.call('XTRIM', key, 'MAXLEN', '2', 'LIMIT', '1'),
+        errorWithMessage(
+          'ERR syntax error, LIMIT cannot be used without the special ~ option',
+        ),
+      )
+      await assert.rejects(
+        () => node.call('XTRIM', key, 'MAXLEN', '~', '2', 'LIMIT'),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => node.call('XTRIM', key, 'MAXLEN', '~', '2', 'LIMIT', 'abc'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () => node.call('XTRIM', key, 'MAXLEN', '~', '2', 'LIMIT', '-1'),
+        errorWithMessage('ERR The LIMIT argument must be >= 0.'),
+      )
+      const removed = (await node.call(
+        'XTRIM',
+        key,
+        'MAXLEN',
+        '~',
+        '2',
+        'LIMIT',
+        '1',
+        'LIMIT',
+        '1',
+      )) as number
+      assert.ok(typeof removed === 'number' && removed >= 0)
+    } finally {
+      node.disconnect()
+    }
+  })
+
   test('XTRIM MINID removes entries with id below threshold', async () => {
     const key = randomKey()
     const node = await connectToSlotOwner(redisClient!, key)
@@ -352,6 +418,87 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
         ['3-1', ['f', 'v']],
         ['4-1', ['f', 'v']],
       ])
+    } finally {
+      node.disconnect()
+    }
+  })
+
+  test('XADD MAXLEN with ~ accepts LIMIT count before generated id', async () => {
+    const key = randomKey()
+    const node = await connectToSlotOwner(redisClient!, key)
+    try {
+      await node.xadd(key, '1-1', 'f', 'v')
+      await node.xadd(key, '2-1', 'f', 'v')
+      await node.xadd(key, '3-1', 'f', 'v')
+
+      const id = (await node.call(
+        'XADD',
+        key,
+        'MAXLEN',
+        '~',
+        '2',
+        'LIMIT',
+        '1',
+        '*',
+        'f',
+        'v',
+      )) as string
+      assert.match(id, /^\d+-\d+$/)
+
+      const duplicateLimitId = (await node.call(
+        'XADD',
+        key,
+        'MAXLEN',
+        '~',
+        '2',
+        'LIMIT',
+        '1',
+        'limit',
+        '1',
+        '*',
+        'f',
+        'v',
+      )) as string
+      assert.match(duplicateLimitId, /^\d+-\d+$/)
+    } finally {
+      node.disconnect()
+    }
+  })
+
+  test('XADD LIMIT validates approximate trim syntax before id', async () => {
+    const key = randomKey()
+    const node = await connectToSlotOwner(redisClient!, key)
+    try {
+      await node.xadd(key, '1-1', 'f', 'v')
+
+      await assert.rejects(
+        () =>
+          node.call('XADD', key, 'MAXLEN', '2', 'LIMIT', '1', '*', 'f', 'v'),
+        errorWithMessage(
+          'ERR syntax error, LIMIT cannot be used without the special ~ option',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          node.call('XADD', key, 'MAXLEN', '~', '2', 'LIMIT', '*', 'f', 'v'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () =>
+          node.call(
+            'XADD',
+            key,
+            'MAXLEN',
+            '~',
+            '2',
+            'LIMIT',
+            '-1',
+            '*',
+            'f',
+            'v',
+          ),
+        errorWithMessage('ERR The LIMIT argument must be >= 0.'),
+      )
     } finally {
       node.disconnect()
     }


### PR DESCRIPTION
## Summary

- Parse `LIMIT count` in the shared `XADD`/`XTRIM` trim-spec schema after the trim threshold.
- Match Redis-visible errors for `LIMIT` without `~`, missing/malformed values, and negative values.
- Cover successful, repeated, and case-insensitive `LIMIT` handling in ioredis stream integration tests.
- Update the stream command matrix to remove the stale LIMIT gap.

## Root Cause

`createTrimSpecSchema()` returned immediately after `MAXLEN`/`MINID` threshold parsing. As a result, `XADD ... LIMIT ... * ...` treated `LIMIT` as the stream entry ID, while `XTRIM ... LIMIT ...` failed before handling the option.

## Validation

- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/stream-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/stream-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`

Fixes #60