### PR TITLE
Fix CLIENT LIST session enumeration

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -137,7 +137,7 @@ graph TD
 | **Session**   | Per-connection state: selected DB, RESP version, transaction queue, `WATCH`ed keys, abort signal, turn acquisition | [`ClientSession`](../src/core/client-session.ts)                                                                                                                                                                                                                                                                                   |
 | **Execution** | Looks up commands, parses args, extracts keys, and runs composable policies around `execute`                       | [`CommandExecutor`](../src/core/command-executor.ts), [`CommandRegistry`](../src/core/command-registry.ts), [`ExecutionPolicy`](../src/core/execution-policies/index.ts)                                                                                                                                                           |
 | **Command**   | Pure `(args, ctx) → RedisResult \| ResponseStream` implementations grouped by data type                            | [`src/commands/`](../src/commands/)                                                                                                                                                                                                                                                                                                |
-| **State**     | In-memory keyspace, mutation events, cluster topology, script cache, pub/sub, monitor feed                         | [`RedisServerState`](../src/state/server-state.ts), [`RedisDatabase`](../src/state/database.ts), [`RedisKeyspace`](../src/state/keyspace.ts)                                                                                                                                                                                       |
+| **State**     | In-memory keyspace, mutation events, cluster topology, script cache, connected clients, pub/sub, monitor feed      | [`RedisServerState`](../src/state/server-state.ts), [`RedisDatabase`](../src/state/database.ts), [`RedisKeyspace`](../src/state/keyspace.ts)                                                                                                                                                                                       |
 
 Commands never touch the transport — they return a `RedisResult` (or a
 `ResponseStream` for push-style replies) and let the executor/session/adapter
@@ -316,11 +316,11 @@ flowchart LR
 is server-wide rather than per-DB: the cluster topology, the Lua
 [`RedisScriptCache`](../src/state/script-cache.ts) (so `FLUSHALL`/`FLUSHDB`
 clear keyspace data but **not** cached scripts — only `SCRIPT FLUSH` does),
