### PR TITLE
feat: ZMSCORE, ZRANDMEMBER + modern ZRANGE (BYSCORE/BYLEX/REV/LIMIT) (#109)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -246,8 +246,10 @@ with `GT` or `LT`.
 - [x] `ZINCRBY key increment member` - Increment the score of a member (`inf`, `+inf`, and `-inf` increments supported; NaN results rejected)
 - [x] `ZRANK key member` - Get the index of a member, lowest score first
 - [x] `ZREVRANK key member` - Get the index of a member, highest score first
-- [x] `ZRANGE key start stop [WITHSCORES]` - Return a range of members by index
+- [x] `ZRANGE key min max [BYSCORE | BYLEX] [REV] [LIMIT offset count] [WITHSCORES]` - Return a range of members by index, score, or lexicographic range, optionally reversed
 - [x] `ZREVRANGE key start stop [WITHSCORES]` - Return a range of members by index, high to low
+- [x] `ZMSCORE key member [member ...]` - Get the scores of multiple members (nil per missing member)
+- [x] `ZRANDMEMBER key [count [WITHSCORES]]` - Get one or more random members, optionally with their scores
 - [x] `ZRANGEBYSCORE key min max` - Return members with scores between min and max (`-inf`, `+inf`, and exclusive `(score` bounds supported)
 - [x] `ZREMRANGEBYSCORE key min max` - Remove members with scores between min and max (`-inf`, `+inf`, and exclusive `(score` bounds supported)
 - [x] `ZCOUNT key min max` - Count members with scores between min and max (`-inf`, `+inf`, and exclusive `(score` bounds supported)
@@ -262,7 +264,7 @@ with `GT` or `LT`.
 #### Notes / gaps vs. real Redis
 
 - Score replies from `ZSCORE`, `ZINCRBY`, `ZRANGE WITHSCORES`, `ZREVRANGE WITHSCORES`, `ZPOPMIN`, `ZPOPMAX`, and `ZSCAN` serialize infinite scores as `inf` / `-inf`.
-- [ ] `ZRANGE`/`ZREVRANGE` do not support the Redis 6.2+ unified syntax (`BYSCORE`, `BYLEX`, `REV`, `LIMIT offset count`) - `start`/`stop` are always treated as indexes
+- [ ] `ZREVRANGE` does not support the Redis 6.2+ unified syntax (`BYSCORE`, `BYLEX`, `REV`, `LIMIT offset count`) - `start`/`stop` are always treated as indexes; use `ZRANGE ... REV` instead
 - [ ] `ZRANGEBYSCORE` does not support `WITHSCORES` or `LIMIT offset count`
 - [ ] `ZRANK`/`ZREVRANK` do not support the Redis 7.2 `WITHSCORE` option
 
@@ -270,7 +272,7 @@ with `GT` or `LT`.
 
 - [ ] `ZREVRANGEBYSCORE` / `ZREMRANGEBYRANK`
 - [ ] `ZUNIONSTORE` / `ZINTERSTORE` / `ZDIFFSTORE` / `ZUNION` / `ZINTER` / `ZDIFF` / `ZINTERCARD`
-- [ ] `ZMSCORE` / `ZRANDMEMBER` / `ZRANGESTORE` / `ZMPOP` / `BZPOPMIN` / `BZPOPMAX` / `BZMPOP`
+- [ ] `ZRANGESTORE` / `ZMPOP` / `BZPOPMIN` / `BZPOPMAX` / `BZMPOP`
 
 ## 9. Stream Commands
 

--- a/src/commands/zsets.ts
+++ b/src/commands/zsets.ts
@@ -12,6 +12,8 @@ import {
   ZaddGtLtNxConflictError,
   ZaddIncrPairError,
   ZaddNxXxConflictError,
+  ZrangeLimitWithoutByError,
+  ZrangeWithScoresByLexError,
 } from '../core/redis-error'
 import { RedisResult } from '../core/redis-result'
 import { RedisValue } from '../core/redis-value'
@@ -462,6 +464,98 @@ export const zscoreCommand = defineCommand({
   },
 })
 
