### PR TITLE
Add LMPOP and BLMPOP list commands

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -349,10 +349,9 @@ carries a `park` handler
 ([`createDefaultParkHandler`](../src/core/redis-context.ts#L47)): a command can
 release its turn while waiting on something, then re-acquire one with priority
 once it resolves — without deadlocking the queue. This is the plumbing the
-[refactor](../src/core/redis-context.ts) was designed around for future
-blocking commands (`BLPOP`, `WAIT`, `XREAD BLOCK`, ...); no shipped command
-uses it yet, but the contract already exists so adding one won't require
-touching the session or queue.
+[refactor](../src/core/redis-context.ts) was designed around for blocking
+commands. `BLPOP`, `BRPOP`, `BLMOVE`, `BLMPOP`, and `XREAD BLOCK` use this
+contract without special session or queue code.
 
 ## Protocol & transports (RESP2 / RESP3)
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -212,11 +212,12 @@ with `GT` or `LT`.
 - [x] `BLPOP key [key ...] timeout` - Blocking left pop
 - [x] `BRPOP key [key ...] timeout` - Blocking right pop
 - [x] `BLMOVE source destination LEFT | RIGHT LEFT | RIGHT timeout` - Blocking variant of `LMOVE`
+- [x] `LMPOP numkeys key [key ...] LEFT | RIGHT [COUNT count]` - Pop from the first non-empty list
+- [x] `BLMPOP timeout numkeys key [key ...] LEFT | RIGHT [COUNT count]` - Blocking variant of `LMPOP`
 
 #### Not implemented
 
 - [ ] `LINSERT`
-- [ ] `LMPOP` / `BLMPOP`
 
 ## 7. Set Commands
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -144,12 +144,14 @@ export {
 } from './scan'
 export {
   listsCommands,
+  blmpopCommand,
   blmoveCommand,
   blpopCommand,
   brpopCommand,
   lindexCommand,
   llenCommand,
   lmoveCommand,
+  lmpopCommand,
   lpopCommand,
   lposCommand,
   lpushCommand,

--- a/src/commands/lists.ts
+++ b/src/commands/lists.ts
@@ -1,14 +1,16 @@
 import { defineCommand } from '../core/command-definition'
-import { t } from '../core/command-schema'
+import { isIntegerToken, t, type ParseContext } from '../core/command-schema'
 import { integer, bulk, ok, array, parseIntegerToken } from './helpers'
 import { RedisValue } from '../core/redis-value'
 import { RedisResult } from '../core/redis-result'
 import {
+  CountGreaterThanZeroError,
   IndexOutOfRangeError,
   LposCountNegativeError,
   LposMaxlenNegativeError,
   LposRankZeroError,
   NoSuchKeyError,
+  NumKeysGreaterThanZeroError,
   PositiveCountError,
   RedisSyntaxError,
   TimeoutNegativeError,
@@ -645,6 +647,235 @@ function parseTimeout(token: Buffer): number {
   return value
 }
 
+type ListMultiPopArgs = {
+  keys: Buffer[]
+  side: 'left' | 'right'
+  count: number
+}
+
+type BlockingListMultiPopArgs = ListMultiPopArgs & {
+  timeout: number
+}
+
+function parsePositiveListPopInteger(
+  token: Buffer,
+  createError: () => Error,
+): number {
+  const raw = token.toString()
+  if (!isIntegerToken(raw)) {
+    throw createError()
+  }
+
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw createError()
+  }
+
+  return value
+}
+
+function parseListPopNumKeys(token: Buffer): number {
+  return parsePositiveListPopInteger(
+    token,
+    () => new NumKeysGreaterThanZeroError(),
+  )
+}
+
+function parseListPopCount(token: Buffer): number {
+  return parsePositiveListPopInteger(
+    token,
+    () => new CountGreaterThanZeroError(),
+  )
+}
+
+function parseListMultiPopArgs(
+  input: readonly Buffer[],
+  index: number,
+  ctx: ParseContext,
+  options: { blocking: false },
+): ListMultiPopArgs
+function parseListMultiPopArgs(
+  input: readonly Buffer[],
+  index: number,
+  ctx: ParseContext,
+  options: { blocking: true },
+): BlockingListMultiPopArgs
+function parseListMultiPopArgs(
+  input: readonly Buffer[],
+  index: number,
+  ctx: ParseContext,
+  options: { blocking: boolean },
+): ListMultiPopArgs | BlockingListMultiPopArgs {
+  if (index >= input.length) {
+    throw new WrongNumberOfArgumentsError(ctx.commandName)
+  }
+
+  let cursor = index
+  let timeout: number | undefined
+
+  if (options.blocking) {
+    timeout = parseTimeout(input[cursor])
+    cursor++
+  }
+
+  const numKeysToken = input[cursor]
+  if (!numKeysToken) {
+    throw new WrongNumberOfArgumentsError(ctx.commandName)
+  }
+
+  const numKeys = parseListPopNumKeys(numKeysToken)
+  cursor++
+
+  const keysEnd = cursor + numKeys
+  if (keysEnd >= input.length) {
+    throw new RedisSyntaxError()
+  }
+
+  const keys = Array.from(input.slice(cursor, keysEnd))
+  cursor = keysEnd
+
+  const side = parseMoveDirection(input[cursor])
+  cursor++
+
+  let count = 1
+  if (cursor < input.length) {
+    const option = input[cursor].toString().toUpperCase()
+    if (option !== 'COUNT' || cursor + 2 !== input.length) {
+      throw new RedisSyntaxError()
+    }
+
+    count = parseListPopCount(input[cursor + 1])
+    cursor += 2
+  }
+
+  if (options.blocking) {
+    return { timeout: timeout!, keys, side, count }
+  }
+
+  return { keys, side, count }
+}
+
+function tryListMultiPop(
+  keys: readonly Buffer[],
+  side: 'left' | 'right',
+  count: number,
+  db: RedisDatabase,
+): RedisResult | null {
+  for (const key of keys) {
+    const list = db.getList(key)
+    if (!list || list.values.length === 0) continue
+
+    const result = db.updateList(key, list => {
+      const values: Buffer[] = []
+      const limit = Math.min(count, list.values.length)
+
+      for (let i = 0; i < limit; i++) {
+        const value = side === 'left' ? list.values.shift() : list.values.pop()
+        if (value) values.push(value)
+      }
+
+      return { values, empty: list.values.length === 0 }
+    })
+    if (result.empty) db.delete(key)
+
+    return RedisResult.create(
+      RedisValue.array([
+        RedisValue.bulkString(key),
+        RedisValue.array(
+          result.values.map(value => RedisValue.bulkString(value)),
+        ),
+      ]),
+    )
+  }
+
+  return null
+}
+
+async function blockingListMultiPop(
+  keys: readonly Buffer[],
+  timeoutSecs: number,
+  side: 'left' | 'right',
+  count: number,
+  ctx: RedisExecutionContext,
+): Promise<RedisResult> {
+  const timeoutMs =
+    timeoutSecs === 0 ? undefined : Math.ceil(timeoutSecs * 1000)
+  const deadline = timeoutMs !== undefined ? Date.now() + timeoutMs : undefined
+
+  while (true) {
+    const remaining =
+      deadline !== undefined ? Math.max(0, deadline - Date.now()) : undefined
+    if (remaining === 0) return RedisResult.create(RedisValue.nullArray())
+
+    let wake!: (v: true) => void
+    const waitFor = new Promise<true>(resolve => {
+      wake = () => resolve(true)
+    })
+
+    const unsubs = keys.map(key =>
+      ctx.db.subscribeKey(key, event => {
+        if (event.type === 'write') wake(true)
+      }),
+    )
+
+    let woken: boolean | null
+    try {
+      woken = await ctx.park({
+        waitFor,
+        timeoutMs: remaining,
+        signal: ctx.signal,
+      })
+    } finally {
+      for (const unsub of unsubs) {
+        try {
+          unsub()
+        } catch {
+          // ignore errors from individual unsubscribers so all are attempted
+        }
+      }
+    }
+
+    if (woken === null) return RedisResult.create(RedisValue.nullArray())
+
+    const result = tryListMultiPop(keys, side, count, ctx.db)
+    if (result) return result
+  }
+}
+
+export const lmpopCommand = defineCommand({
+  name: 'lmpop',
+  schema: t.custom<ListMultiPopArgs>((input, index, ctx) => ({
+    value: parseListMultiPopArgs(input, index, ctx, { blocking: false }),
+    nextIndex: input.length,
+  })),
+  flags: ['write'],
+  keys: args => args.keys,
+  execute: (args, ctx) =>
+    tryListMultiPop(args.keys, args.side, args.count, ctx.db) ??
+    RedisResult.create(RedisValue.nullArray()),
+})
+
+export const blmpopCommand = defineCommand({
+  name: 'blmpop',
+  schema: t.custom<BlockingListMultiPopArgs>((input, index, ctx) => ({
+    value: parseListMultiPopArgs(input, index, ctx, { blocking: true }),
+    nextIndex: input.length,
+  })),
+  flags: ['write', 'noscript'],
+  keys: args => args.keys,
+  execute: (args, ctx) => {
+    const immediate = tryListMultiPop(args.keys, args.side, args.count, ctx.db)
+    if (immediate) return immediate
+    return blockingListMultiPop(
+      args.keys,
+      args.timeout,
+      args.side,
+      args.count,
+      ctx,
+    )
+  },
+})
+
 async function blockingListMove(
   source: Buffer,
   destination: Buffer,
@@ -763,7 +994,9 @@ export const listsCommands = [
   rpoplpushCommand,
   lposCommand,
   lmoveCommand,
+  lmpopCommand,
   blmoveCommand,
+  blmpopCommand,
   blpopCommand,
   brpopCommand,
 ]

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -234,6 +234,12 @@ export class NumKeysGreaterThanZeroError extends RedisCommandError {
   }
 }
 
+export class CountGreaterThanZeroError extends RedisCommandError {
+  constructor() {
+    super('count should be greater than 0')
+  }
+}
+
 export class LimitCantBeNegativeError extends RedisCommandError {
   constructor() {
     super(`LIMIT can't be negative`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ export { CommandRegistry } from './core/command-registry'
 export { defineCommand } from './core/command-definition'
 export { t, parseCommandArgs } from './core/command-schema'
 export {
+  CountGreaterThanZeroError,
   ExpectedFloatError,
   ExpectedIntegerError,
   DiscardWithoutMultiError,

--- a/tests-integration/ioredis/lmpop-blmpop-integration.test.ts
+++ b/tests-integration/ioredis/lmpop-blmpop-integration.test.ts
@@ -1,0 +1,220 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { connectToSlotOwner, errorWithMessage, randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+function waitForPark(ms = 80): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe(`LMPOP / BLMPOP Integration (${testRunner.getBackendName()})`, () => {
+  let client1: Cluster | undefined
+  let client2: Cluster | undefined
+
+  before(async () => {
+    client1 = await testRunner.setupIoredisCluster()
+    client2 = await testRunner.setupIoredisCluster()
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  test('LMPOP pops from the first non-empty key with the requested side and count', async () => {
+    const tag = `{${randomKey()}}`
+    const empty = `${tag}:empty`
+    const first = `${tag}:first`
+    const second = `${tag}:second`
+    await client1!.del(empty, first, second)
+    await client1!.rpush(first, 'a', 'b', 'c')
+    await client1!.rpush(second, 'x', 'y')
+
+    assert.deepStrictEqual(
+      await client1!.call(
+        'LMPOP',
+        '3',
+        empty,
+        first,
+        second,
+        'LEFT',
+        'COUNT',
+        '2',
+      ),
+      [first, ['a', 'b']],
+    )
+    assert.deepStrictEqual(await client1!.lrange(first, 0, -1), ['c'])
+    assert.deepStrictEqual(await client1!.lrange(second, 0, -1), ['x', 'y'])
+
+    assert.deepStrictEqual(
+      await client1!.call('LMPOP', '2', first, second, 'RIGHT'),
+      [first, ['c']],
+    )
+    assert.strictEqual(await client1!.exists(first), 0)
+
+    assert.deepStrictEqual(
+      await client1!.call('LMPOP', '2', first, second, 'RIGHT', 'COUNT', '5'),
+      [second, ['y', 'x']],
+    )
+    assert.strictEqual(await client1!.exists(second), 0)
+  })
+
+  test('LMPOP returns null when all keys are empty or missing', async () => {
+    const tag = `{${randomKey()}}`
+    const first = `${tag}:first`
+    const second = `${tag}:second`
+    await client1!.del(first, second)
+
+    assert.strictEqual(
+      await client1!.call('LMPOP', '2', first, second, 'LEFT'),
+      null,
+    )
+  })
+
+  test('BLMPOP returns immediately when a list is non-empty', async () => {
+    const tag = `{${randomKey()}}`
+    const empty = `${tag}:empty`
+    const list = `${tag}:list`
+    await client1!.del(empty, list)
+    await client1!.rpush(list, 'one', 'two', 'three')
+
+    assert.deepStrictEqual(
+      await client1!.call(
+        'BLMPOP',
+        '1',
+        '2',
+        empty,
+        list,
+        'RIGHT',
+        'COUNT',
+        '2',
+      ),
+      [list, ['three', 'two']],
+    )
+    assert.deepStrictEqual(await client1!.lrange(list, 0, -1), ['one'])
+  })
+
+  test('BLMPOP blocks then returns when a push arrives', async () => {
+    const tag = `{${randomKey()}}`
+    const first = `${tag}:first`
+    const second = `${tag}:second`
+    await client1!.del(first, second)
+
+    const blockPromise = client1!.call(
+      'BLMPOP',
+      '5',
+      '2',
+      first,
+      second,
+      'LEFT',
+      'COUNT',
+      '2',
+    )
+    await waitForPark()
+    await client2!.rpush(second, 'a', 'b')
+
+    assert.deepStrictEqual(await blockPromise, [second, ['a', 'b']])
+    assert.strictEqual(await client1!.exists(second), 0)
+  })
+
+  test('BLMPOP timeout returns null', async () => {
+    const tag = `{${randomKey()}}`
+    const first = `${tag}:first`
+    const second = `${tag}:second`
+    await client1!.del(first, second)
+
+    assert.strictEqual(
+      await client1!.call('BLMPOP', '0.1', '2', first, second, 'LEFT'),
+      null,
+    )
+  })
+
+  test('LMPOP / BLMPOP error paths match Redis', async () => {
+    const tag = `{${randomKey()}}`
+    const list = `${tag}:list`
+    const other = `${tag}:other`
+    const stringKey = `${tag}:string`
+    await client1!.del(list, other, stringKey)
+    await client1!.rpush(list, 'value')
+    await client1!.set(stringKey, 'not-a-list')
+
+    await assert.rejects(
+      () => client1!.call('LMPOP'),
+      errorWithMessage("ERR wrong number of arguments for 'lmpop' command"),
+    )
+    await assert.rejects(
+      () => client1!.call('LMPOP', '0', list, 'LEFT'),
+      errorWithMessage('ERR numkeys should be greater than 0'),
+    )
+    await assert.rejects(
+      () => client1!.call('LMPOP', 'abc', list, 'LEFT'),
+      errorWithMessage('ERR numkeys should be greater than 0'),
+    )
+    await assert.rejects(
+      () => client1!.call('LMPOP', '2', list, other),
+      errorWithMessage('ERR syntax error'),
+    )
+    await assert.rejects(
+      () => client1!.call('LMPOP', '1', list, 'MIDDLE'),
+      errorWithMessage('ERR syntax error'),
+    )
+    await assert.rejects(
+      () => client1!.call('LMPOP', '1', list, 'LEFT', 'LIMIT', '1'),
+      errorWithMessage('ERR syntax error'),
+    )
+    await assert.rejects(
+      () => client1!.call('LMPOP', '1', list, 'LEFT', 'COUNT'),
+      errorWithMessage('ERR syntax error'),
+    )
+    await assert.rejects(
+      () => client1!.call('LMPOP', '1', list, 'LEFT', 'COUNT', '0'),
+      errorWithMessage('ERR count should be greater than 0'),
+    )
+    await assert.rejects(
+      () => client1!.call('LMPOP', '1', list, 'LEFT', 'COUNT', '-1'),
+      errorWithMessage('ERR count should be greater than 0'),
+    )
+    await assert.rejects(
+      () => client1!.call('LMPOP', '1', list, 'LEFT', 'COUNT', 'abc'),
+      errorWithMessage('ERR count should be greater than 0'),
+    )
+    await assert.rejects(
+      () => client1!.call('LMPOP', '1', stringKey, 'LEFT'),
+      errorWithMessage(
+        'WRONGTYPE Operation against a key holding the wrong kind of value',
+      ),
+    )
+
+    await assert.rejects(
+      () => client1!.call('BLMPOP', '-1', '1', list, 'LEFT'),
+      errorWithMessage('ERR timeout is negative'),
+    )
+    await assert.rejects(
+      () => client1!.call('BLMPOP', 'abc', '1', list, 'LEFT'),
+      errorWithMessage('ERR timeout is not a float or out of range'),
+    )
+
+    const directClient = await connectToSlotOwner(client1!, list)
+    try {
+      await assert.rejects(
+        () => directClient.call('LMPOP', '2', list, 'other-slot-key', 'LEFT'),
+        errorWithMessage(
+          "CROSSSLOT Keys in request don't hash to the same slot",
+        ),
+      )
+      await assert.rejects(
+        () =>
+          directClient.call('BLMPOP', '1', '2', list, 'other-slot-key', 'LEFT'),
+        errorWithMessage(
+          "CROSSSLOT Keys in request don't hash to the same slot",
+        ),
+      )
+    } finally {
+      directClient.disconnect()
+    }
+
+    await client1!.del(list, other, stringKey)
+  })
+})


### PR DESCRIPTION
## Summary
- add Redis-compatible `LMPOP` and `BLMPOP` list commands
- implement multi-key pop parsing, COUNT validation, cluster key extraction, wrong-type handling, and blocking wakeups through `ctx.park`
- document the new list command support

## Root cause
`LMPOP` and `BLMPOP` were still absent from the list command registry, leaving the remaining open list-command child scope from #26 unsupported.

## Validation
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/lmpop-blmpop-integration.test.ts`
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/lmpop-blmpop-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`

Fixes #112
Part of #26