### PR TITLE
Fix zset multi-pop commands

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -261,6 +261,8 @@ with `GT` or `LT`.
 - [x] `ZREMRANGEBYLEX key min max` - Remove members within a lexicographic range
 - [x] `ZPOPMIN key [count]` - Remove and return members with the lowest scores
 - [x] `ZPOPMAX key [count]` - Remove and return members with the highest scores
+- [x] `ZMPOP numkeys key [key ...] MIN|MAX [COUNT count]` - Pop one or more members from the first non-empty sorted set
+- [x] `BZMPOP timeout numkeys key [key ...] MIN|MAX [COUNT count]` - Blocking multi-key sorted-set pop; returns null on timeout
 - [x] `ZSCAN key cursor [MATCH pattern] [COUNT count]` - Incrementally iterate members and scores (see [Scan Family](#10-scan-family))
 - [x] `ZUNIONSTORE destination numkeys key [key ...] [WEIGHTS weight [weight ...]] [AGGREGATE SUM|MIN|MAX]` - Union of sorted sets (or plain sets, scored 1) into destination; empty result deletes destination
 - [x] `ZINTERSTORE destination numkeys key [key ...] [WEIGHTS weight [weight ...]] [AGGREGATE SUM|MIN|MAX]` - Intersection of sorted sets into destination; empty result deletes destination
@@ -272,13 +274,13 @@ with `GT` or `LT`.
 
 #### Notes / gaps vs. real Redis
 
-- Score replies from `ZSCORE`, `ZINCRBY`, `ZRANGE WITHSCORES`, `ZREVRANGE WITHSCORES`, `ZRANGEBYSCORE WITHSCORES`, `ZREVRANGEBYSCORE WITHSCORES`, `ZPOPMIN`, `ZPOPMAX`, and `ZSCAN` serialize infinite scores as `inf` / `-inf`.
+- Score replies from `ZSCORE`, `ZINCRBY`, `ZRANGE WITHSCORES`, `ZREVRANGE WITHSCORES`, `ZRANGEBYSCORE WITHSCORES`, `ZREVRANGEBYSCORE WITHSCORES`, `ZPOPMIN`, `ZPOPMAX`, `ZMPOP`, `BZMPOP`, and `ZSCAN` serialize infinite scores as `inf` / `-inf`.
 - [ ] `ZREVRANGE` does not support the Redis 6.2+ unified syntax (`BYSCORE`, `BYLEX`, `REV`, `LIMIT offset count`) - `start`/`stop` are always treated as indexes; use `ZRANGE ... REV` instead
 - [ ] `ZRANK`/`ZREVRANK` do not support the Redis 7.2 `WITHSCORE` option
 
 #### Not implemented
 
-- [ ] `ZRANGESTORE` / `ZMPOP` / `BZPOPMIN` / `BZPOPMAX` / `BZMPOP`
+- [ ] `ZRANGESTORE` / `BZPOPMIN` / `BZPOPMAX`
 
 ## 9. Stream Commands
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -250,4 +250,6 @@ export {
   zcountCommand,
   zpopminCommand,
   zpopmaxCommand,
+  zmpopCommand,
+  bzmpopCommand,
 } from './zsets'

--- a/src/commands/zsets/index.ts
+++ b/src/commands/zsets/index.ts
@@ -19,6 +19,7 @@ import {
   zrevrangebylexCommand,
 } from './zrangebylex'
 import { zpopmaxCommand, zpopminCommand } from './zpop'
+import { bzmpopCommand, zmpopCommand } from './zmpop'
 import {
   zdiffCommand,
   zdiffstoreCommand,
@@ -52,6 +53,8 @@ export const zsetsCommands = [
   zremrangebylexCommand,
   zpopminCommand,
   zpopmaxCommand,
+  zmpopCommand,
+  bzmpopCommand,
   zunionstoreCommand,
   zinterstoreCommand,
   zdiffstoreCommand,
@@ -84,6 +87,8 @@ export {
   zremrangebylexCommand,
   zpopminCommand,
   zpopmaxCommand,
+  zmpopCommand,
+  bzmpopCommand,
   zunionstoreCommand,
   zinterstoreCommand,
   zdiffstoreCommand,

--- a/src/commands/zsets/zmpop.ts
+++ b/src/commands/zsets/zmpop.ts
@@ -1,0 +1,266 @@
+import { defineCommand } from '../../core/command-definition'
+import { isIntegerToken, t, type ParseContext } from '../../core/command-schema'
+import type { RedisExecutionContext } from '../../core/redis-context'
+import { RedisResult } from '../../core/redis-result'
+import {
+  CountGreaterThanZeroError,
+  NumKeysGreaterThanZeroError,
+  RedisSyntaxError,
+  TimeoutNegativeError,
+  TimeoutNotFloatError,
+  WrongNumberOfArgumentsError,
+} from '../../core/redis-error'
+import { RedisValue } from '../../core/redis-value'
+import type { RedisDatabase } from '../../state'
+import { scoreBuffer } from '../helpers'
+import { deleteSortedSetIfEmpty, getSortedMembers } from './helpers'
+
+type ZsetMultiPopSide = 'min' | 'max'
+
+type ZsetMultiPopArgs = {
+  keys: Buffer[]
+  side: ZsetMultiPopSide
+  count: number
+}
+
+type BlockingZsetMultiPopArgs = ZsetMultiPopArgs & {
+  timeout: number
+}
+
+function parsePositiveZsetPopInteger(
+  token: Buffer,
+  createError: () => Error,
+): number {
+  const raw = token.toString()
+  if (!isIntegerToken(raw)) {
+    throw createError()
+  }
+
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw createError()
+  }
+
+  return value
+}
+
+function parseZsetPopNumKeys(token: Buffer): number {
+  return parsePositiveZsetPopInteger(
+    token,
+    () => new NumKeysGreaterThanZeroError(),
+  )
+}
+
+function parseZsetPopCount(token: Buffer): number {
+  return parsePositiveZsetPopInteger(
+    token,
+    () => new CountGreaterThanZeroError(),
+  )
+}
+
+function parseZsetPopSide(token: Buffer | undefined): ZsetMultiPopSide {
+  if (!token) throw new RedisSyntaxError()
+  const side = token.toString().toUpperCase()
+  if (side === 'MIN') return 'min'
+  if (side === 'MAX') return 'max'
+  throw new RedisSyntaxError()
+}
+
+function parseZsetPopTimeout(token: Buffer): number {
+  const value = Number(token.toString())
+  if (isNaN(value)) throw new TimeoutNotFloatError()
+  if (value < 0) throw new TimeoutNegativeError()
+  return value
+}
+
+function parseZsetMultiPopArgs(
+  input: readonly Buffer[],
+  index: number,
+  ctx: ParseContext,
+  options: { blocking: false },
+): ZsetMultiPopArgs
+function parseZsetMultiPopArgs(
+  input: readonly Buffer[],
+  index: number,
+  ctx: ParseContext,
+  options: { blocking: true },
+): BlockingZsetMultiPopArgs
+function parseZsetMultiPopArgs(
+  input: readonly Buffer[],
+  index: number,
+  ctx: ParseContext,
+  options: { blocking: boolean },
+): ZsetMultiPopArgs | BlockingZsetMultiPopArgs {
+  if (index >= input.length) {
+    throw new WrongNumberOfArgumentsError(ctx.commandName)
+  }
+
+  let cursor = index
+  let timeout: number | undefined
+
+  if (options.blocking) {
+    timeout = parseZsetPopTimeout(input[cursor])
+    cursor++
+  }
+
+  const numKeysToken = input[cursor]
+  if (!numKeysToken) {
+    throw new WrongNumberOfArgumentsError(ctx.commandName)
+  }
+
+  const numKeys = parseZsetPopNumKeys(numKeysToken)
+  cursor++
+
+  const keysEnd = cursor + numKeys
+  if (keysEnd >= input.length) {
+    throw new RedisSyntaxError()
+  }
+
+  const keys = Array.from(input.slice(cursor, keysEnd))
+  cursor = keysEnd
+
+  const side = parseZsetPopSide(input[cursor])
+  cursor++
+
+  let count = 1
+  if (cursor < input.length) {
+    const option = input[cursor].toString().toUpperCase()
+    if (option !== 'COUNT' || cursor + 2 !== input.length) {
+      throw new RedisSyntaxError()
+    }
+
+    count = parseZsetPopCount(input[cursor + 1])
+    cursor += 2
+  }
+
+  if (options.blocking) {
+    return { timeout: timeout!, keys, side, count }
+  }
+
+  return { keys, side, count }
+}
+
+export function tryZsetMultiPop(
+  keys: readonly Buffer[],
+  side: ZsetMultiPopSide,
+  count: number,
+  db: RedisDatabase,
+): RedisResult | null {
+  for (const key of keys) {
+    const zset = db.getSortedSet(key)
+    if (!zset || zset.members.size === 0) continue
+
+    const sorted = getSortedMembers(zset)
+    const candidates = side === 'min' ? sorted : sorted.slice().reverse()
+    const toRemove = candidates.slice(0, count)
+    if (toRemove.length === 0) continue
+
+    db.updateSortedSet(key, zset => {
+      for (const entry of toRemove) {
+        zset.members.delete(entry.member.toString('hex'))
+      }
+    })
+    deleteSortedSetIfEmpty(db, key)
+
+    return RedisResult.create(
+      RedisValue.array([
+        RedisValue.bulkString(key),
+        RedisValue.array(
+          toRemove.map(entry =>
+            RedisValue.array([
+              RedisValue.bulkString(entry.member),
+              RedisValue.bulkString(scoreBuffer(entry.score)),
+            ]),
+          ),
+        ),
+      ]),
+    )
+  }
+
+  return null
+}
+
+async function blockingZsetMultiPop(
+  keys: readonly Buffer[],
+  timeoutSecs: number,
+  side: ZsetMultiPopSide,
+  count: number,
+  ctx: RedisExecutionContext,
+): Promise<RedisResult> {
+  const timeoutMs =
+    timeoutSecs === 0 ? undefined : Math.ceil(timeoutSecs * 1000)
+  const deadline = timeoutMs !== undefined ? Date.now() + timeoutMs : undefined
+
+  while (true) {
+    const remaining =
+      deadline !== undefined ? Math.max(0, deadline - Date.now()) : undefined
+    if (remaining === 0) return RedisResult.create(RedisValue.nullArray())
+
+    let wake!: (v: true) => void
+    const waitFor = new Promise<true>(resolve => {
+      wake = () => resolve(true)
+    })
+
+    const unsubs = keys.map(key =>
+      ctx.db.subscribeKey(key, event => {
+        if (event.type === 'write') wake(true)
+      }),
+    )
+
+    let woken: boolean | null
+    try {
+      woken = await ctx.park({
+        waitFor,
+        timeoutMs: remaining,
+        signal: ctx.signal,
+      })
+    } finally {
+      for (const unsub of unsubs) {
+        try {
+          unsub()
+        } catch {
+          // ignore errors from individual unsubscribers so all are attempted
+        }
+      }
+    }
+
+    if (woken === null) return RedisResult.create(RedisValue.nullArray())
+
+    const result = tryZsetMultiPop(keys, side, count, ctx.db)
+    if (result) return result
+  }
+}
+
+export const zmpopCommand = defineCommand({
+  name: 'zmpop',
+  schema: t.custom<ZsetMultiPopArgs>((input, index, ctx) => ({
+    value: parseZsetMultiPopArgs(input, index, ctx, { blocking: false }),
+    nextIndex: input.length,
+  })),
+  flags: ['write'],
+  keys: args => args.keys,
+  execute: (args, ctx) =>
+    tryZsetMultiPop(args.keys, args.side, args.count, ctx.db) ??
+    RedisResult.create(RedisValue.nullArray()),
+})
+
+export const bzmpopCommand = defineCommand({
+  name: 'bzmpop',
+  schema: t.custom<BlockingZsetMultiPopArgs>((input, index, ctx) => ({
+    value: parseZsetMultiPopArgs(input, index, ctx, { blocking: true }),
+    nextIndex: input.length,
+  })),
+  flags: ['write', 'noscript'],
+  keys: args => args.keys,
+  execute: (args, ctx) => {
+    const immediate = tryZsetMultiPop(args.keys, args.side, args.count, ctx.db)
+    if (immediate) return immediate
+    return blockingZsetMultiPop(
+      args.keys,
+      args.timeout,
+      args.side,
+      args.count,
+      ctx,
+    )
+  },
+})

--- a/tests-integration/ioredis/zmpop-bzmpop-integration.test.ts
+++ b/tests-integration/ioredis/zmpop-bzmpop-integration.test.ts
@@ -1,0 +1,282 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { connectToSlotOwner, errorWithMessage, randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+function waitForPark(ms = 80): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe(`ZMPOP / BZMPOP Integration (${testRunner.getBackendName()})`, () => {
+  let client1: Cluster | undefined
+  let client2: Cluster | undefined
+
+  before(async () => {
+    client1 = await testRunner.setupIoredisCluster()
+    client2 = await testRunner.setupIoredisCluster()
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  test('ZMPOP pops from the first non-empty key with the requested side and count', async () => {
+    const tag = `{${randomKey()}}`
+    const empty = `${tag}:empty`
+    const first = `${tag}:first`
+    const second = `${tag}:second`
+
+    try {
+      await client1!.del(empty, first, second)
+      await client1!.zadd(first, 1, 'a', 2, 'b', 3, 'c')
+      await client1!.zadd(second, 10, 'x', 20, 'y')
+
+      assert.deepStrictEqual(
+        await client1!.call(
+          'ZMPOP',
+          '3',
+          empty,
+          first,
+          second,
+          'MIN',
+          'COUNT',
+          '2',
+        ),
+        [
+          first,
+          [
+            ['a', '1'],
+            ['b', '2'],
+          ],
+        ],
+      )
+      assert.deepStrictEqual(await client1!.zrange(first, 0, -1), ['c'])
+      assert.deepStrictEqual(await client1!.zrange(second, 0, -1), ['x', 'y'])
+
+      assert.deepStrictEqual(
+        await client1!.call('ZMPOP', '2', first, second, 'MAX'),
+        [first, [['c', '3']]],
+      )
+      assert.strictEqual(await client1!.exists(first), 0)
+
+      assert.deepStrictEqual(
+        await client1!.call('ZMPOP', '2', first, second, 'mAx', 'count', '5'),
+        [
+          second,
+          [
+            ['y', '20'],
+            ['x', '10'],
+          ],
+        ],
+      )
+      assert.strictEqual(await client1!.exists(second), 0)
+    } finally {
+      await client1!.del(empty, first, second)
+    }
+  })
+
+  test('ZMPOP returns null when all keys are empty or missing', async () => {
+    const tag = `{${randomKey()}}`
+    const first = `${tag}:first`
+    const second = `${tag}:second`
+
+    try {
+      await client1!.del(first, second)
+      assert.strictEqual(
+        await client1!.call('ZMPOP', '2', first, second, 'MIN'),
+        null,
+      )
+    } finally {
+      await client1!.del(first, second)
+    }
+  })
+
+  test('BZMPOP returns immediately when a sorted set is non-empty', async () => {
+    const tag = `{${randomKey()}}`
+    const empty = `${tag}:empty`
+    const zset = `${tag}:zset`
+
+    try {
+      await client1!.del(empty, zset)
+      await client1!.zadd(zset, 1, 'one', 2, 'two', 3, 'three')
+
+      assert.deepStrictEqual(
+        await client1!.call(
+          'BZMPOP',
+          '1',
+          '2',
+          empty,
+          zset,
+          'MAX',
+          'COUNT',
+          '2',
+        ),
+        [
+          zset,
+          [
+            ['three', '3'],
+            ['two', '2'],
+          ],
+        ],
+      )
+      assert.deepStrictEqual(await client1!.zrange(zset, 0, -1), ['one'])
+    } finally {
+      await client1!.del(empty, zset)
+    }
+  })
+
+  test('BZMPOP blocks then returns when a zset write arrives', async () => {
+    const tag = `{${randomKey()}}`
+    const first = `${tag}:first`
+    const second = `${tag}:second`
+
+    try {
+      await client1!.del(first, second)
+
+      const blockPromise = client1!.call(
+        'BZMPOP',
+        '5',
+        '2',
+        first,
+        second,
+        'MIN',
+        'COUNT',
+        '2',
+      )
+      await waitForPark()
+      await client2!.zadd(second, 1, 'a', 2, 'b')
+
+      assert.deepStrictEqual(await blockPromise, [
+        second,
+        [
+          ['a', '1'],
+          ['b', '2'],
+        ],
+      ])
+      assert.strictEqual(await client1!.exists(second), 0)
+    } finally {
+      await client1!.del(first, second)
+    }
+  })
+
+  test('BZMPOP timeout returns null', async () => {
+    const tag = `{${randomKey()}}`
+    const first = `${tag}:first`
+    const second = `${tag}:second`
+
+    try {
+      await client1!.del(first, second)
+      assert.strictEqual(
+        await client1!.call('BZMPOP', '0.1', '2', first, second, 'MIN'),
+        null,
+      )
+    } finally {
+      await client1!.del(first, second)
+    }
+  })
+
+  test('ZMPOP / BZMPOP error paths match Redis', async () => {
+    const tag = `{${randomKey()}}`
+    const zset = `${tag}:zset`
+    const other = `${tag}:other`
+    const stringKey = `${tag}:string`
+
+    try {
+      await client1!.del(zset, other, stringKey)
+      await client1!.zadd(zset, 1, 'value')
+      await client1!.set(stringKey, 'not-a-zset')
+
+      await assert.rejects(
+        () => client1!.call('ZMPOP'),
+        errorWithMessage("ERR wrong number of arguments for 'zmpop' command"),
+      )
+      await assert.rejects(
+        () => client1!.call('ZMPOP', '0', zset, 'MIN'),
+        errorWithMessage('ERR numkeys should be greater than 0'),
+      )
+      await assert.rejects(
+        () => client1!.call('ZMPOP', 'abc', zset, 'MIN'),
+        errorWithMessage('ERR numkeys should be greater than 0'),
+      )
+      await assert.rejects(
+        () => client1!.call('ZMPOP', '2', zset, other),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => client1!.call('ZMPOP', '1', zset, 'MIDDLE'),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => client1!.call('ZMPOP', '1', zset, 'MIN', 'LIMIT', '1'),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => client1!.call('ZMPOP', '1', zset, 'MIN', 'COUNT'),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => client1!.call('ZMPOP', '1', zset, 'MIN', 'COUNT', '0'),
+        errorWithMessage('ERR count should be greater than 0'),
+      )
+      await assert.rejects(
+        () => client1!.call('ZMPOP', '1', zset, 'MIN', 'COUNT', '-1'),
+        errorWithMessage('ERR count should be greater than 0'),
+      )
+      await assert.rejects(
+        () => client1!.call('ZMPOP', '1', zset, 'MIN', 'COUNT', 'abc'),
+        errorWithMessage('ERR count should be greater than 0'),
+      )
+      await assert.rejects(
+        () =>
+          client1!.call('ZMPOP', '1', zset, 'MIN', 'COUNT', '1', 'COUNT', '1'),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => client1!.call('ZMPOP', '1', stringKey, 'MIN'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+
+      await assert.rejects(
+        () => client1!.call('BZMPOP', '-1', '1', zset, 'MIN'),
+        errorWithMessage('ERR timeout is negative'),
+      )
+      await assert.rejects(
+        () => client1!.call('BZMPOP', 'abc', '1', zset, 'MIN'),
+        errorWithMessage('ERR timeout is not a float or out of range'),
+      )
+
+      const directClient = await connectToSlotOwner(client1!, zset)
+      try {
+        await assert.rejects(
+          () => directClient.call('ZMPOP', '2', zset, 'other-slot-key', 'MIN'),
+          errorWithMessage(
+            "CROSSSLOT Keys in request don't hash to the same slot",
+          ),
+        )
+        await assert.rejects(
+          () =>
+            directClient.call(
+              'BZMPOP',
+              '1',
+              '2',
+              zset,
+              'other-slot-key',
+              'MIN',
+            ),
+          errorWithMessage(
+            "CROSSSLOT Keys in request don't hash to the same slot",
+          ),
+        )
+      } finally {
+        directClient.disconnect()
+      }
+    } finally {
+      await client1!.del(zset, other, stringKey)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Add Redis 7 `ZMPOP` and `BZMPOP` sorted-set multi-pop commands.
- Implement Redis-compatible parsing, null replies, wrong-type errors, cluster key routing, count handling, and park-based blocking wakeups.
- Document the new sorted-set command support in `docs/COMMANDS.md`.

## Root Cause
Issue #108 was the remaining open child of #25. The sorted-set command registry had single-key `ZPOPMIN` / `ZPOPMAX`, but no multi-key parser or executor for `ZMPOP` / `BZMPOP`, so clients received unknown-command errors.

## Validation
- Focused mock integration red before fix: unknown `ZMPOP` / `BZMPOP` commands.
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/zmpop-bzmpop-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/zmpop-bzmpop-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`
- Pre-push hook: `npm test`

Fixes #108
Part of #25.