+export const zmscoreCommand = defineCommand({
+  name: 'zmscore',
+  schema: t.object({ key: t.key(), members: t.variadic(t.key(), { min: 1 }) }),
+  flags: ['readonly', 'fast'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const zset = ctx.db.getSortedSet(args.key)
+    const items: RedisValue[] = []
+    for (const member of args.members) {
+      const entry = zset?.members.get(member.toString('hex'))
+      items.push(RedisValue.bulkString(entry ? scoreBuffer(entry.score) : null))
+    }
+    return array(items)
+  },
+})
+
+type ZrandmemberArgs = {
+  key: Buffer
+  count?: number
+  withScores: boolean
+}
+
+function createZrandmemberSchema() {
+  return t.custom<ZrandmemberArgs>((input, index, ctx) => {
+    const key = input[index]
+    if (!key) throw new WrongNumberOfArgumentsError(ctx.commandName)
+
+    let cursor = index + 1
+    let count: number | undefined
+    let withScores = false
+
+    if (cursor < input.length) {
+      count = parseLexLimitInt(input[cursor]!)
+      cursor++
+      if (cursor < input.length) {
+        if (input[cursor]!.toString().toUpperCase() !== 'WITHSCORES') {
+          throw new RedisSyntaxError()
+        }
+        withScores = true
+        cursor++
+      }
+    }
+
+    if (cursor < input.length) throw new RedisSyntaxError()
+    return { value: { key, count, withScores }, nextIndex: input.length }
+  })
+}
+
+export const zrandmemberCommand = defineCommand({
+  name: 'zrandmember',
+  schema: createZrandmemberSchema(),
+  flags: ['readonly'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const zset = ctx.db.getSortedSet(args.key)
+
+    if (args.count === undefined) {
+      if (!zset || zset.members.size === 0) return bulk(null)
+      const all = Array.from(zset.members.values())
+      const pick = all[Math.floor(Math.random() * all.length)]
+      return bulk(pick.member)
+    }
+
+    if (!zset || zset.members.size === 0) return array([])
+    const all = Array.from(zset.members.values())
+    const chosen: RedisSortedSetMember[] = []
+
+    if (args.count < 0) {
+      const n = -args.count
+      for (let i = 0; i < n; i++) {
+        chosen.push(all[Math.floor(Math.random() * all.length)])
+      }
+    } else {
+      const shuffled = all.slice()
+      for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+      }
+      chosen.push(...shuffled.slice(0, Math.min(args.count, shuffled.length)))
+    }
+
+    const items: RedisValue[] = []
+    for (const entry of chosen) {
+      items.push(RedisValue.bulkString(entry.member))
+      if (args.withScores) {
+        items.push(RedisValue.bulkString(scoreBuffer(entry.score)))
+      }
+    }
+    return array(items)
+  },
+})
+
 export const zincrbyCommand = defineCommand({
   name: 'zincrby',
   schema: t.object({ key: t.key(), increment: t.string(), member: t.key() }),
@@ -481,33 +575,172 @@ export const zincrbyCommand = defineCommand({
   },
 })
 
+// Modern ZRANGE (Redis 6.2+):
+//   ZRANGE key min max [BYSCORE | BYLEX] [REV] [LIMIT offset count] [WITHSCORES]
+// The legacy index-based form is the default (no BYSCORE/BYLEX). BYSCORE/BYLEX
+// share the score-range and lex-range parsing/filtering helpers used by
+// ZRANGEBYSCORE/ZRANGEBYLEX. With REV, the min/max arguments are given in
+// reverse order (max then min), matching ZREVRANGEBYSCORE/ZREVRANGEBYLEX.
+type ZrangeBy = 'index' | 'score' | 'lex'
+
+type ZrangeArgs = {
+  key: Buffer
+  min: Buffer
+  max: Buffer
+  by: ZrangeBy
+  rev: boolean
+  limit?: LexLimit
+  withScores: boolean
+}
+
+function createZrangeSchema() {
+  return t.custom<ZrangeArgs>((input, index, ctx) => {
+    const key = input[index]
+    const min = input[index + 1]
+    const max = input[index + 2]
+    if (!key || !min || !max) {
+      throw new WrongNumberOfArgumentsError(ctx.commandName)
+    }
+
+    let by: ZrangeBy = 'index'
+    let rev = false
+    let withScores = false
+    let limit: LexLimit | undefined
+
+    let cursor = index + 3
+    while (cursor < input.length) {
+      const option = input[cursor]!.toString().toUpperCase()
+
+      if (option === 'BYSCORE') {
+        if (by === 'lex') throw new RedisSyntaxError()
+        by = 'score'
+        cursor++
+        continue
+      }
+
+      if (option === 'BYLEX') {
+        if (by === 'score') throw new RedisSyntaxError()
+        by = 'lex'
+        cursor++
+        continue
+      }
+
+      if (option === 'REV') {
+        rev = true
+        cursor++
+        continue
+      }
+
+      if (option === 'WITHSCORES') {
+        withScores = true
+        cursor++
+        continue
+      }
+
+      if (option === 'LIMIT') {
+        const offsetTok = input[cursor + 1]
+        const countTok = input[cursor + 2]
+        if (!offsetTok || !countTok) throw new RedisSyntaxError()
+        limit = {
+          offset: parseLexLimitInt(offsetTok),
+          count: parseLexLimitInt(countTok),
+        }
+        cursor += 3
+        continue
+      }
+
+      throw new RedisSyntaxError()
+    }
+
+    if (limit && by === 'index') throw new ZrangeLimitWithoutByError()
+    if (withScores && by === 'lex') throw new ZrangeWithScoresByLexError()
+
+    return {
+      value: { key, min, max, by, rev, limit, withScores },
+      nextIndex: input.length,
+    }
+  })
+}
+
+function buildRangeOutput(
+  members: RedisSortedSetMember[],
+  withScores: boolean,
+): RedisValue[] {
+  const items: RedisValue[] = []
+  for (const entry of members) {
+    items.push(RedisValue.bulkString(entry.member))
+    if (withScores) {
+      items.push(RedisValue.bulkString(scoreBuffer(entry.score)))
+    }
+  }
+  return items
+}
+
+function sliceByIndex(
+  sorted: RedisSortedSetMember[],
+  startIdx: number,
+  stopIdx: number,
+  rev: boolean,
+): RedisSortedSetMember[] {
+  const ordered = rev ? sorted.slice().reverse() : sorted
+  const len = ordered.length
+  const start = startIdx < 0 ? Math.max(0, len + startIdx) : startIdx
+  const stop = stopIdx < 0 ? len + stopIdx : Math.min(stopIdx, len - 1)
+  if (start > stop) return []
+  return ordered.slice(start, stop + 1)
+}
+
 export const zrangeCommand = defineCommand({
   name: 'zrange',
-  schema: t.object({
-    key: t.key(),
-    start: t.integer(),
-    stop: t.integer(),
-    withScores: t.optional(t.keyword('WITHSCORES')),
-  }),
+  schema: createZrangeSchema(),
   flags: ['readonly'],
   keys: args => [args.key],
   execute: (args, ctx) => {
+    // With REV the bounds are supplied as `max min`, so swap before parsing.
+    const minTok = args.rev ? args.max : args.min
+    const maxTok = args.rev ? args.min : args.max
+
+    if (args.by === 'index') {
+      // parse index bounds up front so a bad index errors even on a missing key
+      const startIdx = parseLexLimitInt(args.min)
+      const stopIdx = parseLexLimitInt(args.max)
+      const zset = ctx.db.getSortedSet(args.key)
+      if (!zset) return array([])
+      const slice = sliceByIndex(
+        getSortedMembers(zset),
+        startIdx,
+        stopIdx,
+        args.rev,
+      )
+      return array(buildRangeOutput(slice, args.withScores))
+    }
+
+    if (args.by === 'score') {
+      const min = parseScoreBoundArg(minTok.toString())
+      const max = parseScoreBoundArg(maxTok.toString())
+      const zset = ctx.db.getSortedSet(args.key)
+      if (!zset) return array([])
+      let matched = getSortedMembers(zset).filter(m =>
+        scoreWithinBounds(m.score, min, max),
+      )
+      if (args.rev) matched = matched.reverse()
+      return array(
+        buildRangeOutput(applyLexLimit(matched, args.limit), args.withScores),
+      )
+    }
+
+    // BYLEX
+    const min = parseLexBoundArg(minTok)
+    const max = parseLexBoundArg(maxTok)
     const zset = ctx.db.getSortedSet(args.key)
     if (!zset) return array([])
-    const sorted = getSortedMembers(zset)
-    const len = sorted.length
-    const start = args.start < 0 ? Math.max(0, len + args.start) : args.start
-    const stop = args.stop < 0 ? len + args.stop : Math.min(args.stop, len - 1)
-    if (start > stop) return array([])
-    const slice = sorted.slice(start, stop + 1)
-    const items: RedisValue[] = []
-    for (const entry of slice) {
-      items.push(RedisValue.bulkString(entry.member))
-      if (args.withScores) {
-        items.push(RedisValue.bulkString(scoreBuffer(entry.score)))
-      }
-    }
-    return array(items)
+    let matched = getLexSortedMembers(zset).filter(m =>
+      lexMemberWithinBounds(m.member, min, max),
+    )
+    if (args.rev) matched = matched.reverse()
+    return array(
+      buildRangeOutput(applyLexLimit(matched, args.limit), args.withScores),
+    )
   },
 })
 
@@ -767,6 +1000,8 @@ export const zsetsCommands = [
   zrankCommand,
   zrevrankCommand,
   zscoreCommand,
+  zmscoreCommand,
+  zrandmemberCommand,
   zincrbyCommand,
   zrangeCommand,
   zrevrangeCommand,

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -264,6 +264,20 @@ export class InvalidLexRangeError extends RedisCommandError {
   }
 }
 
+export class ZrangeLimitWithoutByError extends RedisCommandError {
+  constructor() {
+    super(
+      'syntax error, LIMIT is only supported in combination with either BYSCORE or BYLEX',
+    )
+  }
+}
+
+export class ZrangeWithScoresByLexError extends RedisCommandError {
+  constructor() {
+    super('syntax error, WITHSCORES not supported in combination with BYLEX')
+  }
+}
+
 export class NoScriptError extends RedisCommandError {
   constructor() {
     super('No matching script. Please use EVAL.', 'NOSCRIPT')

--- a/tests-integration/ioredis/zset-modern-range-integration.test.ts
+++ b/tests-integration/ioredis/zset-modern-range-integration.test.ts
@@ -1,0 +1,447 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { errorWithMessage, randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+describe(`Sorted Set Modern Range / ZMSCORE / ZRANDMEMBER (${testRunner.getBackendName()})`, () => {
+  let redisClient: Cluster | undefined
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster(
+      'zset-modern-integration',
+    )
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  async function seedScored(pairs: Array<[number, string]>): Promise<string> {
+    const key = `{zmod:${randomKey()}}`
+    const args: (string | number)[] = []
+    for (const [score, member] of pairs) {
+      args.push(score, member)
+    }
+    await redisClient?.zadd(key, ...(args as [number, string]))
+    return key
+  }
+
+  async function seedLex(members: string[]): Promise<string> {
+    return seedScored(members.map(m => [0, m] as [number, string]))
+  }
+
+  // ---------- ZMSCORE ----------
+
+  test('ZMSCORE returns scores for present members, nil for missing', async () => {
+    const key = await seedScored([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+    ])
+    try {
+      assert.deepStrictEqual(await redisClient?.zmscore(key, 'a', 'x', 'c'), [
+        '1',
+        null,
+        '3',
+      ])
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZMSCORE on a missing key returns all nil', async () => {
+    const key = `{zmod:${randomKey()}}`
+    assert.deepStrictEqual(await redisClient?.zmscore(key, 'a', 'b'), [
+      null,
+      null,
+    ])
+  })
+
+  test('ZMSCORE rejects wrong arity', async () => {
+    const key = await seedScored([[1, 'a']])
+    try {
+      await assert.rejects(
+        () => redisClient?.call('zmscore', key),
+        errorWithMessage("ERR wrong number of arguments for 'zmscore' command"),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZMSCORE on a wrong-type key returns WRONGTYPE', async () => {
+    const key = `{zmod:${randomKey()}}`
+    await redisClient?.set(key, 'notazset')
+    try {
+      await assert.rejects(
+        () => redisClient?.zmscore(key, 'a'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  // ---------- ZRANDMEMBER ----------
+
+  test('ZRANDMEMBER without count returns one existing member', async () => {
+    const key = await seedScored([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+    ])
+    try {
+      const member = await redisClient?.zrandmember(key)
+      assert.ok(['a', 'b', 'c'].includes(member as string))
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANDMEMBER with positive count returns distinct members', async () => {
+    const key = await seedScored([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+      [4, 'd'],
+    ])
+    try {
+      const res = (await redisClient?.zrandmember(key, 3)) as string[]
+      assert.strictEqual(res.length, 3)
+      assert.strictEqual(new Set(res).size, 3) // distinct
+      for (const m of res) assert.ok(['a', 'b', 'c', 'd'].includes(m))
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANDMEMBER with count larger than cardinality returns all members', async () => {
+    const key = await seedScored([
+      [1, 'a'],
+      [2, 'b'],
+    ])
+    try {
+      const res = (await redisClient?.zrandmember(key, 10)) as string[]
+      assert.strictEqual(res.length, 2)
+      assert.deepStrictEqual([...res].sort(), ['a', 'b'])
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANDMEMBER with negative count allows repeats and matches |count| length', async () => {
+    const key = await seedScored([
+      [1, 'a'],
+      [2, 'b'],
+    ])
+    try {
+      const res = (await redisClient?.zrandmember(key, -8)) as string[]
+      assert.strictEqual(res.length, 8)
+      for (const m of res) assert.ok(['a', 'b'].includes(m))
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANDMEMBER WITHSCORES returns member/score pairs', async () => {
+    const key = await seedScored([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+    ])
+    try {
+      const res = (await redisClient?.zrandmember(
+        key,
+        2,
+        'WITHSCORES',
+      )) as string[]
+      assert.strictEqual(res.length, 4)
+      const scores: Record<string, string> = { a: '1', b: '2', c: '3' }
+      for (let i = 0; i < res.length; i += 2) {
+        assert.strictEqual(res[i + 1], scores[res[i]])
+      }
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANDMEMBER with count 0 returns empty array', async () => {
+    const key = await seedScored([[1, 'a']])
+    try {
+      assert.deepStrictEqual(await redisClient?.zrandmember(key, 0), [])
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANDMEMBER on a missing key returns nil / empty array', async () => {
+    const key = `{zmod:${randomKey()}}`
+    assert.strictEqual(await redisClient?.zrandmember(key), null)
+    assert.deepStrictEqual(await redisClient?.zrandmember(key, 3), [])
+  })
+
+  test('ZRANDMEMBER with non-integer count errors', async () => {
+    const key = await seedScored([[1, 'a']])
+    try {
+      await assert.rejects(
+        () => redisClient?.call('zrandmember', key, 'x'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      // WITHSCORES without a count is parsed as the count token -> not an integer
+      await assert.rejects(
+        () => redisClient?.call('zrandmember', key, 'WITHSCORES'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANDMEMBER on a wrong-type key returns WRONGTYPE', async () => {
+    const key = `{zmod:${randomKey()}}`
+    await redisClient?.set(key, 'notazset')
+    try {
+      await assert.rejects(
+        () => redisClient?.zrandmember(key),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  // ---------- modern ZRANGE: index form (legacy still works) ----------
+
+  test('ZRANGE legacy index form returns members in order', async () => {
+    const key = await seedScored([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+      [4, 'd'],
+      [5, 'e'],
+    ])
+    try {
+      assert.deepStrictEqual(await redisClient?.zrange(key, 0, -1), [
+        'a',
+        'b',
+        'c',
+        'd',
+        'e',
+      ])
+      assert.deepStrictEqual(await redisClient?.zrange(key, 1, 3), [
+        'b',
+        'c',
+        'd',
+      ])
+      assert.deepStrictEqual(
+        await redisClient?.zrange(key, 0, -1, 'WITHSCORES'),
+        ['a', '1', 'b', '2', 'c', '3', 'd', '4', 'e', '5'],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGE REV reverses the index ordering', async () => {
+    const key = await seedScored([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+    ])
+    try {
+      assert.deepStrictEqual(await redisClient?.zrange(key, 0, -1, 'REV'), [
+        'c',
+        'b',
+        'a',
+      ])
+      assert.deepStrictEqual(
+        await redisClient?.zrange(key, 0, -1, 'REV', 'WITHSCORES'),
+        ['c', '3', 'b', '2', 'a', '1'],
+      )
+      assert.deepStrictEqual(await redisClient?.zrange(key, 1, 2, 'REV'), [
+        'b',
+        'a',
+      ])
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  // ---------- modern ZRANGE: BYSCORE ----------
+
+  test('ZRANGE BYSCORE filters by score bounds', async () => {
+    const key = await seedScored([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+      [4, 'd'],
+      [5, 'e'],
+    ])
+    try {
+      assert.deepStrictEqual(
+        await redisClient?.zrange(key, '(1', '4', 'BYSCORE'),
+        ['b', 'c', 'd'],
+      )
+      assert.deepStrictEqual(
+        await redisClient?.zrange(key, '-inf', '+inf', 'BYSCORE', 'WITHSCORES'),
+        ['a', '1', 'b', '2', 'c', '3', 'd', '4', 'e', '5'],
+      )
+      assert.deepStrictEqual(
+        await redisClient?.zrange(
+          key,
+          '-inf',
+          '+inf',
+          'BYSCORE',
+          'LIMIT',
+          1,
+          2,
+        ),
+        ['b', 'c'],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGE BYSCORE REV takes bounds as max min and reverses', async () => {
+    const key = await seedScored([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+      [4, 'd'],
+      [5, 'e'],
+    ])
+    try {
+      assert.deepStrictEqual(
+        await redisClient?.zrange(key, 5, 2, 'BYSCORE', 'REV'),
+        ['e', 'd', 'c', 'b'],
+      )
+      assert.deepStrictEqual(
+        await redisClient?.zrange(key, 5, 2, 'BYSCORE', 'REV', 'WITHSCORES'),
+        ['e', '5', 'd', '4', 'c', '3', 'b', '2'],
+      )
+      // min given before max with REV -> empty
+      assert.deepStrictEqual(
+        await redisClient?.zrange(key, 2, 5, 'BYSCORE', 'REV'),
+        [],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  // ---------- modern ZRANGE: BYLEX ----------
+
+  test('ZRANGE BYLEX filters by lex bounds', async () => {
+    const key = await seedLex(['a', 'b', 'c', 'd', 'e'])
+    try {
+      assert.deepStrictEqual(
+        await redisClient?.zrange(key, '[a', '[c', 'BYLEX'),
+        ['a', 'b', 'c'],
+      )
+      assert.deepStrictEqual(
+        await redisClient?.zrange(key, '-', '+', 'BYLEX', 'LIMIT', 1, 2),
+        ['b', 'c'],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGE BYLEX REV takes bounds as max min and reverses', async () => {
+    const key = await seedLex(['a', 'b', 'c', 'd', 'e'])
+    try {
+      assert.deepStrictEqual(
+        await redisClient?.zrange(key, '[c', '[a', 'BYLEX', 'REV'),
+        ['c', 'b', 'a'],
+      )
+      assert.deepStrictEqual(
+        await redisClient?.zrange(key, '+', '-', 'BYLEX', 'REV', 'LIMIT', 1, 2),
+        ['d', 'c'],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGE on a missing key returns empty array', async () => {
+    const key = `{zmod:${randomKey()}}`
+    assert.deepStrictEqual(await redisClient?.zrange(key, 0, -1), [])
+    assert.deepStrictEqual(
+      await redisClient?.zrange(key, '-inf', '+inf', 'BYSCORE'),
+      [],
+    )
+    assert.deepStrictEqual(
+      await redisClient?.zrange(key, '-', '+', 'BYLEX'),
+      [],
+    )
+  })
+
+  // ---------- modern ZRANGE: error paths ----------
+
+  test('ZRANGE rejects invalid option combinations', async () => {
+    const key = await seedScored([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+    ])
+    try {
+      await assert.rejects(
+        () => redisClient?.call('zrange', key, '0', '-1', 'LIMIT', '0', '2'),
+        errorWithMessage(
+          'ERR syntax error, LIMIT is only supported in combination with either BYSCORE or BYLEX',
+        ),
+      )
+      await assert.rejects(
+        () => redisClient?.call('zrange', key, '-', '+', 'BYLEX', 'WITHSCORES'),
+        errorWithMessage(
+          'ERR syntax error, WITHSCORES not supported in combination with BYLEX',
+        ),
+      )
+      await assert.rejects(
+        () => redisClient?.call('zrange', key, '-', '+', 'BYSCORE', 'BYLEX'),
+        errorWithMessage('ERR syntax error'),
+      )
+      // index form requires integer start/stop
+      await assert.rejects(
+        () => redisClient?.call('zrange', key, '(1', '4'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () => redisClient?.call('zrange', key, 'x', '5', 'BYSCORE'),
+        errorWithMessage('ERR min or max is not a float'),
+      )
+      await assert.rejects(
+        () => redisClient?.call('zrange', key, 'a', 'c', 'BYLEX'),
+        errorWithMessage('ERR min or max not valid string range item'),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.call(
+            'zrange',
+            key,
+            '-inf',
+            '+inf',
+            'BYSCORE',
+            'LIMIT',
+            'a',
+            'b',
+          ),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () => redisClient?.call('zrange', key, '0'),
+        errorWithMessage("ERR wrong number of arguments for 'zrange' command"),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Adds the Redis 6.2+ sorted-set surface for #109.
- **ZMSCORE** `key member [member ...]` — returns an array of scores, nil per missing member; WRONGTYPE on a non-zset key; wrong-arity on no members.
- **ZRANDMEMBER** `key [count [WITHSCORES]]` — no count returns one random member (nil on miss); positive count returns distinct members capped at cardinality; negative count allows repeats with `|count|` length; optional `WITHSCORES`. `ZRANDMEMBER key WITHSCORES` (no count) errors with `value is not an integer` like real Redis.
- **ZRANGE** extended to `ZRANGE key min max [BYSCORE | BYLEX] [REV] [LIMIT offset count] [WITHSCORES]`. Reuses the existing score-range (`parseScoreBoundArg`) and lex-range (`parseLexBoundArg`/`getLexSortedMembers`) helpers shared with ZRANGEBYSCORE/ZRANGEBYLEX. With `REV` the bounds are given as `max min` (matching ZREVRANGEBYSCORE/ZREVRANGEBYLEX). `LIMIT` requires BYSCORE/BYLEX and `WITHSCORES` is rejected with BYLEX — both with the exact real-Redis error strings.
- New error classes `ZrangeLimitWithoutByError` / `ZrangeWithScoresByLexError`.
- Docs: updated docs/COMMANDS.md (modern ZRANGE signature, ZMSCORE/ZRANDMEMBER moved to implemented, gap notes rescoped to ZREVRANGE).

Closes #109

## Test plan
- [x] New integration test `tests-integration/ioredis/zset-modern-range-integration.test.ts` (21 cases) reproduces the gap (20/21 red on mock before fix)
- [x] Test passes against real Redis before the fix (confirms mock-only gap, expected behavior matches real Redis)
- [x] Fix makes the test pass on mock too
- [x] Covers error/edge paths: wrong arity, WRONGTYPE, non-integer count, invalid score/lex bounds, LIMIT-without-BY, WITHSCORES-with-BYLEX, BYSCORE+BYLEX, missing-key sentinels
- [x] `npm run build`, `npm run lint`, `npm run test:all` all pass (unit 145, mock 351, real 351)