-and the [`RedisPubSubBroker`](../src/state/pubsub-broker.ts) used by client
-Pub/Sub commands for channel and pattern fan-out within that server state, plus
-the [`RedisMonitorFeed`](../src/state/monitor-feed.ts) used by `MONITOR` to
-fan out cloned command events without any command writing directly to a
-transport.
+a registry of connected client sessions for `CLIENT LIST`, and the
+[`RedisPubSubBroker`](../src/state/pubsub-broker.ts) used by client Pub/Sub
+commands for channel and pattern fan-out within that server state, plus the
+[`RedisMonitorFeed`](../src/state/monitor-feed.ts) used by `MONITOR` to fan out
+cloned command events without any command writing directly to a transport.
 
 Each database wraps a [`RedisKeyspace`](../src/state/keyspace.ts#L34): a
 `Map<keyId, KeyspaceEntry>` holding byte-safe `Buffer` keys and typed

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -33,7 +33,8 @@ only a subset of the real Redis syntax, the supported syntax is shown and a
 - [x] `CLIENT SETNAME connection-name` - Set the connection name
 - [x] `CLIENT SETINFO LIB-NAME|LIB-VER value` - Record client library metadata
 - [x] `CLIENT ID` - Return the connection's ID
-- [x] `CLIENT INFO` / `CLIENT LIST` - Return a single `key=value` line for the current connection
+- [x] `CLIENT INFO` - Return a single `key=value` line for the current connection
+- [x] `CLIENT LIST` - Return one `key=value` line per active client connected to the current server node
 - [x] `CLIENT HELP` - Return subcommand help
 - [ ] `CLIENT KILL`, `CLIENT PAUSE`/`UNPAUSE`, `CLIENT NO-EVICT`, `CLIENT NO-TOUCH`, `CLIENT REPLY`, `CLIENT TRACKING` - not implemented
 

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -185,20 +185,17 @@ function buildInfo(ctx: RedisExecutionContext, section?: string): string {
   return `${lines.join('\r\n')}\r\n`
 }
 
-function formatClientLine(
-  ctx: RedisExecutionContext,
-  session: RedisClientSession,
-): string {
+function formatClientLine(session: RedisClientSession): string {
   const name = clientNames.get(session)?.toString() ?? ''
   const libName = clientLibraryNames.get(session)?.toString()
   const libVersion = clientLibraryVersions.get(session)?.toString()
   const fields = [
     `id=${getClientId(session)}`,
-    'addr=127.0.0.1:0',
+    `addr=${session.clientAddress ?? '127.0.0.1:0'}`,
     'laddr=127.0.0.1:6379',
     'fd=0',
     `name=${name}`,
-    `db=${ctx.session.selectedDatabase}`,
+    `db=${session.selectedDatabase}`,
     'age=0',
     'idle=0',
     `flags=${session.mode === 'subscribed' ? 'P' : 'N'}`,
@@ -462,12 +459,13 @@ export const clientCommand = defineCommand({
 
     if (subcommand === 'info') {
       expectArgCount('client|info', args.args, 0)
-      return bulk(Buffer.from(formatClientLine(ctx, ctx.session)))
+      return bulk(Buffer.from(formatClientLine(ctx.session)))
     }
 
     if (subcommand === 'list') {
       expectArgCount('client|list', args.args, 0)
-      return bulk(Buffer.from(formatClientLine(ctx, ctx.session)))
+      const lines = ctx.server.getConnectedClients().map(formatClientLine)
+      return bulk(Buffer.from(lines.join('')))
     }
 
     if (subcommand === 'help') {

--- a/src/core/client-session.ts
+++ b/src/core/client-session.ts
@@ -111,6 +111,7 @@ export class ClientSession implements RedisClientSession {
   private readonly pushWaiters = new Set<() => void>()
   private pushQueueClosed = false
   private readonly responseStreamCleanups = new Set<() => void>()
+  private unregisterClientSession?: Unsubscribe
 
   constructor(options: ClientSessionOptions) {
     this.id = options.id ?? `client-${++ClientSession.nextId}`
@@ -130,6 +131,7 @@ export class ClientSession implements RedisClientSession {
     }
 
     this.server.getDatabase(this.selectedDatabaseId)
+    this.unregisterClientSession = this.server.registerClientSession(this)
   }
 
   get selectedDatabase(): number {
@@ -668,6 +670,8 @@ export class ClientSession implements RedisClientSession {
 
   /** Tear down the session: abort in-flight work and reset all per-connection state. */
   close(): void {
+    this.unregisterClientSession?.()
+    this.unregisterClientSession = undefined
     this.resetResponseStreams()
     this.signalSource?.abort()
     this.unwatch()

--- a/src/state/server-state.ts
+++ b/src/state/server-state.ts
@@ -1,8 +1,10 @@
 import { RedisClusterTopology } from './cluster-topology'
 import { RedisDatabase } from './database'
 import { RedisMonitorFeed } from './monitor-feed'
+import type { Unsubscribe } from './mutation-events'
 import { RedisPubSubBroker } from './pubsub-broker'
 import { RedisScriptCache } from './script-cache'
+import type { RedisClientSession } from '../core/redis-context'
 
 export type RedisServerStateOptions = {
   databaseCount?: number
@@ -25,6 +27,7 @@ export class RedisServerState {
   readonly pubsubBroker: RedisPubSubBroker
   readonly clusterTopology: RedisClusterTopology
   readonly requirepass?: string
+  private readonly clientSessions = new Set<RedisClientSession>()
 
   constructor(options?: RedisServerStateOptions) {
     this.requirepass = options?.requirepass
@@ -51,6 +54,15 @@ export class RedisServerState {
     }
 
     return database
+  }
+
+  registerClientSession(session: RedisClientSession): Unsubscribe {
+    this.clientSessions.add(session)
+    return () => this.clientSessions.delete(session)
+  }
+
+  getConnectedClients(): readonly RedisClientSession[] {
+    return [...this.clientSessions]
   }
 
   /**

--- a/tests-integration/ioredis/connection-integration.test.ts
+++ b/tests-integration/ioredis/connection-integration.test.ts
@@ -5,6 +5,7 @@ import { TestRunner } from '../test-config'
 import {
   commandFrame,
   connectToSlotOwner,
+  eventually,
   errorWithMessage,
   randomKey,
 } from '../utils'
@@ -63,6 +64,39 @@ describe(`Connection commands integration (${testRunner.getBackendName()})`, () 
 
     const list = (await directClient?.call('CLIENT', 'LIST')) as string
     assert.match(list, new RegExp(`name=${name}`))
+  })
+
+  test('CLIENT LIST reports all active clients on the connected node', async () => {
+    const key = `{client-list:${randomKey()}}:probe`
+    const primary = await connectToSlotOwner(redisClient!, key)
+    const secondary = await connectToSlotOwner(redisClient!, key)
+    const primaryName = `primary-${randomKey()}`
+    const secondaryName = `secondary-${randomKey()}`
+
+    try {
+      assert.strictEqual(
+        await primary.call('CLIENT', 'SETNAME', primaryName),
+        'OK',
+      )
+      assert.strictEqual(
+        await secondary.call('CLIENT', 'SETNAME', secondaryName),
+        'OK',
+      )
+
+      const list = (await primary.call('CLIENT', 'LIST')) as string
+      assert.match(list, new RegExp(`name=${primaryName}`))
+      assert.match(list, new RegExp(`name=${secondaryName}`))
+
+      secondary.disconnect()
+      await eventually(async () => {
+        const updated = (await primary.call('CLIENT', 'LIST')) as string
+        assert.match(updated, new RegExp(`name=${primaryName}`))
+        assert.doesNotMatch(updated, new RegExp(`name=${secondaryName}`))
+      })
+    } finally {
+      primary.disconnect()
+      secondary.disconnect()
+    }
   })
 
   test('HELLO can set the connection name and reports cluster mode', async () => {


### PR DESCRIPTION
## Summary

- Track active `ClientSession` instances on `RedisServerState` and unregister them when sessions close.
- Make `CLIENT LIST` return one formatted line per active client on the connected server node, while `CLIENT INFO` remains current-session scoped.
- Add ioredis integration coverage that proves multiple active clients appear in `CLIENT LIST` and disconnected clients are removed.
- Update command and architecture docs for the new server-node scoped client registry.

## Root Cause

`CLIENT LIST` reused the `CLIENT INFO` formatter against only `ctx.session`, so it always returned the calling connection even when other clients were connected to the same Redis node.

## Validation

- Focused mock integration failed before the fix as expected: `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/connection-integration.test.ts`
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/connection-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/connection-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock` (`320` tests, `0` failures)
- `npm run test:integration:real` (`320` tests, `0` failures)
- `npm run lint`

Fixes #18
