### PR TITLE
feat: ZSet set operations (ZUNIONSTORE/ZINTERSTORE/ZUNION/ZINTER/ZDIFF/ZDIFFSTORE/ZINTERCARD) (#107)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -260,6 +260,13 @@ with `GT` or `LT`.
 - [x] `ZPOPMIN key [count]` - Remove and return members with the lowest scores
 - [x] `ZPOPMAX key [count]` - Remove and return members with the highest scores
 - [x] `ZSCAN key cursor [MATCH pattern] [COUNT count]` - Incrementally iterate members and scores (see [Scan Family](#10-scan-family))
+- [x] `ZUNIONSTORE destination numkeys key [key ...] [WEIGHTS weight [weight ...]] [AGGREGATE SUM|MIN|MAX]` - Union of sorted sets (or plain sets, scored 1) into destination; empty result deletes destination
+- [x] `ZINTERSTORE destination numkeys key [key ...] [WEIGHTS weight [weight ...]] [AGGREGATE SUM|MIN|MAX]` - Intersection of sorted sets into destination; empty result deletes destination
+- [x] `ZDIFFSTORE destination numkeys key [key ...]` - Difference of sorted sets into destination; empty result deletes destination
+- [x] `ZUNION numkeys key [key ...] [WEIGHTS weight [weight ...]] [AGGREGATE SUM|MIN|MAX] [WITHSCORES]` - Union of sorted sets without storing the result
+- [x] `ZINTER numkeys key [key ...] [WEIGHTS weight [weight ...]] [AGGREGATE SUM|MIN|MAX] [WITHSCORES]` - Intersection of sorted sets without storing the result
+- [x] `ZDIFF numkeys key [key ...] [WITHSCORES]` - Difference of sorted sets without storing the result
+- [x] `ZINTERCARD numkeys key [key ...] [LIMIT limit]` - Count members in the intersection of sorted sets (LIMIT 0 means no cap)
 
 #### Notes / gaps vs. real Redis
 
@@ -271,7 +278,6 @@ with `GT` or `LT`.
 #### Not implemented
 
 - [ ] `ZREVRANGEBYSCORE` / `ZREMRANGEBYRANK`
-- [ ] `ZUNIONSTORE` / `ZINTERSTORE` / `ZDIFFSTORE` / `ZUNION` / `ZINTER` / `ZDIFF` / `ZINTERCARD`
 - [ ] `ZRANGESTORE` / `ZMPOP` / `BZPOPMIN` / `BZPOPMAX` / `BZMPOP`
 
 ## 9. Stream Commands

--- a/src/commands/zsets/index.ts
+++ b/src/commands/zsets/index.ts
@@ -17,6 +17,15 @@ import {
   zrevrangebylexCommand,
 } from './zrangebylex'
 import { zpopmaxCommand, zpopminCommand } from './zpop'
+import {
+  zdiffCommand,
+  zdiffstoreCommand,
+  zintercardCommand,
+  zinterCommand,
+  zinterstoreCommand,
+  zunionCommand,
+  zunionstoreCommand,
+} from './zsetops'
 
 export const zsetsCommands = [
   zaddCommand,
@@ -39,6 +48,13 @@ export const zsetsCommands = [
   zremrangebylexCommand,
   zpopminCommand,
   zpopmaxCommand,
+  zunionstoreCommand,
+  zinterstoreCommand,
+  zdiffstoreCommand,
+  zunionCommand,
+  zinterCommand,
+  zdiffCommand,
+  zintercardCommand,
 ]
 
 export {
@@ -62,4 +78,11 @@ export {
   zremrangebylexCommand,
   zpopminCommand,
   zpopmaxCommand,
+  zunionstoreCommand,
+  zinterstoreCommand,
+  zdiffstoreCommand,
+  zunionCommand,
+  zinterCommand,
+  zdiffCommand,
+  zintercardCommand,
 }

--- a/src/commands/zsets/zsetops.ts
+++ b/src/commands/zsets/zsetops.ts
@@ -1,0 +1,396 @@
+import { defineCommand } from '../../core/command-definition'
+import { t, type ParseContext } from '../../core/command-schema'
+import {
+  AtLeastOneInputKeyError,
+  LimitCantBeNegativeError,
+  RedisSyntaxError,
+  WeightNotFloatError,
+  WrongNumberOfArgumentsError,
+  WrongTypeRedisError,
+} from '../../core/redis-error'
+import { RedisValue } from '../../core/redis-value'
+import type {
+  RedisDatabase,
+  RedisSortedSetData,
+  RedisSortedSetMember,
+} from '../../state'
+import { array, integer, parseIntegerToken, scoreBuffer } from '../helpers'
+import { getSortedMembers } from './helpers'
+
+// ZUNIONSTORE/ZINTERSTORE/ZUNION/ZINTER/ZDIFF/ZDIFFSTORE/ZINTERCARD.
+// Source keys may be sorted sets OR plain sets (a set is treated as a zset with
+// every member scored 1). WEIGHTS multiply each source's scores before they are
+// combined; AGGREGATE (SUM default, MIN, MAX) controls how scores merge. ZDIFF
+// has neither WEIGHTS nor AGGREGATE — it just subtracts members, keeping the
+// scores from the first key. STORE variants write the result to a destination
+// key (deleting it when the result is empty) and reply with the cardinality.
+
+type Aggregate = 'sum' | 'min' | 'max'
+
+type SetOpArgs = {
+  destination?: Buffer
+  keys: Buffer[]
+  weights?: number[]
+  aggregate: Aggregate
+  withScores: boolean
+}
+
+type ParserOptions = {
+  hasDest: boolean
+  weightsAggregate: boolean
+}
+
+// ---------------------------------------------------------------- shared logic
+
+function getScoredMembers(
+  db: RedisDatabase,
+  key: Buffer,
+): Map<string, RedisSortedSetMember> {
+  const type = db.getType(key)
+  if (type === null) return new Map()
+
+  if (type === 'zset') {
+    const zset = db.getSortedSet(key)!
+    return new Map(
+      Array.from(zset.members, ([hex, m]) => [
+        hex,
+        { member: m.member, score: m.score },
+      ]),
+    )
+  }
+
+  if (type === 'set') {
+    const set = db.getSet(key)!
+    return new Map(
+      Array.from(set.members, ([hex, member]) => [hex, { member, score: 1 }]),
+    )
+  }
+
+  throw new WrongTypeRedisError()
+}
+
+function weightedScore(score: number, weight: number): number {
+  const result = weight * score
+  // Redis resets a NaN weighted score (e.g. 0 * inf) to 0 before aggregating.
+  return Number.isNaN(result) ? 0 : result
+}
+
+function aggregateScores(a: number, b: number, aggregate: Aggregate): number {
+  if (aggregate === 'min') return Math.min(a, b)
+  if (aggregate === 'max') return Math.max(a, b)
+  const sum = a + b
+  // SUM of +inf and -inf is NaN; Redis stores 0 in that case.
+  return Number.isNaN(sum) ? 0 : sum
+}
+
+function weightAt(weights: number[] | undefined, index: number): number {
+  return weights ? weights[index] : 1
+}
+
+function computeUnion(
+  sources: Map<string, RedisSortedSetMember>[],
+  weights: number[] | undefined,
+  aggregate: Aggregate,
+): Map<string, RedisSortedSetMember> {
+  const result = new Map<string, RedisSortedSetMember>()
+  for (let i = 0; i < sources.length; i++) {
+    const weight = weightAt(weights, i)
+    for (const [hex, { member, score }] of sources[i]) {
+      const weighted = weightedScore(score, weight)
+      const existing = result.get(hex)
+      if (!existing) {
+        result.set(hex, { member, score: weighted })
+        continue
+      }
+      existing.score = aggregateScores(existing.score, weighted, aggregate)
+    }
+  }
+  return result
+}
+
+function computeIntersection(
+  sources: Map<string, RedisSortedSetMember>[],
+  weights: number[] | undefined,
+  aggregate: Aggregate,
+): Map<string, RedisSortedSetMember> {
+  const result = new Map<string, RedisSortedSetMember>()
+  const [first, ...rest] = sources
+  for (const [hex, { member, score }] of first) {
+    let acc = weightedScore(score, weightAt(weights, 0))
+    let present = true
+    for (let i = 0; i < rest.length; i++) {
+      const entry = rest[i].get(hex)
+      if (!entry) {
+        present = false
+        break
+      }
+      acc = aggregateScores(
+        acc,
+        weightedScore(entry.score, weightAt(weights, i + 1)),
+        aggregate,
+      )
+    }
+    if (present) result.set(hex, { member, score: acc })
+  }
+  return result
+}
+
+function computeDifference(
+  sources: Map<string, RedisSortedSetMember>[],
+): Map<string, RedisSortedSetMember> {
+  const [first, ...rest] = sources
+  const result = new Map(first)
+  for (const source of rest) {
+    for (const hex of source.keys()) result.delete(hex)
+  }
+  return result
+}
+
+function buildScoredOutput(
+  members: Map<string, RedisSortedSetMember>,
+  withScores: boolean,
+): RedisValue[] {
+  const sorted = getSortedMembers({
+    type: 'zset',
+    members,
+  } as RedisSortedSetData)
+  const items: RedisValue[] = []
+  for (const entry of sorted) {
+    items.push(RedisValue.bulkString(entry.member))
+    if (withScores) items.push(RedisValue.bulkString(scoreBuffer(entry.score)))
+  }
+  return items
+}
+
+function storeResult(
+  db: RedisDatabase,
+  destination: Buffer,
+  members: Map<string, RedisSortedSetMember>,
+): number {
+  if (members.size === 0) {
+    db.delete(destination)
+    return 0
+  }
+  db.updateSortedSet(destination, zset => {
+    zset.members.clear()
+    for (const [hex, member] of members) zset.members.set(hex, member)
+  })
+  return members.size
+}
+
+// ------------------------------------------------------------------- parsing
+
+function parseWeight(token: Buffer): number {
+  const raw = token.toString()
+  const normalized = raw.toLowerCase()
+  if (normalized === 'inf' || normalized === '+inf') return Infinity
+  if (normalized === '-inf') return -Infinity
+
+  const value = Number(raw)
+  if (raw.trim() === '' || !Number.isFinite(value)) {
+    throw new WeightNotFloatError()
+  }
+  return value
+}
+
+function parseSetOp(
+  input: readonly Buffer[],
+  index: number,
+  ctx: ParseContext,
+  options: ParserOptions,
+): SetOpArgs {
+  let cursor = index
+
+  let destination: Buffer | undefined
+  if (options.hasDest) {
+    destination = input[cursor]
+    if (!destination) throw new WrongNumberOfArgumentsError(ctx.commandName)
+    cursor++
+  }
+
+  const numkeysToken = input[cursor]
+  if (!numkeysToken) throw new WrongNumberOfArgumentsError(ctx.commandName)
+  cursor++
+
+  const numkeys = parseIntegerToken(numkeysToken)
+  if (numkeys <= 0) throw new AtLeastOneInputKeyError(ctx.commandName)
+  if (cursor + numkeys > input.length) throw new RedisSyntaxError()
+
+  const keys = input.slice(cursor, cursor + numkeys)
+  cursor += numkeys
+
+  let weights: number[] | undefined
+  let aggregate: Aggregate = 'sum'
+  let withScores = false
+
+  while (cursor < input.length) {
+    const option = input[cursor]!.toString().toUpperCase()
+
+    if (options.weightsAggregate && option === 'WEIGHTS') {
+      cursor++
+      weights = []
+      for (let i = 0; i < numkeys; i++) {
+        const token = input[cursor]
+        if (!token) throw new RedisSyntaxError()
+        weights.push(parseWeight(token))
+        cursor++
+      }
+      continue
+    }
+
+    if (options.weightsAggregate && option === 'AGGREGATE') {
+      cursor++
+      const token = input[cursor]
+      if (!token) throw new RedisSyntaxError()
+      const value = token.toString().toUpperCase()
+      if (value === 'SUM') aggregate = 'sum'
+      else if (value === 'MIN') aggregate = 'min'
+      else if (value === 'MAX') aggregate = 'max'
+      else throw new RedisSyntaxError()
+      cursor++
+      continue
+    }
+
+    // WITHSCORES is only valid for the non-store ZUNION/ZINTER/ZDIFF variants.
+    if (!options.hasDest && option === 'WITHSCORES') {
+      withScores = true
+      cursor++
+      continue
+    }
+
+    throw new RedisSyntaxError()
+  }
+
+  return { destination, keys, weights, aggregate, withScores }
+}
+
+function setOpSchema(options: ParserOptions) {
+  return t.custom<SetOpArgs>((input, index, ctx) => ({
+    value: parseSetOp(input, index, ctx, options),
+    nextIndex: input.length,
+  }))
+}
+
+// ------------------------------------------------------------------- commands
+
+export const zunionstoreCommand = defineCommand({
+  name: 'zunionstore',
+  schema: setOpSchema({ hasDest: true, weightsAggregate: true }),
+  flags: ['write', 'denyoom'],
+  keys: args => [args.destination!, ...args.keys],
+  execute: (args, ctx) => {
+    const sources = args.keys.map(k => getScoredMembers(ctx.db, k))
+    const result = computeUnion(sources, args.weights, args.aggregate)
+    return integer(storeResult(ctx.db, args.destination!, result))
+  },
+})
+
+export const zinterstoreCommand = defineCommand({
+  name: 'zinterstore',
+  schema: setOpSchema({ hasDest: true, weightsAggregate: true }),
+  flags: ['write', 'denyoom'],
+  keys: args => [args.destination!, ...args.keys],
+  execute: (args, ctx) => {
+    const sources = args.keys.map(k => getScoredMembers(ctx.db, k))
+    const result = computeIntersection(sources, args.weights, args.aggregate)
+    return integer(storeResult(ctx.db, args.destination!, result))
+  },
+})
+
+export const zdiffstoreCommand = defineCommand({
+  name: 'zdiffstore',
+  schema: setOpSchema({ hasDest: true, weightsAggregate: false }),
+  flags: ['write', 'denyoom'],
+  keys: args => [args.destination!, ...args.keys],
+  execute: (args, ctx) => {
+    const sources = args.keys.map(k => getScoredMembers(ctx.db, k))
+    const result = computeDifference(sources)
+    return integer(storeResult(ctx.db, args.destination!, result))
+  },
+})
+
+export const zunionCommand = defineCommand({
+  name: 'zunion',
+  schema: setOpSchema({ hasDest: false, weightsAggregate: true }),
+  flags: ['readonly'],
+  keys: args => args.keys,
+  execute: (args, ctx) => {
+    const sources = args.keys.map(k => getScoredMembers(ctx.db, k))
+    const result = computeUnion(sources, args.weights, args.aggregate)
+    return array(buildScoredOutput(result, args.withScores))
+  },
+})
+
+export const zinterCommand = defineCommand({
+  name: 'zinter',
+  schema: setOpSchema({ hasDest: false, weightsAggregate: true }),
+  flags: ['readonly'],
+  keys: args => args.keys,
+  execute: (args, ctx) => {
+    const sources = args.keys.map(k => getScoredMembers(ctx.db, k))
+    const result = computeIntersection(sources, args.weights, args.aggregate)
+    return array(buildScoredOutput(result, args.withScores))
+  },
+})
+
+export const zdiffCommand = defineCommand({
+  name: 'zdiff',
+  schema: setOpSchema({ hasDest: false, weightsAggregate: false }),
+  flags: ['readonly'],
+  keys: args => args.keys,
+  execute: (args, ctx) => {
+    const sources = args.keys.map(k => getScoredMembers(ctx.db, k))
+    const result = computeDifference(sources)
+    return array(buildScoredOutput(result, args.withScores))
+  },
+})
+
+// ZINTERCARD numkeys key [key ...] [LIMIT limit]
+type ZintercardArgs = { keys: Buffer[]; limit: number }
+
+const zintercardSchema = t.custom<ZintercardArgs>((input, index, ctx) => {
+  let cursor = index
+
+  const numkeysToken = input[cursor]
+  if (!numkeysToken) throw new WrongNumberOfArgumentsError(ctx.commandName)
+  cursor++
+
+  const numkeys = parseIntegerToken(numkeysToken)
+  if (numkeys <= 0) throw new AtLeastOneInputKeyError(ctx.commandName)
+  if (cursor + numkeys > input.length) throw new RedisSyntaxError()
+
+  const keys = input.slice(cursor, cursor + numkeys)
+  cursor += numkeys
+
+  let limit = 0
+  if (cursor < input.length) {
+    if (input[cursor]!.toString().toUpperCase() !== 'LIMIT') {
+      throw new RedisSyntaxError()
+    }
+    cursor++
+    const limitToken = input[cursor]
+    if (!limitToken) throw new RedisSyntaxError()
+    const value = Number(limitToken.toString())
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new LimitCantBeNegativeError()
+    }
+    limit = value
+    cursor++
+    if (cursor !== input.length) throw new RedisSyntaxError()
+  }
+
+  return { value: { keys, limit }, nextIndex: input.length }
+})
+
+export const zintercardCommand = defineCommand({
+  name: 'zintercard',
+  schema: zintercardSchema,
+  flags: ['readonly'],
+  keys: args => args.keys,
+  execute: (args, ctx) => {
+    const sources = args.keys.map(k => getScoredMembers(ctx.db, k))
+    const count = computeIntersection(sources, undefined, 'sum').size
+    if (args.limit > 0) return integer(Math.min(count, args.limit))
+    return integer(count)
+  },
+})

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -234,6 +234,19 @@ export class NumKeysGreaterThanZeroError extends RedisCommandError {
   }
 }
 
+/** ZUNION/ZINTER/ZDIFF family when numkeys <= 0. */
+export class AtLeastOneInputKeyError extends RedisCommandError {
+  constructor(commandName: string) {
+    super(`at least 1 input key is needed for '${commandName}' command`)
+  }
+}
+
+export class WeightNotFloatError extends RedisCommandError {
+  constructor() {
+    super('weight value is not a float')
+  }
+}
+
 export class CountGreaterThanZeroError extends RedisCommandError {
   constructor() {
     super('count should be greater than 0')

--- a/tests-integration/ioredis/zset-setops-integration.test.ts
+++ b/tests-integration/ioredis/zset-setops-integration.test.ts
@@ -1,0 +1,437 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster, Redis } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { connectToSlotOwner, errorWithMessage, randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+describe(`Sorted Set Set-Operations (${testRunner.getBackendName()})`, () => {
+  let redisClient: Cluster | undefined
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster(
+      'zset-setops-integration',
+    )
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  // All keys in a single op must hash to the same slot, so every test shares a
+  // hash tag and talks to that slot's owner through a prefix-free directClient.
+  async function withOps(
+    fn: (client: Redis, k: (name: string) => string) => Promise<void>,
+  ): Promise<void> {
+    assert.ok(redisClient)
+    const tag = `{zsetops:${randomKey()}}`
+    const k = (name: string) => `${tag}:${name}`
+    const directClient = await connectToSlotOwner(redisClient, k('seed'))
+    try {
+      await fn(directClient, k)
+    } finally {
+      directClient.disconnect()
+    }
+  }
+
+  // ---------------------------------------------------------------- ZUNIONSTORE
+
+  test('ZUNIONSTORE sums scores by default and stores the result', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a', 2, 'b', 3, 'c')
+      await c.zadd(k('z2'), 10, 'b', 20, 'c', 30, 'd')
+
+      const n = await c.call('ZUNIONSTORE', k('dest'), '2', k('z1'), k('z2'))
+      assert.strictEqual(n, 4)
+      assert.deepStrictEqual(
+        await c.call('ZRANGE', k('dest'), '0', '-1', 'WITHSCORES'),
+        ['a', '1', 'b', '12', 'c', '23', 'd', '30'],
+      )
+    })
+  })
+
+  test('ZUNIONSTORE applies WEIGHTS before aggregating', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a', 2, 'b', 3, 'c')
+      await c.zadd(k('z2'), 10, 'b', 20, 'c', 30, 'd')
+
+      await c.call(
+        'ZUNIONSTORE',
+        k('dest'),
+        '2',
+        k('z1'),
+        k('z2'),
+        'WEIGHTS',
+        '2',
+        '3',
+      )
+      assert.deepStrictEqual(
+        await c.call('ZRANGE', k('dest'), '0', '-1', 'WITHSCORES'),
+        ['a', '2', 'b', '34', 'c', '66', 'd', '90'],
+      )
+    })
+  })
+
+  test('ZUNIONSTORE honors AGGREGATE MIN and MAX', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a', 2, 'b', 3, 'c')
+      await c.zadd(k('z2'), 10, 'b', 20, 'c', 30, 'd')
+
+      await c.call(
+        'ZUNIONSTORE',
+        k('dest'),
+        '2',
+        k('z1'),
+        k('z2'),
+        'AGGREGATE',
+        'MIN',
+      )
+      assert.deepStrictEqual(
+        await c.call('ZRANGE', k('dest'), '0', '-1', 'WITHSCORES'),
+        ['a', '1', 'b', '2', 'c', '3', 'd', '30'],
+      )
+
+      await c.call(
+        'ZUNIONSTORE',
+        k('dest'),
+        '2',
+        k('z1'),
+        k('z2'),
+        'AGGREGATE',
+        'MAX',
+      )
+      assert.deepStrictEqual(
+        await c.call('ZRANGE', k('dest'), '0', '-1', 'WITHSCORES'),
+        ['a', '1', 'b', '10', 'c', '20', 'd', '30'],
+      )
+    })
+  })
+
+  test('ZUNIONSTORE treats a plain set source as scores of 1', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a', 2, 'b', 3, 'c')
+      await c.sadd(k('s1'), 'a', 'b', 'x')
+
+      await c.call('ZUNIONSTORE', k('dest'), '2', k('z1'), k('s1'))
+      assert.deepStrictEqual(
+        await c.call('ZRANGE', k('dest'), '0', '-1', 'WITHSCORES'),
+        ['x', '1', 'a', '2', 'b', '3', 'c', '3'],
+      )
+    })
+  })
+
+  test('ZUNIONSTORE resets a SUM that becomes NaN (inf + -inf) to 0', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('za'), '+inf', 'm')
+      await c.zadd(k('zb'), '-inf', 'm')
+
+      await c.call('ZUNIONSTORE', k('dest'), '2', k('za'), k('zb'))
+      assert.strictEqual(await c.call('ZSCORE', k('dest'), 'm'), '0')
+    })
+  })
+
+  // ---------------------------------------------------------------- ZINTERSTORE
+
+  test('ZINTERSTORE keeps only common members, summing scores', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a', 2, 'b', 3, 'c')
+      await c.zadd(k('z2'), 10, 'b', 20, 'c', 30, 'd')
+
+      const n = await c.call('ZINTERSTORE', k('dest'), '2', k('z1'), k('z2'))
+      assert.strictEqual(n, 2)
+      assert.deepStrictEqual(
+        await c.call('ZRANGE', k('dest'), '0', '-1', 'WITHSCORES'),
+        ['b', '12', 'c', '23'],
+      )
+    })
+  })
+
+  test('ZINTERSTORE with empty result deletes the destination key', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a')
+      await c.zadd(k('z2'), 1, 'b')
+      await c.set(k('dest'), 'preexisting')
+
+      const n = await c.call('ZINTERSTORE', k('dest'), '2', k('z1'), k('z2'))
+      assert.strictEqual(n, 0)
+      assert.strictEqual(await c.exists(k('dest')), 0)
+    })
+  })
+
+  // ----------------------------------------------------------- ZUNION / ZINTER
+
+  test('ZUNION returns the union, with and without WITHSCORES', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a', 2, 'b', 3, 'c')
+      await c.zadd(k('z2'), 10, 'b', 20, 'c', 30, 'd')
+
+      assert.deepStrictEqual(await c.call('ZUNION', '2', k('z1'), k('z2')), [
+        'a',
+        'b',
+        'c',
+        'd',
+      ])
+      assert.deepStrictEqual(
+        await c.call('ZUNION', '2', k('z1'), k('z2'), 'WITHSCORES'),
+        ['a', '1', 'b', '12', 'c', '23', 'd', '30'],
+      )
+    })
+  })
+
+  test('ZINTER returns the intersection WITHSCORES', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a', 2, 'b', 3, 'c')
+      await c.zadd(k('z2'), 10, 'b', 20, 'c', 30, 'd')
+
+      assert.deepStrictEqual(
+        await c.call('ZINTER', '2', k('z1'), k('z2'), 'WITHSCORES'),
+        ['b', '12', 'c', '23'],
+      )
+    })
+  })
+
+  // ----------------------------------------------------------- ZDIFF / STORE
+
+  test('ZDIFF returns members of the first set not in the rest', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a', 2, 'b', 3, 'c')
+      await c.zadd(k('z2'), 10, 'b', 20, 'c')
+
+      assert.deepStrictEqual(await c.call('ZDIFF', '2', k('z1'), k('z2')), [
+        'a',
+      ])
+      assert.deepStrictEqual(
+        await c.call('ZDIFF', '2', k('z1'), k('z2'), 'WITHSCORES'),
+        ['a', '1'],
+      )
+    })
+  })
+
+  test('ZDIFFSTORE stores the difference and returns its cardinality', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a', 2, 'b', 3, 'c')
+      await c.zadd(k('z2'), 10, 'b', 20, 'c')
+
+      const n = await c.call('ZDIFFSTORE', k('dest'), '2', k('z1'), k('z2'))
+      assert.strictEqual(n, 1)
+      assert.deepStrictEqual(
+        await c.call('ZRANGE', k('dest'), '0', '-1', 'WITHSCORES'),
+        ['a', '1'],
+      )
+    })
+  })
+
+  // ----------------------------------------------------------------- ZINTERCARD
+
+  test('ZINTERCARD counts the intersection and honors LIMIT', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a', 2, 'b', 3, 'c')
+      await c.zadd(k('z2'), 10, 'b', 20, 'c', 30, 'd')
+
+      assert.strictEqual(await c.call('ZINTERCARD', '2', k('z1'), k('z2')), 2)
+      assert.strictEqual(
+        await c.call('ZINTERCARD', '2', k('z1'), k('z2'), 'LIMIT', '1'),
+        1,
+      )
+      // LIMIT 0 means no limit
+      assert.strictEqual(
+        await c.call('ZINTERCARD', '2', k('z1'), k('z2'), 'LIMIT', '0'),
+        2,
+      )
+    })
+  })
+
+  // -------------------------------------------------------------- error paths
+
+  test('ZUNIONSTORE rejects numkeys <= 0 with the input-key error', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a')
+      await assert.rejects(
+        () => c.call('ZUNIONSTORE', k('dest'), '0', k('z1')),
+        errorWithMessage(
+          "ERR at least 1 input key is needed for 'zunionstore' command",
+        ),
+      )
+      await assert.rejects(
+        () => c.call('ZUNIONSTORE', k('dest'), '-1', k('z1')),
+        errorWithMessage(
+          "ERR at least 1 input key is needed for 'zunionstore' command",
+        ),
+      )
+    })
+  })
+
+  test('ZUNION rejects numkeys <= 0 with the input-key error', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a')
+      await assert.rejects(
+        () => c.call('ZUNION', '0', k('z1')),
+        errorWithMessage(
+          "ERR at least 1 input key is needed for 'zunion' command",
+        ),
+      )
+    })
+  })
+
+  test('ZINTERCARD rejects numkeys <= 0 with the input-key error', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a')
+      await assert.rejects(
+        () => c.call('ZINTERCARD', '0', k('z1')),
+        errorWithMessage(
+          "ERR at least 1 input key is needed for 'zintercard' command",
+        ),
+      )
+    })
+  })
+
+  test('ZUNIONSTORE rejects a non-integer numkeys', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a')
+      await assert.rejects(
+        () => c.call('ZUNIONSTORE', k('dest'), 'abc', k('z1')),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+    })
+  })
+
+  test('ZUNIONSTORE rejects numkeys greater than available keys', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a')
+      await c.zadd(k('z2'), 1, 'b')
+      await assert.rejects(
+        () => c.call('ZUNIONSTORE', k('dest'), '3', k('z1'), k('z2')),
+        errorWithMessage('ERR syntax error'),
+      )
+    })
+  })
+
+  test('ZUNIONSTORE rejects a WEIGHTS count mismatch', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a')
+      await c.zadd(k('z2'), 1, 'b')
+      await assert.rejects(
+        () =>
+          c.call(
+            'ZUNIONSTORE',
+            k('dest'),
+            '2',
+            k('z1'),
+            k('z2'),
+            'WEIGHTS',
+            '1',
+          ),
+        errorWithMessage('ERR syntax error'),
+      )
+    })
+  })
+
+  test('ZUNIONSTORE rejects a non-float weight', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a')
+      await c.zadd(k('z2'), 1, 'b')
+      await assert.rejects(
+        () =>
+          c.call(
+            'ZUNIONSTORE',
+            k('dest'),
+            '2',
+            k('z1'),
+            k('z2'),
+            'WEIGHTS',
+            'x',
+            'y',
+          ),
+        errorWithMessage('ERR weight value is not a float'),
+      )
+    })
+  })
+
+  test('ZUNIONSTORE rejects an invalid AGGREGATE value', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a')
+      await c.zadd(k('z2'), 1, 'b')
+      await assert.rejects(
+        () =>
+          c.call(
+            'ZUNIONSTORE',
+            k('dest'),
+            '2',
+            k('z1'),
+            k('z2'),
+            'AGGREGATE',
+            'foo',
+          ),
+        errorWithMessage('ERR syntax error'),
+      )
+    })
+  })
+
+  test('ZUNIONSTORE rejects WITHSCORES (store variants have no scores option)', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a')
+      await c.zadd(k('z2'), 1, 'b')
+      await assert.rejects(
+        () =>
+          c.call('ZUNIONSTORE', k('dest'), '2', k('z1'), k('z2'), 'WITHSCORES'),
+        errorWithMessage('ERR syntax error'),
+      )
+    })
+  })
+
+  test('ZDIFF rejects WEIGHTS (diff has no weights/aggregate)', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a')
+      await c.zadd(k('z2'), 1, 'b')
+      await assert.rejects(
+        () => c.call('ZDIFF', '2', k('z1'), k('z2'), 'WEIGHTS', '1', '2'),
+        errorWithMessage('ERR syntax error'),
+      )
+    })
+  })
+
+  test('ZINTERCARD rejects a negative LIMIT', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a')
+      await c.zadd(k('z2'), 1, 'b')
+      await assert.rejects(
+        () => c.call('ZINTERCARD', '2', k('z1'), k('z2'), 'LIMIT', '-1'),
+        errorWithMessage("ERR LIMIT can't be negative"),
+      )
+    })
+  })
+
+  test('ZUNION propagates WRONGTYPE for a non-zset/non-set source', async () => {
+    await withOps(async (c, k) => {
+      await c.zadd(k('z1'), 1, 'a')
+      await c.set(k('str'), 'hello')
+      await assert.rejects(
+        () => c.call('ZUNION', '2', k('z1'), k('str')),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+    })
+  })
+
+  test('ZUNIONSTORE rejects wrong arity', async () => {
+    await withOps(async (c, k) => {
+      await assert.rejects(
+        () => c.call('ZUNIONSTORE', k('dest')),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'zunionstore' command",
+        ),
+      )
+    })
+  })
+
+  test('ZUNION rejects wrong arity', async () => {
+    await withOps(async c => {
+      await assert.rejects(
+        () => c.call('ZUNION'),
+        errorWithMessage("ERR wrong number of arguments for 'zunion' command"),
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Implements the seven sorted-set set-operation commands that previously returned `ERR unknown command`: `ZUNIONSTORE`, `ZINTERSTORE`, `ZDIFFSTORE`, `ZUNION`, `ZINTER`, `ZDIFF`, `ZINTERCARD`.
- Source keys may be sorted sets **or** plain sets (set members treated as score `1`).
- Full Redis-compatible options: `WEIGHTS` (applied per-source before aggregation), `AGGREGATE SUM|MIN|MAX`, `WITHSCORES` (non-store variants), `LIMIT` (ZINTERCARD).
- Matches Redis edge cases: `numkeys <= 0` → `at least 1 input key is needed for '<cmd>' command`; non-integer numkeys → `value is not an integer or out of range`; numkeys > available keys → `syntax error`; non-float weight → `weight value is not a float`; SUM of `+inf` and `-inf` resets to `0`; STORE variants delete the destination when the result is empty.
- New code in `src/commands/zsets/zsetops.ts` (shared union/intersection/difference helpers), registered via `src/commands/zsets/index.ts`. Added `AtLeastOneInputKeyError` and `WeightNotFloatError`.

Closes #107

## Test plan
- [x] New `tests-integration/ioredis/zset-setops-integration.test.ts` (26 cases) reproduces the gap — all red on mock before the fix
- [x] Same suite green against real Redis before the fix (confirms our-impl-only gap)
- [x] Fix makes the suite green on mock too
- [x] `npm run build`, `npm run lint`, `npm run test:all` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)