### PR TITLE
feat: ZRANGEBYSCORE WITHSCORES/LIMIT, ZREVRANGEBYSCORE, ZREMRANGEBYRANK (#106)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -250,7 +250,9 @@ with `GT` or `LT`.
 - [x] `ZREVRANGE key start stop [WITHSCORES]` - Return a range of members by index, high to low
 - [x] `ZMSCORE key member [member ...]` - Get the scores of multiple members (nil per missing member)
 - [x] `ZRANDMEMBER key [count [WITHSCORES]]` - Get one or more random members, optionally with their scores
-- [x] `ZRANGEBYSCORE key min max` - Return members with scores between min and max (`-inf`, `+inf`, and exclusive `(score` bounds supported)
+- [x] `ZRANGEBYSCORE key min max [WITHSCORES] [LIMIT offset count]` - Return members with scores between min and max (`-inf`, `+inf`, and exclusive `(score` bounds supported)
+- [x] `ZREVRANGEBYSCORE key max min [WITHSCORES] [LIMIT offset count]` - Return members with scores between max and min, high to low (`-inf`, `+inf`, and exclusive `(score` bounds supported)
+- [x] `ZREMRANGEBYRANK key start stop` - Remove members by rank range (negative ranks count from highest)
 - [x] `ZREMRANGEBYSCORE key min max` - Remove members with scores between min and max (`-inf`, `+inf`, and exclusive `(score` bounds supported)
 - [x] `ZCOUNT key min max` - Count members with scores between min and max (`-inf`, `+inf`, and exclusive `(score` bounds supported)
 - [x] `ZRANGEBYLEX key min max [LIMIT offset count]` - Return members within a lexicographic range (`-`, `+`, and inclusive `[member`/exclusive `(member` bounds supported)
@@ -270,14 +272,12 @@ with `GT` or `LT`.
 
 #### Notes / gaps vs. real Redis
 
-- Score replies from `ZSCORE`, `ZINCRBY`, `ZRANGE WITHSCORES`, `ZREVRANGE WITHSCORES`, `ZPOPMIN`, `ZPOPMAX`, and `ZSCAN` serialize infinite scores as `inf` / `-inf`.
+- Score replies from `ZSCORE`, `ZINCRBY`, `ZRANGE WITHSCORES`, `ZREVRANGE WITHSCORES`, `ZRANGEBYSCORE WITHSCORES`, `ZREVRANGEBYSCORE WITHSCORES`, `ZPOPMIN`, `ZPOPMAX`, and `ZSCAN` serialize infinite scores as `inf` / `-inf`.
 - [ ] `ZREVRANGE` does not support the Redis 6.2+ unified syntax (`BYSCORE`, `BYLEX`, `REV`, `LIMIT offset count`) - `start`/`stop` are always treated as indexes; use `ZRANGE ... REV` instead
-- [ ] `ZRANGEBYSCORE` does not support `WITHSCORES` or `LIMIT offset count`
 - [ ] `ZRANK`/`ZREVRANK` do not support the Redis 7.2 `WITHSCORE` option
 
 #### Not implemented
 
-- [ ] `ZREVRANGEBYSCORE` / `ZREMRANGEBYRANK`
 - [ ] `ZRANGESTORE` / `ZMPOP` / `BZPOPMIN` / `BZPOPMAX` / `BZMPOP`
 
 ## 9. Stream Commands

--- a/src/commands/zsets/index.ts
+++ b/src/commands/zsets/index.ts
@@ -8,7 +8,9 @@ import { zrangeCommand, zrevrangeCommand } from './zrange'
 import {
   zcountCommand,
   zrangebyscoreCommand,
+  zrevrangebyscoreCommand,
   zremrangebyscoreCommand,
+  zremrangebyrankCommand,
 } from './zrangebyscore'
 import {
   zlexcountCommand,
@@ -40,7 +42,9 @@ export const zsetsCommands = [
   zrangeCommand,
   zrevrangeCommand,
   zrangebyscoreCommand,
+  zrevrangebyscoreCommand,
   zremrangebyscoreCommand,
+  zremrangebyrankCommand,
   zcountCommand,
   zrangebylexCommand,
   zrevrangebylexCommand,
@@ -70,7 +74,9 @@ export {
   zrangeCommand,
   zrevrangeCommand,
   zrangebyscoreCommand,
+  zrevrangebyscoreCommand,
   zremrangebyscoreCommand,
+  zremrangebyrankCommand,
   zcountCommand,
   zrangebylexCommand,
   zrevrangebylexCommand,

--- a/src/commands/zsets/zrangebyscore.ts
+++ b/src/commands/zsets/zrangebyscore.ts
@@ -1,27 +1,147 @@
 import { defineCommand } from '../../core/command-definition'
 import { t } from '../../core/command-schema'
+import {
+  ExpectedIntegerError,
+  RedisSyntaxError,
+  WrongNumberOfArgumentsError,
+} from '../../core/redis-error'
 import { RedisValue } from '../../core/redis-value'
-import { array, integer } from '../helpers'
+import type { RedisSortedSetMember } from '../../state/data-types'
+import { array, integer, scoreBuffer } from '../helpers'
 import { getSortedMembers, deleteSortedSetIfEmpty } from './helpers'
 import { parseScoreBoundArg, scoreWithinBounds } from './score'
 
+// ZRANGEBYSCORE key min max [WITHSCORES] [LIMIT offset count]
+// ZREVRANGEBYSCORE key max min [WITHSCORES] [LIMIT offset count]
+// WITHSCORES and LIMIT may appear in either order, matching real Redis.
+type ScoreLimit = { offset: number; count: number }
+
+type ScoreRangeArgs = {
+  key: Buffer
+  first: Buffer
+  second: Buffer
+  withScores: boolean
+  limit?: ScoreLimit
+}
+
+function parseScoreLimitInt(token: Buffer): number {
+  const raw = token.toString()
+  if (!/^-?\d+$/.test(raw)) throw new ExpectedIntegerError()
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value)) throw new ExpectedIntegerError()
+  return value
+}
+
+function createScoreRangeSchema() {
+  return t.custom<ScoreRangeArgs>((input, index, ctx) => {
+    const key = input[index]
+    const first = input[index + 1]
+    const second = input[index + 2]
+    if (!key || !first || !second) {
+      throw new WrongNumberOfArgumentsError(ctx.commandName)
+    }
+
+    let withScores = false
+    let limit: ScoreLimit | undefined
+
+    let cursor = index + 3
+    while (cursor < input.length) {
+      const option = input[cursor]!.toString().toUpperCase()
+
+      if (option === 'WITHSCORES') {
+        withScores = true
+        cursor++
+        continue
+      }
+
+      if (option === 'LIMIT') {
+        const offsetTok = input[cursor + 1]
+        const countTok = input[cursor + 2]
+        if (!offsetTok || !countTok) throw new RedisSyntaxError()
+        limit = {
+          offset: parseScoreLimitInt(offsetTok),
+          count: parseScoreLimitInt(countTok),
+        }
+        cursor += 3
+        continue
+      }
+
+      throw new RedisSyntaxError()
+    }
+
+    return {
+      value: { key, first, second, withScores, limit },
+      nextIndex: input.length,
+    }
+  })
+}
+
+function applyScoreLimit(
+  members: RedisSortedSetMember[],
+  limit: ScoreLimit | undefined,
+): RedisSortedSetMember[] {
+  if (!limit) return members
+  if (limit.offset < 0) return []
+  const end = limit.count < 0 ? members.length : limit.offset + limit.count
+  return members.slice(limit.offset, end)
+}
+
+function buildScoreRangeOutput(
+  members: RedisSortedSetMember[],
+  withScores: boolean,
+): RedisValue[] {
+  const items: RedisValue[] = []
+  for (const entry of members) {
+    items.push(RedisValue.bulkString(entry.member))
+    if (withScores) {
+      items.push(RedisValue.bulkString(scoreBuffer(entry.score)))
+    }
+  }
+  return items
+}
+
 export const zrangebyscoreCommand = defineCommand({
   name: 'zrangebyscore',
-  schema: t.object({ key: t.key(), min: t.string(), max: t.string() }),
+  schema: createScoreRangeSchema(),
   flags: ['readonly'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const min = parseScoreBoundArg(args.min)
-    const max = parseScoreBoundArg(args.max)
+    const min = parseScoreBoundArg(args.first.toString())
+    const max = parseScoreBoundArg(args.second.toString())
     const zset = ctx.db.getSortedSet(args.key)
     if (!zset) return array([])
-    const items: RedisValue[] = []
-    for (const entry of getSortedMembers(zset)) {
-      if (scoreWithinBounds(entry.score, min, max)) {
-        items.push(RedisValue.bulkString(entry.member))
-      }
-    }
-    return array(items)
+    const matched = getSortedMembers(zset).filter(m =>
+      scoreWithinBounds(m.score, min, max),
+    )
+    return array(
+      buildScoreRangeOutput(
+        applyScoreLimit(matched, args.limit),
+        args.withScores,
+      ),
+    )
+  },
+})
+
+export const zrevrangebyscoreCommand = defineCommand({
+  name: 'zrevrangebyscore',
+  schema: createScoreRangeSchema(),
+  flags: ['readonly'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    // ZREVRANGEBYSCORE takes bounds as `max min`.
+    const max = parseScoreBoundArg(args.first.toString())
+    const min = parseScoreBoundArg(args.second.toString())
+    const zset = ctx.db.getSortedSet(args.key)
+    if (!zset) return array([])
+    const matched = getSortedMembers(zset)
+      .filter(m => scoreWithinBounds(m.score, min, max))
+      .reverse()
+    return array(
+      buildScoreRangeOutput(
+        applyScoreLimit(matched, args.limit),
+        args.withScores,
+      ),
+    )
   },
 })
 
@@ -40,6 +160,34 @@ export const zremrangebyscoreCommand = defineCommand({
           zset.members.delete(hex)
           removed++
         }
+      }
+    })
+    if (removed > 0) deleteSortedSetIfEmpty(ctx.db, args.key)
+    return integer(removed)
+  },
+})
+
+export const zremrangebyrankCommand = defineCommand({
+  name: 'zremrangebyrank',
+  schema: t.object({ key: t.key(), start: t.integer(), stop: t.integer() }),
+  flags: ['write'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const zset = ctx.db.getSortedSet(args.key)
+    if (!zset) return integer(0)
+    const sorted = getSortedMembers(zset)
+    const len = sorted.length
+    const start = args.start < 0 ? Math.max(0, len + args.start) : args.start
+    const stop = args.stop < 0 ? len + args.stop : Math.min(args.stop, len - 1)
+    if (start > stop) return integer(0)
+
+    const toRemove = new Set(
+      sorted.slice(start, stop + 1).map(m => m.member.toString('hex')),
+    )
+    let removed = 0
+    ctx.db.updateSortedSet(args.key, set => {
+      for (const hex of toRemove) {
+        if (set.members.delete(hex)) removed++
       }
     })
     if (removed > 0) deleteSortedSetIfEmpty(ctx.db, args.key)

--- a/tests-integration/ioredis/zset-score-range-integration.test.ts
+++ b/tests-integration/ioredis/zset-score-range-integration.test.ts
@@ -1,0 +1,368 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { errorWithMessage, randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+describe(`Sorted Set Score-Range (ZRANGEBYSCORE/ZREVRANGEBYSCORE/ZREMRANGEBYRANK) (${testRunner.getBackendName()})`, () => {
+  let redisClient: Cluster | undefined
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster('zset-score-range')
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  async function seedScored(pairs: Array<[number, string]>): Promise<string> {
+    const key = `{zsr:${randomKey()}}`
+    const args: (string | number)[] = []
+    for (const [score, member] of pairs) {
+      args.push(score, member)
+    }
+    await redisClient?.zadd(key, ...(args as [number, string]))
+    return key
+  }
+
+  const sample: Array<[number, string]> = [
+    [1, 'a'],
+    [2, 'b'],
+    [3, 'c'],
+    [4, 'd'],
+    [5, 'e'],
+  ]
+
+  // ---------- ZRANGEBYSCORE WITHSCORES / LIMIT ----------
+
+  test('ZRANGEBYSCORE WITHSCORES returns member/score pairs', async () => {
+    const key = await seedScored(sample)
+    try {
+      assert.deepStrictEqual(
+        await redisClient?.zrangebyscore(key, 2, 4, 'WITHSCORES'),
+        ['b', '2', 'c', '3', 'd', '4'],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGEBYSCORE LIMIT offset count paginates', async () => {
+    const key = await seedScored(sample)
+    try {
+      assert.deepStrictEqual(
+        await redisClient?.zrangebyscore(key, '-inf', '+inf', 'LIMIT', 1, 2),
+        ['b', 'c'],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGEBYSCORE LIMIT negative count returns all remaining', async () => {
+    const key = await seedScored(sample)
+    try {
+      assert.deepStrictEqual(
+        await redisClient?.zrangebyscore(
+          key,
+          '-inf',
+          '+inf',
+          'LIMIT',
+          2,
+          -1,
+          'WITHSCORES',
+        ),
+        ['c', '3', 'd', '4', 'e', '5'],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGEBYSCORE WITHSCORES and LIMIT in either order', async () => {
+    const key = await seedScored(sample)
+    try {
+      const expected = ['a', '1', 'b', '2']
+      assert.deepStrictEqual(
+        await redisClient?.call(
+          'zrangebyscore',
+          key,
+          '-inf',
+          '+inf',
+          'LIMIT',
+          '0',
+          '2',
+          'WITHSCORES',
+        ),
+        expected,
+      )
+      assert.deepStrictEqual(
+        await redisClient?.call(
+          'zrangebyscore',
+          key,
+          '-inf',
+          '+inf',
+          'WITHSCORES',
+          'LIMIT',
+          '0',
+          '2',
+        ),
+        expected,
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGEBYSCORE exclusive bound with LIMIT', async () => {
+    const key = await seedScored(sample)
+    try {
+      assert.deepStrictEqual(await redisClient?.zrangebyscore(key, '(1', 3), [
+        'b',
+        'c',
+      ])
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGEBYSCORE LIMIT negative offset returns empty', async () => {
+    const key = await seedScored(sample)
+    try {
+      assert.deepStrictEqual(
+        await redisClient?.zrangebyscore(key, '-inf', '+inf', 'LIMIT', -1, 2),
+        [],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGEBYSCORE LIMIT with non-integer rejects', async () => {
+    const key = await seedScored(sample)
+    try {
+      await assert.rejects(
+        () =>
+          redisClient?.call('zrangebyscore', key, '1', '2', 'LIMIT', 'a', 'b'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGEBYSCORE LIMIT without offset/count rejects with syntax error', async () => {
+    const key = await seedScored(sample)
+    try {
+      await assert.rejects(
+        () => redisClient?.call('zrangebyscore', key, '1', '2', 'LIMIT'),
+        errorWithMessage('ERR syntax error'),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGEBYSCORE rejects wrong arity', async () => {
+    const key = await seedScored([[1, 'a']])
+    try {
+      await assert.rejects(
+        () => redisClient?.call('zrangebyscore', key, '1'),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'zrangebyscore' command",
+        ),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGEBYSCORE rejects non-float bound', async () => {
+    const key = await seedScored([[1, 'a']])
+    try {
+      await assert.rejects(
+        () => redisClient?.call('zrangebyscore', key, 'x', '2'),
+        errorWithMessage('ERR min or max is not a float'),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGEBYSCORE on wrong type rejects WRONGTYPE', async () => {
+    const key = `{zsr:${randomKey()}}`
+    await redisClient?.set(key, 'v')
+    try {
+      await assert.rejects(
+        () => redisClient?.call('zrangebyscore', key, '1', '2'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  // ---------- ZREVRANGEBYSCORE ----------
+
+  test('ZREVRANGEBYSCORE returns descending range with max/min order', async () => {
+    const key = await seedScored(sample)
+    try {
+      assert.deepStrictEqual(
+        await redisClient?.zrevrangebyscore(key, 4, 2, 'WITHSCORES'),
+        ['d', '4', 'c', '3', 'b', '2'],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZREVRANGEBYSCORE supports LIMIT', async () => {
+    const key = await seedScored(sample)
+    try {
+      assert.deepStrictEqual(
+        await redisClient?.zrevrangebyscore(key, '+inf', '-inf', 'LIMIT', 1, 2),
+        ['d', 'c'],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZREVRANGEBYSCORE exclusive bounds', async () => {
+    const key = await seedScored(sample)
+    try {
+      assert.deepStrictEqual(
+        await redisClient?.zrevrangebyscore(key, '(4', '(2'),
+        ['c'],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZREVRANGEBYSCORE on missing key returns empty', async () => {
+    const key = `{zsr:${randomKey()}}`
+    assert.deepStrictEqual(
+      await redisClient?.zrevrangebyscore(key, '+inf', '-inf'),
+      [],
+    )
+  })
+
+  test('ZREVRANGEBYSCORE rejects non-float bound', async () => {
+    const key = await seedScored([[1, 'a']])
+    try {
+      await assert.rejects(
+        () => redisClient?.call('zrevrangebyscore', key, 'x', '2'),
+        errorWithMessage('ERR min or max is not a float'),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZREVRANGEBYSCORE on wrong type rejects WRONGTYPE', async () => {
+    const key = `{zsr:${randomKey()}}`
+    await redisClient?.set(key, 'v')
+    try {
+      await assert.rejects(
+        () => redisClient?.call('zrevrangebyscore', key, '2', '1'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  // ---------- ZREMRANGEBYRANK ----------
+
+  test('ZREMRANGEBYRANK removes members in rank range', async () => {
+    const key = await seedScored(sample)
+    try {
+      assert.strictEqual(await redisClient?.zremrangebyrank(key, 1, 2), 2)
+      assert.deepStrictEqual(await redisClient?.zrange(key, 0, -1), [
+        'a',
+        'd',
+        'e',
+      ])
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZREMRANGEBYRANK supports negative ranks', async () => {
+    const key = await seedScored([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+      [4, 'd'],
+    ])
+    try {
+      assert.strictEqual(await redisClient?.zremrangebyrank(key, -2, -1), 2)
+      assert.deepStrictEqual(await redisClient?.zrange(key, 0, -1), ['a', 'b'])
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZREMRANGEBYRANK on missing key returns 0', async () => {
+    const key = `{zsr:${randomKey()}}`
+    assert.strictEqual(await redisClient?.zremrangebyrank(key, 0, 1), 0)
+  })
+
+  test('ZREMRANGEBYRANK removing all members deletes the key', async () => {
+    const key = await seedScored([[1, 'a']])
+    try {
+      assert.strictEqual(await redisClient?.zremrangebyrank(key, 0, -1), 1)
+      assert.strictEqual(await redisClient?.exists(key), 0)
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZREMRANGEBYRANK rejects non-integer rank', async () => {
+    const key = await seedScored([[1, 'a']])
+    try {
+      await assert.rejects(
+        () => redisClient?.call('zremrangebyrank', key, 'x', '1'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZREMRANGEBYRANK rejects wrong arity', async () => {
+    const key = await seedScored([[1, 'a']])
+    try {
+      await assert.rejects(
+        () => redisClient?.call('zremrangebyrank', key, '0'),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'zremrangebyrank' command",
+        ),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZREMRANGEBYRANK on wrong type rejects WRONGTYPE', async () => {
+    const key = `{zsr:${randomKey()}}`
+    await redisClient?.set(key, 'v')
+    try {
+      await assert.rejects(
+        () => redisClient?.call('zremrangebyrank', key, '0', '1'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- `ZRANGEBYSCORE` now supports `WITHSCORES` and `LIMIT offset count` (previously both were ignored — extra args errored). Options may appear in either order, matching real Redis.
- Implemented `ZREVRANGEBYSCORE key max min [WITHSCORES] [LIMIT offset count]` (was entirely absent).
- Implemented `ZREMRANGEBYRANK key start stop` — rank/index-based removal with negative-index support; deletes the key when it becomes empty.
- `ZCOUNT` / `ZREMRANGEBYSCORE` left unchanged (already correct; they take no WITHSCORES/LIMIT in real Redis).

Score-range parsing reuses the existing `parseScoreBoundArg` / `scoreWithinBounds` helpers (exclusive `(` and `+inf`/`-inf` already handled).

Closes #106

## Test plan
- [x] New integration test `tests-integration/ioredis/zset-score-range-integration.test.ts` (24 cases) — red on mock before the fix
- [x] Test passes against real Redis (confirms mock-only gap)
- [x] Fix makes the test pass on mock too
- [x] Covers WITHSCORES, LIMIT (offset/count, negative count, negative offset), either-order options, exclusive bounds, missing key, wrong arity, non-float bound, non-integer rank, WRONGTYPE
- [x] `npm run test:all` passes (unit 145, mock 401, real 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)