### PR TITLE
Fix approximate stream trimming

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -303,7 +303,7 @@ with `GT` or `LT`.
 
 #### Notes / gaps vs. real Redis
 
-- `LIMIT count` is accepted on approximate (`~`) `XADD`/`XTRIM` trim specs for Redis-compatible parsing; the mock treats it as a trimming hint.
+- Approximate (`~`) `XADD`/`XTRIM` trim specs use a simplified mock heuristic that may leave one extra eligible entry; `LIMIT count` is accepted for Redis-compatible parsing and treated as a trimming hint.
 - [ ] Stream radix-tree statistics in `XINFO STREAM` are approximated for mock compatibility rather than mirroring Redis internals
 
 #### Not implemented

--- a/src/commands/streams/trim.ts
+++ b/src/commands/streams/trim.ts
@@ -98,7 +98,9 @@ export function createTrimSpecSchema() {
 
 export function applyTrim(stream: RedisStreamData, spec: TrimSpec): number {
   if (spec.strategy === 'maxlen') {
-    const removeCount = stream.entries.length - Number(spec.count)
+    const targetLength = spec.approximate ? spec.count + 1n : spec.count
+    const removeCountBigint = BigInt(stream.entries.length) - targetLength
+    const removeCount = removeCountBigint > 0n ? Number(removeCountBigint) : 0
     if (removeCount <= 0) return 0
     for (const entry of stream.entries.slice(0, removeCount)) {
       updateMaxDeletedId(stream, entry.id)
@@ -114,6 +116,10 @@ export function applyTrim(stream: RedisStreamData, spec: TrimSpec): number {
       i++
     }
     if (i === 0) return 0
+    if (spec.approximate) {
+      i--
+      if (i === 0) return 0
+    }
     for (const entry of stream.entries.slice(0, i)) {
       updateMaxDeletedId(stream, entry.id)
     }

--- a/tests-integration/ioredis/stream-integration.test.ts
+++ b/tests-integration/ioredis/stream-integration.test.ts
@@ -257,9 +257,9 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
     ])
   })
 
-  test('XTRIM MAXLEN with ~ (approximate) accepts the flag and returns an integer', async () => {
-    // Real Redis uses radix-tree node boundaries for ~; on a tiny stream it may not
-    // trim at all. We only assert the command succeeds and returns a non-negative int.
+  test('XTRIM MAXLEN with ~ (approximate) does not exact-trim tiny streams', async () => {
+    // Real Redis uses radix-tree node boundaries for ~; on a tiny stream it
+    // keeps entries above the threshold instead of trimming exactly to it.
     const key = randomKey()
     const node = await connectToSlotOwner(redisClient!, key)
     try {
@@ -274,7 +274,13 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
         '~',
         '2',
       )) as number
-      assert.ok(typeof removed === 'number' && removed >= 0)
+      assert.strictEqual(removed, 0)
+      assert.strictEqual(await node.xlen(key), 3)
+      assert.deepStrictEqual(await node.xrange(key, '-', '+'), [
+        ['1-1', ['f', 'v']],
+        ['2-1', ['f', 'v']],
+        ['3-1', ['f', 'v']],
+      ])
     } finally {
       node.disconnect()
     }

--- a/tests/commands-streams.test.ts
+++ b/tests/commands-streams.test.ts
@@ -43,14 +43,12 @@ describe('stream commands (unit)', () => {
     )
   })
 
-  test('XTRIM MAXLEN ~ (approximate) trims exactly in this implementation', async () => {
-    // Our mock uses exact trimming even for ~; this test pins that contract.
-    // The integration test against real Redis only asserts the flag is accepted
-    // (real Redis may defer trimming on small streams).
+  test('XTRIM MAXLEN ~ (approximate) leaves one extra entry when possible', async () => {
     const { session } = createSession()
     await session.execute('xadd', buf('s', '1-1', 'f', 'v'))
     await session.execute('xadd', buf('s', '2-1', 'f', 'v'))
     await session.execute('xadd', buf('s', '3-1', 'f', 'v'))
+    await session.execute('xadd', buf('s', '4-1', 'f', 'v'))
 
     assert.deepStrictEqual(
       await session.execute('xtrim', buf('s', 'MAXLEN', '~', '2')),
@@ -58,7 +56,7 @@ describe('stream commands (unit)', () => {
     )
     assert.deepStrictEqual(
       await session.execute('xlen', buf('s')),
-      intResult(2),
+      intResult(3),
     )
   })
 
@@ -78,14 +76,14 @@ describe('stream commands (unit)', () => {
     )
   })
 
-  test('XTRIM MINID ~ trims exactly in this implementation', async () => {
+  test('XTRIM MINID ~ (approximate) leaves one eligible entry when possible', async () => {
     const { session } = createSession()
     await session.execute('xadd', buf('s', '1-0', 'f', 'v'))
     await session.execute('xadd', buf('s', '2-0', 'f', 'v'))
     await session.execute('xadd', buf('s', '3-0', 'f', 'v'))
 
     assert.deepStrictEqual(
-      await session.execute('xtrim', buf('s', 'MINID', '~', '2-0')),
+      await session.execute('xtrim', buf('s', 'MINID', '~', '3-0')),
       intResult(1),
     )
     assert.deepStrictEqual(
@@ -171,6 +169,19 @@ describe('stream commands (unit)', () => {
       ).value.toString(),
     )
     assert.deepStrictEqual(ids, ['3-1', '4-1'])
+  })
+
+  test('XADD MAXLEN ~ (approximate) leaves one extra entry when possible', async () => {
+    const { session } = createSession()
+    await session.execute('xadd', buf('s', '1-1', 'f', 'v'))
+    await session.execute('xadd', buf('s', '2-1', 'f', 'v'))
+    await session.execute('xadd', buf('s', '3-1', 'f', 'v'))
+    await session.execute('xadd', buf('s', 'MAXLEN', '~', '2', '4-1', 'f', 'v'))
+
+    assert.deepStrictEqual(
+      await session.execute('xlen', buf('s')),
+      intResult(3),
+    )
   })
 
   // XREAD


### PR DESCRIPTION
## Summary
- Make approximate stream trims use a simplified mock heuristic that can leave one extra eligible entry instead of exact-trimming to the threshold.
- Add Redis-backed coverage for tiny `XTRIM MAXLEN ~` streams and update unit coverage for shared `XADD`/`XTRIM` trim behavior.
- Document the simplified approximate trim behavior in the command support notes.

## Root cause
`applyTrim` ignored `TrimSpec.approximate` and always trimmed to the exact `MAXLEN`/`MINID` threshold.

## Validation
- Red check: `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test --test-name-pattern "does not exact-trim tiny streams" ./tests-integration/ioredis/stream-integration.test.ts` failed before the fix with removed count `1 !== 0`.
- `node --enable-source-maps --import tsx --no-warnings --test ./tests/commands-streams.test.ts`
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test --test-name-pattern "does not exact-trim tiny streams" ./tests-integration/ioredis/stream-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test --test-name-pattern "does not exact-trim tiny streams" ./tests-integration/ioredis/stream-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`
- Pre-push `npm test`

Fixes #65