### PR TITLE
Fix HINCRBYFLOAT float parsing

### DIFF
--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -1,5 +1,10 @@
 import { defineCommand } from '../core/command-definition'
-import { isIntegerToken, t, type ParseContext } from '../core/command-schema'
+import {
+  isIntegerToken,
+  parseFiniteFloatToken,
+  t,
+  type ParseContext,
+} from '../core/command-schema'
 import {
   HashValueNotFloatError,
   HashValueNotIntegerError,
@@ -352,8 +357,8 @@ export const hincrbyfloatCommand = defineCommand({
       let current = 0
       if (entry) {
         const raw = entry.value.toString()
-        const parsed = parseFloat(raw)
-        if (isNaN(parsed)) {
+        const parsed = parseFiniteFloatToken(raw)
+        if (parsed === undefined) {
           throw new HashValueNotFloatError()
         }
         current = parsed

--- a/src/core/command-schema.ts
+++ b/src/core/command-schema.ts
@@ -33,6 +33,8 @@ type InferShape<TShape extends SchemaShape> = {
 }
 
 const INTEGER_TOKEN_PATTERN = /^(0|-?[1-9]\d*)$/
+const FLOAT_TOKEN_PATTERN =
+  /^[+-]?(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?:[eE][+-]?\d+)?$/
 
 class MissingInputError extends Error {
   constructor() {
@@ -86,6 +88,19 @@ function keywordMatches(actual: Buffer, expected: string): boolean {
 
 export function isIntegerToken(raw: string): boolean {
   return INTEGER_TOKEN_PATTERN.test(raw)
+}
+
+export function parseFiniteFloatToken(raw: string): number | undefined {
+  if (!FLOAT_TOKEN_PATTERN.test(raw)) {
+    return undefined
+  }
+
+  const value = Number(raw)
+  if (!Number.isFinite(value)) {
+    return undefined
+  }
+
+  return value
 }
 
 function makeSchema<TValue>(
@@ -164,8 +179,8 @@ export const t = {
 
   float(): CommandSchema<number> {
     return makeSchema((input, index) => {
-      const value = Number(readToken(input, index).toString())
-      if (!Number.isFinite(value)) {
+      const value = parseFiniteFloatToken(readToken(input, index).toString())
+      if (value === undefined) {
         throw new ExpectedFloatError()
       }
 

--- a/tests-integration/ioredis/hash-integration.test.ts
+++ b/tests-integration/ioredis/hash-integration.test.ts
@@ -370,6 +370,12 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
         'abc',
         'float',
         'abc',
+        'float-trailing-garbage',
+        '1abc',
+        'float-dangling-exponent',
+        '1.0e',
+        'float-trailing-space',
+        '1.5 ',
         'leading-zero',
         '007',
         'negative-zero',
@@ -414,6 +420,23 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
         () => redisClient?.hincrbyfloat(hashKey, 'float', 1.5),
         errorWithMessage('ERR hash value is not a float'),
       )
+      for (const field of [
+        'float-trailing-garbage',
+        'float-dangling-exponent',
+        'float-trailing-space',
+      ]) {
+        await assert.rejects(
+          () => redisClient?.hincrbyfloat(hashKey, field, 1),
+          errorWithMessage('ERR hash value is not a float'),
+        )
+      }
+      for (const increment of ['1abc', '1.0e', '1.5 ']) {
+        await assert.rejects(
+          () =>
+            redisClient?.call('HINCRBYFLOAT', hashKey, 'missing', increment),
+          errorWithMessage('ERR value is not a valid float'),
+        )
+      }
     } finally {
       await redisClient?.del(hashKey, stringKey)
     }


### PR DESCRIPTION
## Summary

- Add a strict finite-float token parser for command schemas.
- Use it when reading existing `HINCRBYFLOAT` hash field values so trailing garbage, dangling exponents, and trailing spaces are rejected like Redis.
- Extend ioredis integration coverage for malformed stored hash floats and malformed increment tokens.

## Root cause

`HINCRBYFLOAT` parsed existing hash field values with `parseFloat()`, which silently accepted prefixes like `1abc` and `1.0e`. The command schema also used `Number()` directly for increments, which accepted whitespace-padded tokens that Redis rejects.

## Validation

- Focused mock integration failed before the fix on the new malformed-float assertions.
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/hash-integration.test.ts`
- `npm run clean:redis && TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/hash-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run clean:redis && npm run test:integration:real`
- `npm run lint`

Fixes #58
