### PR TITLE
Fix no-op WATCH invalidation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -333,10 +333,11 @@ emitting an `evict` mutation event so `WATCH` observes expiry exactly like a
 real delete. Every mutation (`write`/`delete`/`expire`/`persist`/`evict`/`flush`)
 flows through [`RedisMutationBus.emit`](../src/state/mutation-events.ts#L68),
 which clones values before fan-out so subscribers can never mutate shared state.
-In-place collection updates return both their command result and a `changed`
-flag; `RedisKeyspace.update()` only emits a `write` or auto-delete event when
-that flag says the key's stored value really changed, so no-op removals do not
-spuriously dirty `WATCH`.
+In-place collection updates run through a keyspace-owned mutation tracker and
+typed helpers such as `TrackedHashData.setField()` and
+`TrackedListData.trim()`. Helpers mark a key dirty only for real mutations, with
+an explicit force-write escape hatch for Redis-compatible semantics where a
+successful write dirties `WATCH` even when the final value is unchanged.
 
 ## Concurrency model
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -335,9 +335,12 @@ flows through [`RedisMutationBus.emit`](../src/state/mutation-events.ts#L68),
 which clones values before fan-out so subscribers can never mutate shared state.
 In-place collection updates run through a keyspace-owned mutation tracker and
 typed helpers such as `TrackedHashData.setField()` and
-`TrackedListData.trim()`. Helpers mark a key dirty only for real mutations, with
-an explicit force-write escape hatch for Redis-compatible semantics where a
-successful write dirties `WATCH` even when the final value is unchanged.
+`TrackedListData.trim()`. Dirty tracking is operation-based rather than a
+before/after value diff: effective helper operations mark the key dirty as they
+run, even if a later operation restores the same final value. Commands use an
+explicit force-write escape hatch for Redis-compatible semantics where a
+successful write dirties `WATCH` even when no helper operation changed the final
+value, such as identical STORE rewrites or `LTRIM key 0 -1`.
 
 ## Concurrency model
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -333,6 +333,10 @@ emitting an `evict` mutation event so `WATCH` observes expiry exactly like a
 real delete. Every mutation (`write`/`delete`/`expire`/`persist`/`evict`/`flush`)
 flows through [`RedisMutationBus.emit`](../src/state/mutation-events.ts#L68),
 which clones values before fan-out so subscribers can never mutate shared state.
+In-place collection updates return both their command result and a `changed`
+flag; `RedisKeyspace.update()` only emits a `write` or auto-delete event when
+that flag says the key's stored value really changed, so no-op removals do not
+spuriously dirty `WATCH`.
 
 ## Concurrency model
 

--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -134,10 +134,13 @@ export const hsetCommand = defineCommand({
       let count = 0
       for (const { field, value } of args.pairs) {
         const hex = field.toString('hex')
-        if (!hash.fields.has(hex)) count++
+        const existing = hash.fields.get(hex)
+        if (!existing) {
+          count++
+        }
         hash.fields.set(hex, { field, value })
       }
-      return count
+      return { result: count, changed: true }
     })
     return integer(added)
   },
@@ -151,9 +154,9 @@ export const hsetnxCommand = defineCommand({
   execute: (args, ctx) => {
     const set = ctx.db.updateHash(args.key, hash => {
       const hex = args.field.toString('hex')
-      if (hash.fields.has(hex)) return false
+      if (hash.fields.has(hex)) return { result: false, changed: false }
       hash.fields.set(hex, { field: args.field, value: args.value })
-      return true
+      return { result: true, changed: true }
     })
     return integer(set ? 1 : 0)
   },
@@ -186,7 +189,7 @@ export const hdelCommand = defineCommand({
       for (const field of args.fields) {
         if (hash.fields.delete(field.toString('hex'))) deleted++
       }
-      return hash.fields.size
+      return { result: hash.fields.size, changed: deleted > 0 }
     })
     if (remaining === 0) {
       ctx.db.delete(args.key)
@@ -203,8 +206,10 @@ export const hmsetCommand = defineCommand({
   execute: (args, ctx) => {
     ctx.db.updateHash(args.key, hash => {
       for (const { field, value } of args.pairs) {
-        hash.fields.set(field.toString('hex'), { field, value })
+        const hex = field.toString('hex')
+        hash.fields.set(hex, { field, value })
       }
+      return { result: undefined, changed: true }
     })
     return ok()
   },
@@ -339,7 +344,7 @@ export const hincrbyCommand = defineCommand({
       const next = current + args.increment
       const valueBuf = Buffer.from(String(next))
       hash.fields.set(hex, { field: args.field, value: valueBuf })
-      return next
+      return { result: next, changed: true }
     })
     return integer(result)
   },
@@ -374,7 +379,7 @@ export const hincrbyfloatCommand = defineCommand({
       }
       const valueBuf = Buffer.from(formatted)
       hash.fields.set(hex, { field: args.field, value: valueBuf })
-      return valueBuf
+      return { result: valueBuf, changed: true }
     })
     return bulk(result)
   },

--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -133,14 +133,9 @@ export const hsetCommand = defineCommand({
     const added = ctx.db.updateHash(args.key, hash => {
       let count = 0
       for (const { field, value } of args.pairs) {
-        const hex = field.toString('hex')
-        const existing = hash.fields.get(hex)
-        if (!existing) {
-          count++
-        }
-        hash.fields.set(hex, { field, value })
+        if (hash.setField(field, value, { forceDirty: true }).added) count++
       }
-      return { result: count, changed: true }
+      return count
     })
     return integer(added)
   },
@@ -153,10 +148,7 @@ export const hsetnxCommand = defineCommand({
   keys: args => [args.key],
   execute: (args, ctx) => {
     const set = ctx.db.updateHash(args.key, hash => {
-      const hex = args.field.toString('hex')
-      if (hash.fields.has(hex)) return { result: false, changed: false }
-      hash.fields.set(hex, { field: args.field, value: args.value })
-      return { result: true, changed: true }
+      return hash.setFieldIfAbsent(args.field, args.value)
     })
     return integer(set ? 1 : 0)
   },
@@ -187,9 +179,9 @@ export const hdelCommand = defineCommand({
     let deleted = 0
     const remaining = ctx.db.updateHash(args.key, hash => {
       for (const field of args.fields) {
-        if (hash.fields.delete(field.toString('hex'))) deleted++
+        if (hash.deleteField(field)) deleted++
       }
-      return { result: hash.fields.size, changed: deleted > 0 }
+      return hash.size
     })
     if (remaining === 0) {
       ctx.db.delete(args.key)
@@ -206,10 +198,8 @@ export const hmsetCommand = defineCommand({
   execute: (args, ctx) => {
     ctx.db.updateHash(args.key, hash => {
       for (const { field, value } of args.pairs) {
-        const hex = field.toString('hex')
-        hash.fields.set(hex, { field, value })
+        hash.setField(field, value, { forceDirty: true })
       }
-      return { result: undefined, changed: true }
     })
     return ok()
   },
@@ -331,8 +321,7 @@ export const hincrbyCommand = defineCommand({
   keys: args => [args.key],
   execute: (args, ctx) => {
     const result = ctx.db.updateHash(args.key, hash => {
-      const hex = args.field.toString('hex')
-      const entry = hash.fields.get(hex)
+      const entry = hash.getField(args.field)
       let current = 0
       if (entry) {
         const raw = entry.value.toString()
@@ -343,8 +332,8 @@ export const hincrbyCommand = defineCommand({
       }
       const next = current + args.increment
       const valueBuf = Buffer.from(String(next))
-      hash.fields.set(hex, { field: args.field, value: valueBuf })
-      return { result: next, changed: true }
+      hash.setField(args.field, valueBuf, { forceDirty: true })
+      return next
     })
     return integer(result)
   },
@@ -357,8 +346,7 @@ export const hincrbyfloatCommand = defineCommand({
   keys: args => [args.key],
   execute: (args, ctx) => {
     const result = ctx.db.updateHash(args.key, hash => {
-      const hex = args.field.toString('hex')
-      const entry = hash.fields.get(hex)
+      const entry = hash.getField(args.field)
       let current = 0
       if (entry) {
         const raw = entry.value.toString()
@@ -378,8 +366,8 @@ export const hincrbyfloatCommand = defineCommand({
         formatted = next.toFixed(17).replace(/\.?0+$/, '')
       }
       const valueBuf = Buffer.from(formatted)
-      hash.fields.set(hex, { field: args.field, value: valueBuf })
-      return { result: valueBuf, changed: true }
+      hash.setField(args.field, valueBuf, { forceDirty: true })
+      return valueBuf
     })
     return bulk(result)
   },

--- a/src/commands/lists/access.ts
+++ b/src/commands/lists/access.ts
@@ -78,6 +78,7 @@ export const lsetCommand = defineCommand({
 
     ctx.db.updateList(args.key, list => {
       list.values[idx] = args.value
+      return { result: undefined, changed: true }
     })
     return ok()
   },
@@ -98,7 +99,10 @@ export const lremCommand = defineCommand({
 
     const result = ctx.db.updateList(args.key, list => {
       const removed = listRemove(list.values, args.count, args.element)
-      return { removed, empty: list.values.length === 0 }
+      return {
+        result: { removed, empty: list.values.length === 0 },
+        changed: removed > 0,
+      }
     })
     if (result.empty) ctx.db.delete(args.key)
     return integer(result.removed)
@@ -129,7 +133,10 @@ export const ltrimCommand = defineCommand({
         list.values.splice(0, start)
         list.values.splice(stop - start + 1)
       }
-      return { empty: list.values.length === 0 }
+      return {
+        result: { empty: list.values.length === 0 },
+        changed: true,
+      }
     })
     if (result.empty) ctx.db.delete(args.key)
     return ok()

--- a/src/commands/lists/access.ts
+++ b/src/commands/lists/access.ts
@@ -3,7 +3,7 @@ import { t } from '../../core/command-schema'
 import { IndexOutOfRangeError, NoSuchKeyError } from '../../core/redis-error'
 import { RedisValue } from '../../core/redis-value'
 import { array, bulk, integer, ok } from '../helpers'
-import { listRemove, resolveIndex } from './helpers'
+import { resolveIndex } from './helpers'
 
 export const llenCommand = defineCommand({
   name: 'llen',
@@ -77,8 +77,7 @@ export const lsetCommand = defineCommand({
     if (idx < 0 || idx >= list.values.length) throw new IndexOutOfRangeError()
 
     ctx.db.updateList(args.key, list => {
-      list.values[idx] = args.value
-      return { result: undefined, changed: true }
+      list.setAt(idx, args.value)
     })
     return ok()
   },
@@ -98,11 +97,8 @@ export const lremCommand = defineCommand({
     if (!list) return integer(0)
 
     const result = ctx.db.updateList(args.key, list => {
-      const removed = listRemove(list.values, args.count, args.element)
-      return {
-        result: { removed, empty: list.values.length === 0 },
-        changed: removed > 0,
-      }
+      const removed = list.removeMatching(args.count, args.element)
+      return { removed, empty: list.length === 0 }
     })
     if (result.empty) ctx.db.delete(args.key)
     return integer(result.removed)
@@ -123,20 +119,11 @@ export const ltrimCommand = defineCommand({
     if (!list) return ok()
 
     const result = ctx.db.updateList(args.key, list => {
-      let start = resolveIndex(args.start, list.values.length)
-      let stop = resolveIndex(args.stop, list.values.length)
+      let start = resolveIndex(args.start, list.length)
+      let stop = resolveIndex(args.stop, list.length)
       start = Math.max(0, start)
-      stop = Math.min(list.values.length - 1, stop)
-      if (start > stop) {
-        list.values.length = 0
-      } else {
-        list.values.splice(0, start)
-        list.values.splice(stop - start + 1)
-      }
-      return {
-        result: { empty: list.values.length === 0 },
-        changed: true,
-      }
+      stop = Math.min(list.length - 1, stop)
+      return list.trim(start, stop, { forceDirty: true })
     })
     if (result.empty) ctx.db.delete(args.key)
     return ok()

--- a/src/commands/lists/blpop.ts
+++ b/src/commands/lists/blpop.ts
@@ -19,11 +19,8 @@ export function tryListPop(
     if (!list || list.values.length === 0) continue
 
     const result = db.updateList(key, list => {
-      const value = side === 'left' ? list.values.shift()! : list.values.pop()!
-      return {
-        result: { value, empty: list.values.length === 0 },
-        changed: true,
-      }
+      const value = list.pop(side)
+      return { value, empty: list.length === 0 }
     })
     if (result.empty) db.delete(key)
     return RedisResult.create(

--- a/src/commands/lists/blpop.ts
+++ b/src/commands/lists/blpop.ts
@@ -20,7 +20,10 @@ export function tryListPop(
 
     const result = db.updateList(key, list => {
       const value = side === 'left' ? list.values.shift()! : list.values.pop()!
-      return { value, empty: list.values.length === 0 }
+      return {
+        result: { value, empty: list.values.length === 0 },
+        changed: true,
+      }
     })
     if (result.empty) db.delete(key)
     return RedisResult.create(

--- a/src/commands/lists/helpers.ts
+++ b/src/commands/lists/helpers.ts
@@ -67,11 +67,8 @@ export function popList(
 
   if (count === undefined) {
     const result = ctx.db.updateList(args.key, list => {
-      const value = side === 'left' ? list.values.shift() : list.values.pop()
-      return {
-        result: { value: value ?? null, empty: list.values.length === 0 },
-        changed: value !== undefined,
-      }
+      const value = list.pop(side)
+      return { value, empty: list.length === 0 }
     })
     if (result.empty) ctx.db.delete(args.key)
     return bulk(result.value)
@@ -82,14 +79,8 @@ export function popList(
   }
 
   const result = ctx.db.updateList(args.key, list => {
-    const values =
-      side === 'left'
-        ? list.values.splice(0, count)
-        : list.values.splice(Math.max(0, list.values.length - count))
-    return {
-      result: { values, empty: list.values.length === 0 },
-      changed: values.length > 0,
-    }
+    const values = list.popMany(side, count)
+    return { values, empty: list.length === 0 }
   })
   if (result.empty) ctx.db.delete(args.key)
 

--- a/src/commands/lists/helpers.ts
+++ b/src/commands/lists/helpers.ts
@@ -68,7 +68,10 @@ export function popList(
   if (count === undefined) {
     const result = ctx.db.updateList(args.key, list => {
       const value = side === 'left' ? list.values.shift() : list.values.pop()
-      return { value: value ?? null, empty: list.values.length === 0 }
+      return {
+        result: { value: value ?? null, empty: list.values.length === 0 },
+        changed: value !== undefined,
+      }
     })
     if (result.empty) ctx.db.delete(args.key)
     return bulk(result.value)
@@ -83,7 +86,10 @@ export function popList(
       side === 'left'
         ? list.values.splice(0, count)
         : list.values.splice(Math.max(0, list.values.length - count))
-    return { values, empty: list.values.length === 0 }
+    return {
+      result: { values, empty: list.values.length === 0 },
+      changed: values.length > 0,
+    }
   })
   if (result.empty) ctx.db.delete(args.key)
 

--- a/src/commands/lists/lmpop.ts
+++ b/src/commands/lists/lmpop.ts
@@ -139,7 +139,10 @@ export function tryListMultiPop(
         if (value) values.push(value)
       }
 
-      return { values, empty: list.values.length === 0 }
+      return {
+        result: { values, empty: list.values.length === 0 },
+        changed: values.length > 0,
+      }
     })
     if (result.empty) db.delete(key)
 

--- a/src/commands/lists/lmpop.ts
+++ b/src/commands/lists/lmpop.ts
@@ -131,18 +131,8 @@ export function tryListMultiPop(
     if (!list || list.values.length === 0) continue
 
     const result = db.updateList(key, list => {
-      const values: Buffer[] = []
-      const limit = Math.min(count, list.values.length)
-
-      for (let i = 0; i < limit; i++) {
-        const value = side === 'left' ? list.values.shift() : list.values.pop()
-        if (value) values.push(value)
-      }
-
-      return {
-        result: { values, empty: list.values.length === 0 },
-        changed: values.length > 0,
-      }
+      const values = list.popMany(side, count)
+      return { values, empty: list.length === 0 }
     })
     if (result.empty) db.delete(key)
 

--- a/src/commands/lists/move.ts
+++ b/src/commands/lists/move.ts
@@ -46,7 +46,10 @@ export function tryListMove(
     const value =
       (fromDirection === 'left' ? list.values.shift() : list.values.pop()) ??
       null
-    return { value, empty: list.values.length === 0 }
+    return {
+      result: { value, empty: list.values.length === 0 },
+      changed: value !== null,
+    }
   })
   if (popped.empty) db.delete(source)
   if (popped.value === null) return null
@@ -54,6 +57,7 @@ export function tryListMove(
   db.updateList(destination, list => {
     if (toDirection === 'left') list.values.unshift(popped.value!)
     else list.values.push(popped.value!)
+    return { result: undefined, changed: true }
   })
 
   return bulk(popped.value)
@@ -76,13 +80,17 @@ export const rpoplpushCommand = defineCommand({
 
     const value = ctx.db.updateList(args.source, list => {
       const val = list.values.pop() ?? null
-      return { val, empty: list.values.length === 0 }
+      return {
+        result: { val, empty: list.values.length === 0 },
+        changed: val !== null,
+      }
     })
     if (value.empty) ctx.db.delete(args.source)
     if (value.val === null) return bulk(null)
 
     ctx.db.updateList(args.destination, list => {
       list.values.unshift(value.val!)
+      return { result: undefined, changed: true }
     })
 
     return bulk(value.val)

--- a/src/commands/lists/move.ts
+++ b/src/commands/lists/move.ts
@@ -43,21 +43,15 @@ export function tryListMove(
   db.getList(destination)
 
   const popped = db.updateList(source, list => {
-    const value =
-      (fromDirection === 'left' ? list.values.shift() : list.values.pop()) ??
-      null
-    return {
-      result: { value, empty: list.values.length === 0 },
-      changed: value !== null,
-    }
+    const value = list.pop(fromDirection)
+    return { value, empty: list.length === 0 }
   })
   if (popped.empty) db.delete(source)
   if (popped.value === null) return null
 
   db.updateList(destination, list => {
-    if (toDirection === 'left') list.values.unshift(popped.value!)
-    else list.values.push(popped.value!)
-    return { result: undefined, changed: true }
+    if (toDirection === 'left') list.pushLeft([popped.value!])
+    else list.pushRight([popped.value!])
   })
 
   return bulk(popped.value)
@@ -79,18 +73,14 @@ export const rpoplpushCommand = defineCommand({
     ctx.db.getList(args.destination)
 
     const value = ctx.db.updateList(args.source, list => {
-      const val = list.values.pop() ?? null
-      return {
-        result: { val, empty: list.values.length === 0 },
-        changed: val !== null,
-      }
+      const val = list.pop('right')
+      return { val, empty: list.length === 0 }
     })
     if (value.empty) ctx.db.delete(args.source)
     if (value.val === null) return bulk(null)
 
     ctx.db.updateList(args.destination, list => {
-      list.values.unshift(value.val!)
-      return { result: undefined, changed: true }
+      list.pushLeft([value.val!])
     })
 
     return bulk(value.val)

--- a/src/commands/lists/push.ts
+++ b/src/commands/lists/push.ts
@@ -11,12 +11,7 @@ export const lpushCommand = defineCommand({
   flags: ['write', 'denyoom', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const len = ctx.db.updateList(args.key, list => {
-      for (const val of args.values) {
-        list.values.unshift(val)
-      }
-      return { result: list.values.length, changed: true }
-    })
+    const len = ctx.db.updateList(args.key, list => list.pushLeft(args.values))
     return integer(len)
   },
 })
@@ -30,12 +25,7 @@ export const rpushCommand = defineCommand({
   flags: ['write', 'denyoom', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const len = ctx.db.updateList(args.key, list => {
-      for (const val of args.values) {
-        list.values.push(val)
-      }
-      return { result: list.values.length, changed: true }
-    })
+    const len = ctx.db.updateList(args.key, list => list.pushRight(args.values))
     return integer(len)
   },
 })
@@ -52,12 +42,7 @@ export const lpushxCommand = defineCommand({
     const list = ctx.db.getList(args.key)
     if (!list) return integer(0)
 
-    const len = ctx.db.updateList(args.key, list => {
-      for (const val of args.values) {
-        list.values.unshift(val)
-      }
-      return { result: list.values.length, changed: true }
-    })
+    const len = ctx.db.updateList(args.key, list => list.pushLeft(args.values))
     return integer(len)
   },
 })
@@ -74,12 +59,7 @@ export const rpushxCommand = defineCommand({
     const list = ctx.db.getList(args.key)
     if (!list) return integer(0)
 
-    const len = ctx.db.updateList(args.key, list => {
-      for (const val of args.values) {
-        list.values.push(val)
-      }
-      return { result: list.values.length, changed: true }
-    })
+    const len = ctx.db.updateList(args.key, list => list.pushRight(args.values))
     return integer(len)
   },
 })

--- a/src/commands/lists/push.ts
+++ b/src/commands/lists/push.ts
@@ -15,7 +15,7 @@ export const lpushCommand = defineCommand({
       for (const val of args.values) {
         list.values.unshift(val)
       }
-      return list.values.length
+      return { result: list.values.length, changed: true }
     })
     return integer(len)
   },
@@ -34,7 +34,7 @@ export const rpushCommand = defineCommand({
       for (const val of args.values) {
         list.values.push(val)
       }
-      return list.values.length
+      return { result: list.values.length, changed: true }
     })
     return integer(len)
   },
@@ -56,7 +56,7 @@ export const lpushxCommand = defineCommand({
       for (const val of args.values) {
         list.values.unshift(val)
       }
-      return list.values.length
+      return { result: list.values.length, changed: true }
     })
     return integer(len)
   },
@@ -78,7 +78,7 @@ export const rpushxCommand = defineCommand({
       for (const val of args.values) {
         list.values.push(val)
       }
-      return list.values.length
+      return { result: list.values.length, changed: true }
     })
     return integer(len)
   },

--- a/src/commands/sets.ts
+++ b/src/commands/sets.ts
@@ -66,12 +66,18 @@ function storeSetResult(
     db.delete(destKey)
     return 0
   }
+  const existing = db.getSet(destKey)
+  const changed =
+    !existing ||
+    existing.members.size !== hexSet.size ||
+    Array.from(hexSet).some(hex => !existing.members.has(hex))
   db.updateSet(destKey, set => {
     set.members.clear()
     for (const hex of hexSet) {
       const buf = bufferMap.get(hex)!
       set.members.set(hex, buf)
     }
+    return { result: undefined, changed }
   })
   return hexSet.size
 }
@@ -154,7 +160,7 @@ export const saddCommand = defineCommand({
           set.members.set(hex, member)
         }
       }
-      return count
+      return { result: count, changed: count > 0 }
     })
     return integer(added)
   },
@@ -176,6 +182,7 @@ export const sremCommand = defineCommand({
       for (const member of args.members) {
         if (set.members.delete(member.toString('hex'))) removed++
       }
+      return { result: undefined, changed: removed > 0 }
     })
     if (removed > 0 && (ctx.db.getSet(args.key)?.members.size ?? 0) === 0) {
       ctx.db.delete(args.key)
@@ -274,12 +281,18 @@ export const spopCommand = defineCommand({
     if (args.count === undefined) {
       const result = ctx.db.updateSet(args.key, set => {
         if (set.members.size === 0)
-          return { member: null as Buffer | null, empty: false }
+          return {
+            result: { member: null as Buffer | null, empty: false },
+            changed: false,
+          }
         const entries = Array.from(set.members.entries())
         const [hex, member] =
           entries[Math.floor(Math.random() * entries.length)]
         set.members.delete(hex)
-        return { member, empty: set.members.size === 0 }
+        return {
+          result: { member, empty: set.members.size === 0 },
+          changed: true,
+        }
       })
       if (result.empty) ctx.db.delete(args.key)
       return bulk(result.member)
@@ -289,7 +302,10 @@ export const spopCommand = defineCommand({
 
     const result = ctx.db.updateSet(args.key, set => {
       if (set.members.size === 0)
-        return { members: [] as Buffer[], empty: true }
+        return {
+          result: { members: [] as Buffer[], empty: true },
+          changed: false,
+        }
       const entries = Array.from(set.members.entries())
       const size = Math.min(args.count!, entries.length)
       const members: Buffer[] = []
@@ -302,7 +318,10 @@ export const spopCommand = defineCommand({
         members.push(member)
       }
 
-      return { members, empty: set.members.size === 0 }
+      return {
+        result: { members, empty: set.members.size === 0 },
+        changed: members.length > 0,
+      }
     })
     if (result.empty) ctx.db.delete(args.key)
     return array(result.members.map(member => RedisValue.bulkString(member)))
@@ -464,6 +483,7 @@ export const smoveCommand = defineCommand({
         set.members.delete(hex)
         moved = true
       }
+      return { result: undefined, changed: moved }
     })
 
     if (!moved) return integer(0)
@@ -473,7 +493,9 @@ export const smoveCommand = defineCommand({
     }
 
     ctx.db.updateSet(args.destination, set => {
+      const changed = !set.members.has(hex)
       set.members.set(hex, args.member)
+      return { result: undefined, changed }
     })
 
     return integer(1)

--- a/src/commands/sets.ts
+++ b/src/commands/sets.ts
@@ -66,18 +66,8 @@ function storeSetResult(
     db.delete(destKey)
     return 0
   }
-  const existing = db.getSet(destKey)
-  const changed =
-    !existing ||
-    existing.members.size !== hexSet.size ||
-    Array.from(hexSet).some(hex => !existing.members.has(hex))
   db.updateSet(destKey, set => {
-    set.members.clear()
-    for (const hex of hexSet) {
-      const buf = bufferMap.get(hex)!
-      set.members.set(hex, buf)
-    }
-    return { result: undefined, changed }
+    set.replaceMembers(hexSet, bufferMap, { forceDirty: true })
   })
   return hexSet.size
 }
@@ -154,13 +144,9 @@ export const saddCommand = defineCommand({
     const added = ctx.db.updateSet(args.key, set => {
       let count = 0
       for (const member of args.members) {
-        const hex = member.toString('hex')
-        if (!set.members.has(hex)) {
-          count++
-          set.members.set(hex, member)
-        }
+        if (set.addMember(member)) count++
       }
-      return { result: count, changed: count > 0 }
+      return count
     })
     return integer(added)
   },
@@ -180,9 +166,8 @@ export const sremCommand = defineCommand({
     let removed = 0
     ctx.db.updateSet(args.key, set => {
       for (const member of args.members) {
-        if (set.members.delete(member.toString('hex'))) removed++
+        if (set.deleteMember(member)) removed++
       }
-      return { result: undefined, changed: removed > 0 }
     })
     if (removed > 0 && (ctx.db.getSet(args.key)?.members.size ?? 0) === 0) {
       ctx.db.delete(args.key)
@@ -280,19 +265,13 @@ export const spopCommand = defineCommand({
 
     if (args.count === undefined) {
       const result = ctx.db.updateSet(args.key, set => {
-        if (set.members.size === 0)
-          return {
-            result: { member: null as Buffer | null, empty: false },
-            changed: false,
-          }
-        const entries = Array.from(set.members.entries())
+        if (set.size === 0)
+          return { member: null as Buffer | null, empty: false }
+        const entries = set.randomMemberEntries()
         const [hex, member] =
           entries[Math.floor(Math.random() * entries.length)]
-        set.members.delete(hex)
-        return {
-          result: { member, empty: set.members.size === 0 },
-          changed: true,
-        }
+        set.deleteMemberId(hex)
+        return { member, empty: set.size === 0 }
       })
       if (result.empty) ctx.db.delete(args.key)
       return bulk(result.member)
@@ -301,12 +280,8 @@ export const spopCommand = defineCommand({
     if (args.count === 0) return array([])
 
     const result = ctx.db.updateSet(args.key, set => {
-      if (set.members.size === 0)
-        return {
-          result: { members: [] as Buffer[], empty: true },
-          changed: false,
-        }
-      const entries = Array.from(set.members.entries())
+      if (set.size === 0) return { members: [] as Buffer[], empty: true }
+      const entries = set.randomMemberEntries()
       const size = Math.min(args.count!, entries.length)
       const members: Buffer[] = []
 
@@ -314,14 +289,11 @@ export const spopCommand = defineCommand({
         const j = i + Math.floor(Math.random() * (entries.length - i))
         ;[entries[i], entries[j]] = [entries[j], entries[i]]
         const [hex, member] = entries[i]
-        set.members.delete(hex)
+        set.deleteMemberId(hex)
         members.push(member)
       }
 
-      return {
-        result: { members, empty: set.members.size === 0 },
-        changed: members.length > 0,
-      }
+      return { members, empty: set.size === 0 }
     })
     if (result.empty) ctx.db.delete(args.key)
     return array(result.members.map(member => RedisValue.bulkString(member)))
@@ -467,8 +439,6 @@ export const smoveCommand = defineCommand({
   flags: ['write', 'fast'],
   keys: args => [args.source, args.destination],
   execute: (args, ctx) => {
-    const hex = args.member.toString('hex')
-
     const sourceType = ctx.db.getType(args.source)
     if (sourceType === null) return integer(0)
     if (sourceType !== 'set') throw new WrongTypeRedisError()
@@ -479,11 +449,7 @@ export const smoveCommand = defineCommand({
 
     let moved = false
     ctx.db.updateSet(args.source, set => {
-      if (set.members.has(hex)) {
-        set.members.delete(hex)
-        moved = true
-      }
-      return { result: undefined, changed: moved }
+      moved = set.deleteMember(args.member)
     })
 
     if (!moved) return integer(0)
@@ -493,9 +459,7 @@ export const smoveCommand = defineCommand({
     }
 
     ctx.db.updateSet(args.destination, set => {
-      const changed = !set.members.has(hex)
-      set.members.set(hex, args.member)
-      return { result: undefined, changed }
+      set.addMember(args.member)
     })
 
     return integer(1)

--- a/src/commands/streams/xack.ts
+++ b/src/commands/streams/xack.ts
@@ -22,7 +22,7 @@ export const xackCommand = defineCommand({
       for (const id of ids) {
         if (group.pending.delete(streamIdKey(id))) count++
       }
-      return count
+      return { result: count, changed: count > 0 }
     })
     return integer(acknowledged)
   },

--- a/src/commands/streams/xack.ts
+++ b/src/commands/streams/xack.ts
@@ -2,7 +2,7 @@ import { defineCommand } from '../../core/command-definition'
 import { t } from '../../core/command-schema'
 import { integer } from '../helpers'
 import { requireStreamGroup } from './groups'
-import { parseExactId, streamIdKey } from './ids'
+import { parseExactId } from './ids'
 
 export const xackCommand = defineCommand({
   name: 'xack',
@@ -17,12 +17,8 @@ export const xackCommand = defineCommand({
     const ids = args.ids.map(parseExactId)
     requireStreamGroup(ctx.db.getStream(args.key), args.key, args.group)
     const acknowledged = ctx.db.updateStream(args.key, stream => {
-      const group = requireStreamGroup(stream, args.key, args.group)
-      let count = 0
-      for (const id of ids) {
-        if (group.pending.delete(streamIdKey(id))) count++
-      }
-      return { result: count, changed: count > 0 }
+      const group = requireStreamGroup(stream.value, args.key, args.group)
+      return stream.ack(group, ids)
     })
     return integer(acknowledged)
   },

--- a/src/commands/streams/xadd.ts
+++ b/src/commands/streams/xadd.ts
@@ -122,15 +122,14 @@ export const xaddCommand = defineCommand({
         throw new StreamIdEqualOrSmallerError()
       }
 
-      stream.entries.push({ id: next, fields: args.fields })
-      stream.lastId = next
-      stream.entriesAdded++
+      stream.appendEntry(next, args.fields)
 
       if (args.trim !== undefined) {
-        applyTrim(stream, args.trim)
+        const trim = args.trim
+        stream.trim(value => applyTrim(value, trim))
       }
 
-      return { result: next, changed: true }
+      return next
     })
 
     return bulk(Buffer.from(formatStreamId(id)))

--- a/src/commands/streams/xadd.ts
+++ b/src/commands/streams/xadd.ts
@@ -130,7 +130,7 @@ export const xaddCommand = defineCommand({
         applyTrim(stream, args.trim)
       }
 
-      return next
+      return { result: next, changed: true }
     })
 
     return bulk(Buffer.from(formatStreamId(id)))

--- a/src/commands/streams/xautoclaim.ts
+++ b/src/commands/streams/xautoclaim.ts
@@ -98,7 +98,8 @@ export const xautoclaimCommand = defineCommand({
       command.group,
     )
     const result = ctx.db.updateStream(command.key, stream => {
-      const group = requireStreamGroup(stream, command.key, command.group)
+      const value = stream.value
+      const group = requireStreamGroup(value, command.key, command.group)
       ensureConsumer(group, command.consumer, now).activeAt = now
       const consumerId = bufferId(command.consumer)
       const claimed: RedisValue[] = []
@@ -108,7 +109,7 @@ export const xautoclaimCommand = defineCommand({
       for (const pending of pendingEntriesSorted(group)) {
         if (compareStreamId(pending.id, command.start) < 0) continue
 
-        const entry = findEntry(stream, pending.id)
+        const entry = findEntry(value, pending.id)
         if (!entry) {
           group.pending.delete(streamIdKey(pending.id))
           deleted.push(streamIdValue(pending.id))
@@ -136,7 +137,8 @@ export const xautoclaimCommand = defineCommand({
         }
       }
 
-      return { result: { nextStartId, claimed, deleted }, changed: true }
+      stream.forceWrite()
+      return { nextStartId, claimed, deleted }
     })
 
     return array([

--- a/src/commands/streams/xautoclaim.ts
+++ b/src/commands/streams/xautoclaim.ts
@@ -136,7 +136,7 @@ export const xautoclaimCommand = defineCommand({
         }
       }
 
-      return { nextStartId, claimed, deleted }
+      return { result: { nextStartId, claimed, deleted }, changed: true }
     })
 
     return array([

--- a/src/commands/streams/xclaim.ts
+++ b/src/commands/streams/xclaim.ts
@@ -140,7 +140,8 @@ export const xclaimCommand = defineCommand({
       command.group,
     )
     const claimed = ctx.db.updateStream(command.key, stream => {
-      const group = requireStreamGroup(stream, command.key, command.group)
+      const value = stream.value
+      const group = requireStreamGroup(value, command.key, command.group)
       ensureConsumer(group, command.consumer, now).activeAt = now
       const consumerId = bufferId(command.consumer)
       if (command.lastId) group.lastDeliveredId = cloneStreamId(command.lastId)
@@ -148,7 +149,7 @@ export const xclaimCommand = defineCommand({
       const replies: RedisValue[] = []
       for (const id of command.ids) {
         const pendingId = streamIdKey(id)
-        const entry = findEntry(stream, id)
+        const entry = findEntry(value, id)
         let pending = group.pending.get(pendingId)
 
         if (!pending && command.force && entry) {
@@ -186,7 +187,8 @@ export const xclaimCommand = defineCommand({
             : entryToReply(entry.id, entry.fields),
         )
       }
-      return { result: replies, changed: true }
+      stream.forceWrite()
+      return replies
     })
 
     return array(claimed)

--- a/src/commands/streams/xclaim.ts
+++ b/src/commands/streams/xclaim.ts
@@ -186,7 +186,7 @@ export const xclaimCommand = defineCommand({
             : entryToReply(entry.id, entry.fields),
         )
       }
-      return replies
+      return { result: replies, changed: true }
     })
 
     return array(claimed)

--- a/src/commands/streams/xdel.ts
+++ b/src/commands/streams/xdel.ts
@@ -31,7 +31,7 @@ export const xdelCommand = defineCommand({
           count++
         }
       }
-      return count
+      return { result: count, changed: count > 0 }
     })
     // Streams are not removed when they become empty, matching Redis.
     return integer(deleted)

--- a/src/commands/streams/xdel.ts
+++ b/src/commands/streams/xdel.ts
@@ -19,20 +19,11 @@ export const xdelCommand = defineCommand({
       return integer(0)
     }
 
-    const deleted = ctx.db.updateStream(args.key, stream => {
-      let count = 0
-      for (const target of targets) {
-        const idx = stream.entries.findIndex(
-          entry => compareStreamId(entry.id, target) === 0,
-        )
-        if (idx !== -1) {
-          updateMaxDeletedId(stream, stream.entries[idx].id)
-          stream.entries.splice(idx, 1)
-          count++
-        }
-      }
-      return { result: count, changed: count > 0 }
-    })
+    const deleted = ctx.db.updateStream(args.key, stream =>
+      stream.deleteEntries(targets, compareStreamId, entry =>
+        updateMaxDeletedId(stream.value, entry.id),
+      ),
+    )
     // Streams are not removed when they become empty, matching Redis.
     return integer(deleted)
   },

--- a/src/commands/streams/xgroup.ts
+++ b/src/commands/streams/xgroup.ts
@@ -161,18 +161,17 @@ export const xgroupCommand = defineCommand({
 
       ctx.db.updateStream(command.key, stream => {
         const groupId = bufferId(command.group)
-        if (stream.groups.has(groupId)) {
+        if (stream.value.groups.has(groupId)) {
           throw new BusyStreamGroupError()
         }
 
-        stream.groups.set(groupId, {
+        stream.addGroup(groupId, {
           name: Buffer.from(command.group),
           lastDeliveredId: cloneStreamId(lastDeliveredId),
           entriesRead: command.entriesRead,
           consumers: new Map(),
           pending: new Map(),
         })
-        return { result: undefined, changed: true }
       })
       return ok()
     }
@@ -184,13 +183,17 @@ export const xgroupCommand = defineCommand({
         command.group,
       )
       ctx.db.updateStream(command.key, stream => {
-        const group = requireStreamGroup(stream, command.key, command.group)
+        const group = requireStreamGroup(
+          stream.value,
+          command.key,
+          command.group,
+        )
         group.lastDeliveredId =
           command.id === '$'
             ? cloneStreamId(stream.lastId)
             : cloneStreamId(command.id)
         group.entriesRead = command.entriesRead
-        return { result: undefined, changed: true }
+        stream.forceWrite()
       })
       return ok()
     }
@@ -200,8 +203,7 @@ export const xgroupCommand = defineCommand({
       if (!stream) return integer(0)
 
       const removed = ctx.db.updateStream(command.key, writable => {
-        const removed = writable.groups.delete(bufferId(command.group))
-        return { result: removed, changed: removed }
+        return writable.deleteGroup(bufferId(command.group))
       })
       return integer(removed ? 1 : 0)
     }
@@ -213,18 +215,17 @@ export const xgroupCommand = defineCommand({
         command.group,
       )
       const created = ctx.db.updateStream(command.key, stream => {
-        const group = requireStreamGroup(stream, command.key, command.group)
+        const group = requireStreamGroup(
+          stream.value,
+          command.key,
+          command.group,
+        )
         const consumerId = bufferId(command.consumer)
-        if (group.consumers.has(consumerId)) {
-          return { result: false, changed: false }
-        }
-
-        group.consumers.set(consumerId, {
+        return stream.addConsumer(group, consumerId, {
           name: Buffer.from(command.consumer),
           seenAt: Date.now(),
           activeAt: null,
         })
-        return { result: true, changed: true }
       })
       return integer(created ? 1 : 0)
     }
@@ -235,19 +236,9 @@ export const xgroupCommand = defineCommand({
       command.group,
     )
     const deleted = ctx.db.updateStream(command.key, stream => {
-      const group = requireStreamGroup(stream, command.key, command.group)
+      const group = requireStreamGroup(stream.value, command.key, command.group)
       const consumerId = bufferId(command.consumer)
-      if (!group.consumers.delete(consumerId)) {
-        return { result: 0, changed: false }
-      }
-
-      let removedPending = 0
-      for (const [pendingId, pending] of Array.from(group.pending)) {
-        if (pending.consumerId !== consumerId) continue
-        group.pending.delete(pendingId)
-        removedPending++
-      }
-      return { result: removedPending, changed: true }
+      return stream.deleteConsumer(group, consumerId)
     })
     return integer(deleted)
   },

--- a/src/commands/streams/xgroup.ts
+++ b/src/commands/streams/xgroup.ts
@@ -172,6 +172,7 @@ export const xgroupCommand = defineCommand({
           consumers: new Map(),
           pending: new Map(),
         })
+        return { result: undefined, changed: true }
       })
       return ok()
     }
@@ -189,6 +190,7 @@ export const xgroupCommand = defineCommand({
             ? cloneStreamId(stream.lastId)
             : cloneStreamId(command.id)
         group.entriesRead = command.entriesRead
+        return { result: undefined, changed: true }
       })
       return ok()
     }
@@ -197,9 +199,10 @@ export const xgroupCommand = defineCommand({
       const stream = ctx.db.getStream(command.key)
       if (!stream) return integer(0)
 
-      const removed = ctx.db.updateStream(command.key, writable =>
-        writable.groups.delete(bufferId(command.group)),
-      )
+      const removed = ctx.db.updateStream(command.key, writable => {
+        const removed = writable.groups.delete(bufferId(command.group))
+        return { result: removed, changed: removed }
+      })
       return integer(removed ? 1 : 0)
     }
 
@@ -212,14 +215,16 @@ export const xgroupCommand = defineCommand({
       const created = ctx.db.updateStream(command.key, stream => {
         const group = requireStreamGroup(stream, command.key, command.group)
         const consumerId = bufferId(command.consumer)
-        if (group.consumers.has(consumerId)) return false
+        if (group.consumers.has(consumerId)) {
+          return { result: false, changed: false }
+        }
 
         group.consumers.set(consumerId, {
           name: Buffer.from(command.consumer),
           seenAt: Date.now(),
           activeAt: null,
         })
-        return true
+        return { result: true, changed: true }
       })
       return integer(created ? 1 : 0)
     }
@@ -232,7 +237,9 @@ export const xgroupCommand = defineCommand({
     const deleted = ctx.db.updateStream(command.key, stream => {
       const group = requireStreamGroup(stream, command.key, command.group)
       const consumerId = bufferId(command.consumer)
-      if (!group.consumers.delete(consumerId)) return 0
+      if (!group.consumers.delete(consumerId)) {
+        return { result: 0, changed: false }
+      }
 
       let removedPending = 0
       for (const [pendingId, pending] of Array.from(group.pending)) {
@@ -240,7 +247,7 @@ export const xgroupCommand = defineCommand({
         group.pending.delete(pendingId)
         removedPending++
       }
-      return removedPending
+      return { result: removedPending, changed: true }
     })
     return integer(deleted)
   },

--- a/src/commands/streams/xreadgroup.ts
+++ b/src/commands/streams/xreadgroup.ts
@@ -165,7 +165,7 @@ function readGroupEntries(
         }
       }
 
-      return replies
+      return { result: replies, changed: true }
     })
 
     if (entries.length > 0 || id !== '>') {

--- a/src/commands/streams/xreadgroup.ts
+++ b/src/commands/streams/xreadgroup.ts
@@ -123,7 +123,8 @@ function readGroupEntries(
 
   for (const { key, id } of streams) {
     const entries = ctx.db.updateStream(key, stream => {
-      const group = requireStreamGroup(stream, key, groupName, 'XREADGROUP')
+      const value = stream.value
+      const group = requireStreamGroup(value, key, groupName, 'XREADGROUP')
       const consumer = ensureConsumer(group, consumerName, now)
       consumer.activeAt = now
 
@@ -131,7 +132,7 @@ function readGroupEntries(
       const replies: RedisValue[] = []
 
       if (id === '>') {
-        for (const entry of stream.entries) {
+        for (const entry of value.entries) {
           if (compareStreamId(entry.id, group.lastDeliveredId) <= 0) continue
 
           replies.push(entryToReply(entry.id, entry.fields))
@@ -154,7 +155,7 @@ function readGroupEntries(
           if (pending.consumerId !== consumerId) continue
           if (compareStreamId(pending.id, id) <= 0) continue
 
-          const entry = findEntry(stream, pending.id)
+          const entry = findEntry(value, pending.id)
           replies.push(
             entry
               ? entryToReply(entry.id, entry.fields)
@@ -165,7 +166,8 @@ function readGroupEntries(
         }
       }
 
-      return { result: replies, changed: true }
+      stream.forceWrite()
+      return replies
     })
 
     if (entries.length > 0 || id !== '>') {

--- a/src/commands/streams/xtrim.ts
+++ b/src/commands/streams/xtrim.ts
@@ -15,10 +15,9 @@ export const xtrimCommand = defineCommand({
     if (ctx.db.getType(args.key) === null) {
       return integer(0)
     }
-    const removed = ctx.db.updateStream(args.key, stream => {
-      const removed = applyTrim(stream, args.trim)
-      return { result: removed, changed: removed > 0 }
-    })
+    const removed = ctx.db.updateStream(args.key, stream =>
+      stream.trim(value => applyTrim(value, args.trim)),
+    )
     return integer(removed)
   },
 })

--- a/src/commands/streams/xtrim.ts
+++ b/src/commands/streams/xtrim.ts
@@ -15,9 +15,10 @@ export const xtrimCommand = defineCommand({
     if (ctx.db.getType(args.key) === null) {
       return integer(0)
     }
-    const removed = ctx.db.updateStream(args.key, stream =>
-      applyTrim(stream, args.trim),
-    )
+    const removed = ctx.db.updateStream(args.key, stream => {
+      const removed = applyTrim(stream, args.trim)
+      return { result: removed, changed: removed > 0 }
+    })
     return integer(removed)
   },
 })

--- a/src/commands/zsets/zadd.ts
+++ b/src/commands/zsets/zadd.ts
@@ -155,29 +155,25 @@ export const zaddCommand = defineCommand({
     if (args.options.incr) {
       const [{ score, member }] = args.pairs
       const newScore = ctx.db.updateSortedSet(args.key, zset => {
-        const hex = member.toString('hex')
-        const existing = zset.members.get(hex)
+        const existing = zset.getMember(member)
         const nextScore = (existing?.score ?? 0) + score
         assertValidResultingScore(nextScore)
 
         if (!shouldApplyZaddUpdate(existing, nextScore, args.options)) {
-          return { result: null, changed: false }
+          return null
         }
 
-        const changed = !existing || existing.score !== nextScore
-        zset.members.set(hex, { member, score: nextScore })
-        return { result: nextScore, changed }
+        zset.setScore(member, nextScore)
+        return nextScore
       })
       deleteSortedSetIfEmpty(ctx.db, args.key)
       return bulk(newScore === null ? null : scoreBuffer(newScore))
     }
 
-    const changed = ctx.db.updateSortedSet(args.key, zset => {
+    const replyCount = ctx.db.updateSortedSet(args.key, zset => {
       let count = 0
-      let didChange = false
       for (const { score, member } of args.pairs) {
-        const hex = member.toString('hex')
-        const existing = zset.members.get(hex)
+        const existing = zset.getMember(member)
 
         if (!shouldApplyZaddUpdate(existing, score, args.options)) {
           continue
@@ -187,12 +183,11 @@ export const zaddCommand = defineCommand({
           if (!existing || existing.score !== score) count++
         }
 
-        if (!existing || existing.score !== score) didChange = true
-        zset.members.set(hex, { member, score })
+        zset.setScore(member, score)
       }
-      return { result: count, changed: didChange }
+      return count
     })
     deleteSortedSetIfEmpty(ctx.db, args.key)
-    return integer(changed)
+    return integer(replyCount)
   },
 })

--- a/src/commands/zsets/zadd.ts
+++ b/src/commands/zsets/zadd.ts
@@ -161,11 +161,12 @@ export const zaddCommand = defineCommand({
         assertValidResultingScore(nextScore)
 
         if (!shouldApplyZaddUpdate(existing, nextScore, args.options)) {
-          return null
+          return { result: null, changed: false }
         }
 
+        const changed = !existing || existing.score !== nextScore
         zset.members.set(hex, { member, score: nextScore })
-        return nextScore
+        return { result: nextScore, changed }
       })
       deleteSortedSetIfEmpty(ctx.db, args.key)
       return bulk(newScore === null ? null : scoreBuffer(newScore))
@@ -173,6 +174,7 @@ export const zaddCommand = defineCommand({
 
     const changed = ctx.db.updateSortedSet(args.key, zset => {
       let count = 0
+      let didChange = false
       for (const { score, member } of args.pairs) {
         const hex = member.toString('hex')
         const existing = zset.members.get(hex)
@@ -185,9 +187,10 @@ export const zaddCommand = defineCommand({
           if (!existing || existing.score !== score) count++
         }
 
+        if (!existing || existing.score !== score) didChange = true
         zset.members.set(hex, { member, score })
       }
-      return count
+      return { result: count, changed: didChange }
     })
     deleteSortedSetIfEmpty(ctx.db, args.key)
     return integer(changed)

--- a/src/commands/zsets/zincrby.ts
+++ b/src/commands/zsets/zincrby.ts
@@ -15,8 +15,9 @@ export const zincrbyCommand = defineCommand({
       const existing = zset.members.get(hex)
       const score = (existing?.score ?? 0) + inc
       assertValidResultingScore(score)
+      const changed = !existing || existing.score !== score
       zset.members.set(hex, { member: args.member, score })
-      return score
+      return { result: score, changed }
     })
     return bulk(scoreBuffer(newScore))
   },

--- a/src/commands/zsets/zincrby.ts
+++ b/src/commands/zsets/zincrby.ts
@@ -11,13 +11,11 @@ export const zincrbyCommand = defineCommand({
   execute: (args, ctx) => {
     const inc = parseFloatArg(args.increment)
     const newScore = ctx.db.updateSortedSet(args.key, zset => {
-      const hex = args.member.toString('hex')
-      const existing = zset.members.get(hex)
+      const existing = zset.getMember(args.member)
       const score = (existing?.score ?? 0) + inc
       assertValidResultingScore(score)
-      const changed = !existing || existing.score !== score
-      zset.members.set(hex, { member: args.member, score })
-      return { result: score, changed }
+      zset.setScore(args.member, score)
+      return score
     })
     return bulk(scoreBuffer(newScore))
   },

--- a/src/commands/zsets/zmpop.ts
+++ b/src/commands/zsets/zmpop.ts
@@ -159,6 +159,7 @@ export function tryZsetMultiPop(
       for (const entry of toRemove) {
         zset.members.delete(entry.member.toString('hex'))
       }
+      return { result: undefined, changed: toRemove.length > 0 }
     })
     deleteSortedSetIfEmpty(db, key)
 

--- a/src/commands/zsets/zmpop.ts
+++ b/src/commands/zsets/zmpop.ts
@@ -157,9 +157,8 @@ export function tryZsetMultiPop(
 
     db.updateSortedSet(key, zset => {
       for (const entry of toRemove) {
-        zset.members.delete(entry.member.toString('hex'))
+        zset.deleteMember(entry.member)
       }
-      return { result: undefined, changed: toRemove.length > 0 }
     })
     deleteSortedSetIfEmpty(db, key)
 

--- a/src/commands/zsets/zpop.ts
+++ b/src/commands/zsets/zpop.ts
@@ -51,6 +51,7 @@ export const zpopminCommand = defineCommand({
       for (const entry of toRemove) {
         z.members.delete(entry.member.toString('hex'))
       }
+      return { result: undefined, changed: toRemove.length > 0 }
     })
     deleteSortedSetIfEmpty(ctx.db, args.key)
     const items: RedisValue[] = []
@@ -78,6 +79,7 @@ export const zpopmaxCommand = defineCommand({
       for (const entry of toRemove) {
         z.members.delete(entry.member.toString('hex'))
       }
+      return { result: undefined, changed: toRemove.length > 0 }
     })
     deleteSortedSetIfEmpty(ctx.db, args.key)
     const items: RedisValue[] = []

--- a/src/commands/zsets/zpop.ts
+++ b/src/commands/zsets/zpop.ts
@@ -49,9 +49,8 @@ export const zpopminCommand = defineCommand({
     if (toRemove.length === 0) return array([])
     ctx.db.updateSortedSet(args.key, z => {
       for (const entry of toRemove) {
-        z.members.delete(entry.member.toString('hex'))
+        z.deleteMember(entry.member)
       }
-      return { result: undefined, changed: toRemove.length > 0 }
     })
     deleteSortedSetIfEmpty(ctx.db, args.key)
     const items: RedisValue[] = []
@@ -77,9 +76,8 @@ export const zpopmaxCommand = defineCommand({
     if (toRemove.length === 0) return array([])
     ctx.db.updateSortedSet(args.key, z => {
       for (const entry of toRemove) {
-        z.members.delete(entry.member.toString('hex'))
+        z.deleteMember(entry.member)
       }
-      return { result: undefined, changed: toRemove.length > 0 }
     })
     deleteSortedSetIfEmpty(ctx.db, args.key)
     const items: RedisValue[] = []

--- a/src/commands/zsets/zrangebylex.ts
+++ b/src/commands/zsets/zrangebylex.ts
@@ -76,13 +76,12 @@ export const zremrangebylexCommand = defineCommand({
     const max = parseLexBoundArg(args.max)
     let removed = 0
     ctx.db.updateSortedSet(args.key, zset => {
-      for (const [hex, entry] of zset.members) {
+      for (const [hex, entry] of zset.entries()) {
         if (lexMemberWithinBounds(entry.member, min, max)) {
-          zset.members.delete(hex)
+          zset.deleteMemberId(hex)
           removed++
         }
       }
-      return { result: undefined, changed: removed > 0 }
     })
     if (removed > 0) deleteSortedSetIfEmpty(ctx.db, args.key)
     return integer(removed)

--- a/src/commands/zsets/zrangebylex.ts
+++ b/src/commands/zsets/zrangebylex.ts
@@ -82,6 +82,7 @@ export const zremrangebylexCommand = defineCommand({
           removed++
         }
       }
+      return { result: undefined, changed: removed > 0 }
     })
     if (removed > 0) deleteSortedSetIfEmpty(ctx.db, args.key)
     return integer(removed)

--- a/src/commands/zsets/zrangebyscore.ts
+++ b/src/commands/zsets/zrangebyscore.ts
@@ -161,6 +161,7 @@ export const zremrangebyscoreCommand = defineCommand({
           removed++
         }
       }
+      return { result: undefined, changed: removed > 0 }
     })
     if (removed > 0) deleteSortedSetIfEmpty(ctx.db, args.key)
     return integer(removed)
@@ -189,6 +190,7 @@ export const zremrangebyrankCommand = defineCommand({
       for (const hex of toRemove) {
         if (set.members.delete(hex)) removed++
       }
+      return { result: undefined, changed: removed > 0 }
     })
     if (removed > 0) deleteSortedSetIfEmpty(ctx.db, args.key)
     return integer(removed)

--- a/src/commands/zsets/zrangebyscore.ts
+++ b/src/commands/zsets/zrangebyscore.ts
@@ -155,13 +155,12 @@ export const zremrangebyscoreCommand = defineCommand({
     const max = parseScoreBoundArg(args.max)
     let removed = 0
     ctx.db.updateSortedSet(args.key, zset => {
-      for (const [hex, entry] of zset.members) {
+      for (const [hex, entry] of zset.entries()) {
         if (scoreWithinBounds(entry.score, min, max)) {
-          zset.members.delete(hex)
+          zset.deleteMemberId(hex)
           removed++
         }
       }
-      return { result: undefined, changed: removed > 0 }
     })
     if (removed > 0) deleteSortedSetIfEmpty(ctx.db, args.key)
     return integer(removed)
@@ -188,9 +187,8 @@ export const zremrangebyrankCommand = defineCommand({
     let removed = 0
     ctx.db.updateSortedSet(args.key, set => {
       for (const hex of toRemove) {
-        if (set.members.delete(hex)) removed++
+        if (set.deleteMemberId(hex)) removed++
       }
-      return { result: undefined, changed: removed > 0 }
     })
     if (removed > 0) deleteSortedSetIfEmpty(ctx.db, args.key)
     return integer(removed)

--- a/src/commands/zsets/zrem.ts
+++ b/src/commands/zsets/zrem.ts
@@ -11,9 +11,8 @@ export const zremCommand = defineCommand({
     let removed = 0
     ctx.db.updateSortedSet(args.key, zset => {
       for (const member of args.members) {
-        if (zset.members.delete(member.toString('hex'))) removed++
+        if (zset.deleteMember(member)) removed++
       }
-      return { result: undefined, changed: removed > 0 }
     })
     if (
       removed > 0 &&

--- a/src/commands/zsets/zrem.ts
+++ b/src/commands/zsets/zrem.ts
@@ -13,6 +13,7 @@ export const zremCommand = defineCommand({
       for (const member of args.members) {
         if (zset.members.delete(member.toString('hex'))) removed++
       }
+      return { result: undefined, changed: removed > 0 }
     })
     if (
       removed > 0 &&

--- a/src/commands/zsets/zsetops.ts
+++ b/src/commands/zsets/zsetops.ts
@@ -171,18 +171,8 @@ function storeResult(
     db.delete(destination)
     return 0
   }
-  const existing = db.getSortedSet(destination)
-  const changed =
-    !existing ||
-    existing.members.size !== members.size ||
-    Array.from(members).some(([hex, member]) => {
-      const current = existing.members.get(hex)
-      return !current || current.score !== member.score
-    })
   db.updateSortedSet(destination, zset => {
-    zset.members.clear()
-    for (const [hex, member] of members) zset.members.set(hex, member)
-    return { result: undefined, changed }
+    zset.replaceMembers(members, { forceDirty: true })
   })
   return members.size
 }

--- a/src/commands/zsets/zsetops.ts
+++ b/src/commands/zsets/zsetops.ts
@@ -171,9 +171,18 @@ function storeResult(
     db.delete(destination)
     return 0
   }
+  const existing = db.getSortedSet(destination)
+  const changed =
+    !existing ||
+    existing.members.size !== members.size ||
+    Array.from(members).some(([hex, member]) => {
+      const current = existing.members.get(hex)
+      return !current || current.score !== member.score
+    })
   db.updateSortedSet(destination, zset => {
     zset.members.clear()
     for (const [hex, member] of members) zset.members.set(hex, member)
+    return { result: undefined, changed }
   })
   return members.size
 }

--- a/src/state/database.ts
+++ b/src/state/database.ts
@@ -14,8 +14,8 @@ import {
 } from './data-types'
 import {
   ExpirationState,
-  KeyspaceUpdateResult,
   KeyspaceEntry,
+  type KeyspaceMutationTracker,
   RedisKeyspace,
   SetOptions,
   WrongRedisTypeError,
@@ -27,6 +27,13 @@ import {
 } from './mutation-events'
 import { SerialTurnQueue, type RedisTurnQueue } from '../core/turn-queue'
 import { WrongTypeRedisError } from '../core/redis-error'
+import {
+  TrackedHashData,
+  TrackedListData,
+  TrackedSetData,
+  TrackedSortedSetData,
+  TrackedStreamData,
+} from './tracked-values'
 
 export class RedisDatabase {
   readonly mutations = new RedisMutationBus()
@@ -108,37 +115,67 @@ export class RedisDatabase {
 
   updateHash<TResult>(
     key: Buffer,
-    mutator: (hash: RedisHashData) => KeyspaceUpdateResult<TResult>,
+    mutator: (hash: TrackedHashData) => TResult,
   ): TResult {
-    return this.updateTyped(key, 'hash', createHashData, mutator)
+    return this.updateTyped(
+      key,
+      'hash',
+      createHashData,
+      mutator,
+      (value, tracker) => new TrackedHashData(value, tracker),
+    )
   }
 
   updateList<TResult>(
     key: Buffer,
-    mutator: (list: RedisListData) => KeyspaceUpdateResult<TResult>,
+    mutator: (list: TrackedListData) => TResult,
   ): TResult {
-    return this.updateTyped(key, 'list', createListData, mutator)
+    return this.updateTyped(
+      key,
+      'list',
+      createListData,
+      mutator,
+      (value, tracker) => new TrackedListData(value, tracker),
+    )
   }
 
   updateSet<TResult>(
     key: Buffer,
-    mutator: (set: RedisSetData) => KeyspaceUpdateResult<TResult>,
+    mutator: (set: TrackedSetData) => TResult,
   ): TResult {
-    return this.updateTyped(key, 'set', createSetData, mutator)
+    return this.updateTyped(
+      key,
+      'set',
+      createSetData,
+      mutator,
+      (value, tracker) => new TrackedSetData(value, tracker),
+    )
   }
 
   updateSortedSet<TResult>(
     key: Buffer,
-    mutator: (zset: RedisSortedSetData) => KeyspaceUpdateResult<TResult>,
+    mutator: (zset: TrackedSortedSetData) => TResult,
   ): TResult {
-    return this.updateTyped(key, 'zset', createSortedSetData, mutator)
+    return this.updateTyped(
+      key,
+      'zset',
+      createSortedSetData,
+      mutator,
+      (value, tracker) => new TrackedSortedSetData(value, tracker),
+    )
   }
 
   updateStream<TResult>(
     key: Buffer,
-    mutator: (stream: RedisStreamData) => KeyspaceUpdateResult<TResult>,
+    mutator: (stream: TrackedStreamData) => TResult,
   ): TResult {
-    return this.updateTyped(key, 'stream', createStreamData, mutator)
+    return this.updateTyped(
+      key,
+      'stream',
+      createStreamData,
+      mutator,
+      (value, tracker) => new TrackedStreamData(value, tracker),
+    )
   }
 
   private getTyped<TValue extends RedisDataValue>(
@@ -151,14 +188,20 @@ export class RedisDatabase {
     return value as TValue
   }
 
-  private updateTyped<TValue extends RedisDataValue, TResult>(
+  private updateTyped<TValue extends RedisDataValue, TTracked, TResult>(
     key: Buffer,
     expectedType: TValue['type'],
     createValue: () => TValue,
-    mutator: (value: TValue) => KeyspaceUpdateResult<TResult>,
+    mutator: (value: TTracked) => TResult,
+    track: (value: TValue, tracker: KeyspaceMutationTracker) => TTracked,
   ): TResult {
     try {
-      return this.keyspace.update(key, expectedType, createValue, mutator)
+      return this.keyspace.update(
+        key,
+        expectedType,
+        createValue,
+        (value, tracker) => mutator(track(value as TValue, tracker)),
+      )
     } catch (err) {
       if (err instanceof WrongRedisTypeError) throw new WrongTypeRedisError()
       throw err

--- a/src/state/database.ts
+++ b/src/state/database.ts
@@ -14,6 +14,7 @@ import {
 } from './data-types'
 import {
   ExpirationState,
+  KeyspaceUpdateResult,
   KeyspaceEntry,
   RedisKeyspace,
   SetOptions,
@@ -107,35 +108,35 @@ export class RedisDatabase {
 
   updateHash<TResult>(
     key: Buffer,
-    mutator: (hash: RedisHashData) => TResult,
+    mutator: (hash: RedisHashData) => KeyspaceUpdateResult<TResult>,
   ): TResult {
     return this.updateTyped(key, 'hash', createHashData, mutator)
   }
 
   updateList<TResult>(
     key: Buffer,
-    mutator: (list: RedisListData) => TResult,
+    mutator: (list: RedisListData) => KeyspaceUpdateResult<TResult>,
   ): TResult {
     return this.updateTyped(key, 'list', createListData, mutator)
   }
 
   updateSet<TResult>(
     key: Buffer,
-    mutator: (set: RedisSetData) => TResult,
+    mutator: (set: RedisSetData) => KeyspaceUpdateResult<TResult>,
   ): TResult {
     return this.updateTyped(key, 'set', createSetData, mutator)
   }
 
   updateSortedSet<TResult>(
     key: Buffer,
-    mutator: (zset: RedisSortedSetData) => TResult,
+    mutator: (zset: RedisSortedSetData) => KeyspaceUpdateResult<TResult>,
   ): TResult {
     return this.updateTyped(key, 'zset', createSortedSetData, mutator)
   }
 
   updateStream<TResult>(
     key: Buffer,
-    mutator: (stream: RedisStreamData) => TResult,
+    mutator: (stream: RedisStreamData) => KeyspaceUpdateResult<TResult>,
   ): TResult {
     return this.updateTyped(key, 'stream', createStreamData, mutator)
   }
@@ -154,7 +155,7 @@ export class RedisDatabase {
     key: Buffer,
     expectedType: TValue['type'],
     createValue: () => TValue,
-    mutator: (value: TValue) => TResult,
+    mutator: (value: TValue) => KeyspaceUpdateResult<TResult>,
   ): TResult {
     try {
       return this.keyspace.update(key, expectedType, createValue, mutator)

--- a/src/state/keyspace.ts
+++ b/src/state/keyspace.ts
@@ -21,6 +21,11 @@ export type SetOptions = {
   keepTtl?: boolean
 }
 
+export type KeyspaceUpdateResult<TResult> = {
+  result: TResult
+  changed: boolean
+}
+
 export class WrongRedisTypeError extends Error {
   constructor(
     public readonly expected: RedisDataTypeName,
@@ -132,7 +137,7 @@ export class RedisKeyspace {
     key: Buffer,
     expectedType: TValue['type'],
     createValue: () => TValue,
-    mutator: (value: TValue) => TResult,
+    mutator: (value: TValue) => KeyspaceUpdateResult<TResult>,
   ): TResult {
     const existing = this.getLiveEntry(key)
 
@@ -147,8 +152,12 @@ export class RedisKeyspace {
       value: createValue(),
     }
 
-    const result = mutator(entry.value as TValue)
+    const { result, changed } = mutator(entry.value as TValue)
     const id = keyId(key)
+
+    if (!changed) {
+      return result
+    }
 
     // Centralized "delete the key when its collection is empty" rule, so each
     // command no longer has to remember to clean up emptied hashes/lists/etc.

--- a/src/state/keyspace.ts
+++ b/src/state/keyspace.ts
@@ -21,9 +21,8 @@ export type SetOptions = {
   keepTtl?: boolean
 }
 
-export type KeyspaceUpdateResult<TResult> = {
-  result: TResult
-  changed: boolean
+export type KeyspaceMutationTracker = {
+  markChanged(): void
 }
 
 export class WrongRedisTypeError extends Error {
@@ -137,7 +136,7 @@ export class RedisKeyspace {
     key: Buffer,
     expectedType: TValue['type'],
     createValue: () => TValue,
-    mutator: (value: TValue) => KeyspaceUpdateResult<TResult>,
+    mutator: (value: TValue, tracker: KeyspaceMutationTracker) => TResult,
   ): TResult {
     const existing = this.getLiveEntry(key)
 
@@ -152,7 +151,14 @@ export class RedisKeyspace {
       value: createValue(),
     }
 
-    const { result, changed } = mutator(entry.value as TValue)
+    let changed = false
+    const tracker: KeyspaceMutationTracker = {
+      markChanged: () => {
+        changed = true
+      },
+    }
+
+    const result = mutator(entry.value as TValue, tracker)
     const id = keyId(key)
 
     if (!changed) {

--- a/src/state/tracked-values.ts
+++ b/src/state/tracked-values.ts
@@ -13,6 +13,12 @@ import type {
 } from './data-types'
 import type { KeyspaceMutationTracker } from './keyspace'
 
+// Dirty tracking is operation-based, not a final-value diff. An effective
+// mutating helper marks the key dirty when the operation changes structure, and
+// commands use forceDirty/forceWrite for Redis writes that must dirty WATCH even
+// when the final value is equal (for example identical STORE rewrites or
+// full-range LTRIM).
+
 export class TrackedHashData {
   constructor(
     private readonly hash: RedisHashData,

--- a/src/state/tracked-values.ts
+++ b/src/state/tracked-values.ts
@@ -1,0 +1,428 @@
+import type {
+  RedisHashData,
+  RedisHashField,
+  RedisListData,
+  RedisSetData,
+  RedisSortedSetData,
+  RedisSortedSetMember,
+  RedisStreamConsumer,
+  RedisStreamConsumerGroup,
+  RedisStreamData,
+  RedisStreamEntry,
+  StreamId,
+} from './data-types'
+import type { KeyspaceMutationTracker } from './keyspace'
+
+export class TrackedHashData {
+  constructor(
+    private readonly hash: RedisHashData,
+    private readonly tracker: KeyspaceMutationTracker,
+  ) {}
+
+  get size(): number {
+    return this.hash.fields.size
+  }
+
+  getField(field: Buffer): RedisHashField | undefined {
+    return this.hash.fields.get(field.toString('hex'))
+  }
+
+  hasField(field: Buffer): boolean {
+    return this.hash.fields.has(field.toString('hex'))
+  }
+
+  setField(
+    field: Buffer,
+    value: Buffer,
+    options: { forceDirty?: boolean } = {},
+  ): { added: boolean; valueChanged: boolean } {
+    const hex = field.toString('hex')
+    const existing = this.hash.fields.get(hex)
+    const valueChanged = !existing || !existing.value.equals(value)
+    this.hash.fields.set(hex, { field, value })
+    if (options.forceDirty || valueChanged) {
+      this.tracker.markChanged()
+    }
+    return { added: existing === undefined, valueChanged }
+  }
+
+  setFieldIfAbsent(field: Buffer, value: Buffer): boolean {
+    if (this.hasField(field)) {
+      return false
+    }
+
+    this.setField(field, value)
+    return true
+  }
+
+  deleteField(field: Buffer): boolean {
+    const deleted = this.hash.fields.delete(field.toString('hex'))
+    if (deleted) {
+      this.tracker.markChanged()
+    }
+    return deleted
+  }
+
+  entries(): IterableIterator<RedisHashField> {
+    return this.hash.fields.values()
+  }
+}
+
+export class TrackedListData {
+  constructor(
+    private readonly list: RedisListData,
+    private readonly tracker: KeyspaceMutationTracker,
+  ) {}
+
+  get length(): number {
+    return this.list.values.length
+  }
+
+  pushLeft(values: readonly Buffer[]): number {
+    for (const value of values) {
+      this.list.values.unshift(value)
+    }
+    this.tracker.markChanged()
+    return this.list.values.length
+  }
+
+  pushRight(values: readonly Buffer[]): number {
+    for (const value of values) {
+      this.list.values.push(value)
+    }
+    this.tracker.markChanged()
+    return this.list.values.length
+  }
+
+  pop(side: 'left' | 'right'): Buffer | null {
+    const value =
+      side === 'left' ? this.list.values.shift() : this.list.values.pop()
+    if (value !== undefined) {
+      this.tracker.markChanged()
+    }
+    return value ?? null
+  }
+
+  popMany(side: 'left' | 'right', count: number): Buffer[] {
+    const values =
+      side === 'left'
+        ? this.list.values.splice(0, count)
+        : this.list.values.splice(Math.max(0, this.list.values.length - count))
+    if (side === 'right') {
+      values.reverse()
+    }
+    if (values.length > 0) {
+      this.tracker.markChanged()
+    }
+    return values
+  }
+
+  setAt(index: number, value: Buffer): void {
+    this.list.values[index] = value
+    this.tracker.markChanged()
+  }
+
+  removeMatching(count: number, element: Buffer): number {
+    const target = element.toString('binary')
+    let removed = 0
+
+    if (count === 0) {
+      for (let i = this.list.values.length - 1; i >= 0; i--) {
+        if (this.list.values[i].toString('binary') === target) {
+          this.list.values.splice(i, 1)
+          removed++
+        }
+      }
+    } else if (count > 0) {
+      for (let i = 0; i < this.list.values.length && removed < count; i++) {
+        if (this.list.values[i].toString('binary') === target) {
+          this.list.values.splice(i, 1)
+          removed++
+          i--
+        }
+      }
+    } else {
+      const absCount = Math.abs(count)
+      for (
+        let i = this.list.values.length - 1;
+        i >= 0 && removed < absCount;
+        i--
+      ) {
+        if (this.list.values[i].toString('binary') === target) {
+          this.list.values.splice(i, 1)
+          removed++
+        }
+      }
+    }
+
+    if (removed > 0) {
+      this.tracker.markChanged()
+    }
+    return removed
+  }
+
+  trim(start: number, stop: number, options: { forceDirty?: boolean } = {}) {
+    const originalLength = this.list.values.length
+    const changed = start > stop || start > 0 || stop < originalLength - 1
+
+    if (start > stop) {
+      this.list.values.length = 0
+    } else {
+      this.list.values.splice(0, start)
+      this.list.values.splice(stop - start + 1)
+    }
+    if (options.forceDirty || changed) {
+      this.tracker.markChanged()
+    }
+    return { empty: this.list.values.length === 0 }
+  }
+}
+
+export class TrackedSetData {
+  constructor(
+    private readonly set: RedisSetData,
+    private readonly tracker: KeyspaceMutationTracker,
+  ) {}
+
+  get size(): number {
+    return this.set.members.size
+  }
+
+  hasMember(member: Buffer): boolean {
+    return this.set.members.has(member.toString('hex'))
+  }
+
+  addMember(member: Buffer): boolean {
+    const hex = member.toString('hex')
+    if (this.set.members.has(hex)) {
+      return false
+    }
+
+    this.set.members.set(hex, member)
+    this.tracker.markChanged()
+    return true
+  }
+
+  deleteMember(member: Buffer): boolean {
+    const deleted = this.set.members.delete(member.toString('hex'))
+    if (deleted) {
+      this.tracker.markChanged()
+    }
+    return deleted
+  }
+
+  deleteMemberId(hex: string): boolean {
+    const deleted = this.set.members.delete(hex)
+    if (deleted) {
+      this.tracker.markChanged()
+    }
+    return deleted
+  }
+
+  randomMemberEntries(): [string, Buffer][] {
+    return Array.from(this.set.members.entries())
+  }
+
+  replaceMembers(
+    hexSet: Set<string>,
+    bufferMap: Map<string, Buffer>,
+    options: { forceDirty?: boolean } = {},
+  ): void {
+    const changed =
+      options.forceDirty ||
+      this.set.members.size !== hexSet.size ||
+      Array.from(hexSet).some(hex => !this.set.members.has(hex))
+
+    this.set.members.clear()
+    for (const hex of hexSet) {
+      const buf = bufferMap.get(hex)!
+      this.set.members.set(hex, buf)
+    }
+
+    if (changed) {
+      this.tracker.markChanged()
+    }
+  }
+}
+
+export class TrackedSortedSetData {
+  constructor(
+    private readonly zset: RedisSortedSetData,
+    private readonly tracker: KeyspaceMutationTracker,
+  ) {}
+
+  get size(): number {
+    return this.zset.members.size
+  }
+
+  getMember(member: Buffer): RedisSortedSetMember | undefined {
+    return this.zset.members.get(member.toString('hex'))
+  }
+
+  setScore(
+    member: Buffer,
+    score: number,
+    options: { forceDirty?: boolean } = {},
+  ): { added: boolean; scoreChanged: boolean } {
+    const hex = member.toString('hex')
+    const existing = this.zset.members.get(hex)
+    const scoreChanged = !existing || existing.score !== score
+    this.zset.members.set(hex, { member, score })
+    if (options.forceDirty || scoreChanged) {
+      this.tracker.markChanged()
+    }
+    return { added: existing === undefined, scoreChanged }
+  }
+
+  deleteMember(member: Buffer): boolean {
+    return this.deleteMemberId(member.toString('hex'))
+  }
+
+  deleteMemberId(hex: string): boolean {
+    const deleted = this.zset.members.delete(hex)
+    if (deleted) {
+      this.tracker.markChanged()
+    }
+    return deleted
+  }
+
+  entries(): IterableIterator<[string, RedisSortedSetMember]> {
+    return this.zset.members.entries()
+  }
+
+  replaceMembers(
+    members: Map<string, RedisSortedSetMember>,
+    options: { forceDirty?: boolean } = {},
+  ): void {
+    const changed =
+      options.forceDirty ||
+      this.zset.members.size !== members.size ||
+      Array.from(members).some(([hex, member]) => {
+        const current = this.zset.members.get(hex)
+        return !current || current.score !== member.score
+      })
+
+    this.zset.members.clear()
+    for (const [hex, member] of members) {
+      this.zset.members.set(hex, member)
+    }
+
+    if (changed) {
+      this.tracker.markChanged()
+    }
+  }
+}
+
+export class TrackedStreamData {
+  constructor(
+    private readonly stream: RedisStreamData,
+    private readonly tracker: KeyspaceMutationTracker,
+  ) {}
+
+  get value(): RedisStreamData {
+    return this.stream
+  }
+
+  get lastId(): StreamId {
+    return this.stream.lastId
+  }
+
+  appendEntry(id: StreamId, fields: Buffer[]): void {
+    this.stream.entries.push({ id, fields })
+    this.stream.lastId = id
+    this.stream.entriesAdded++
+    this.tracker.markChanged()
+  }
+
+  trim(callback: (stream: RedisStreamData) => number): number {
+    const removed = callback(this.stream)
+    if (removed > 0) {
+      this.tracker.markChanged()
+    }
+    return removed
+  }
+
+  deleteEntries(
+    targets: readonly StreamId[],
+    compare: (left: StreamId, right: StreamId) => number,
+    onDelete: (entry: RedisStreamEntry) => void,
+  ): number {
+    let count = 0
+    for (const target of targets) {
+      const idx = this.stream.entries.findIndex(
+        entry => compare(entry.id, target) === 0,
+      )
+      if (idx !== -1) {
+        onDelete(this.stream.entries[idx])
+        this.stream.entries.splice(idx, 1)
+        count++
+      }
+    }
+
+    if (count > 0) {
+      this.tracker.markChanged()
+    }
+    return count
+  }
+
+  ack(group: RedisStreamConsumerGroup, ids: readonly StreamId[]): number {
+    let count = 0
+    for (const id of ids) {
+      if (group.pending.delete(streamIdKey(id))) count++
+    }
+    if (count > 0) {
+      this.tracker.markChanged()
+    }
+    return count
+  }
+
+  forceWrite(): void {
+    this.tracker.markChanged()
+  }
+
+  addGroup(groupId: string, group: RedisStreamConsumerGroup): void {
+    this.stream.groups.set(groupId, group)
+    this.tracker.markChanged()
+  }
+
+  deleteGroup(groupId: string): boolean {
+    const removed = this.stream.groups.delete(groupId)
+    if (removed) {
+      this.tracker.markChanged()
+    }
+    return removed
+  }
+
+  addConsumer(
+    group: RedisStreamConsumerGroup,
+    consumerId: string,
+    consumer: RedisStreamConsumer,
+  ): boolean {
+    if (group.consumers.has(consumerId)) {
+      return false
+    }
+
+    group.consumers.set(consumerId, consumer)
+    this.tracker.markChanged()
+    return true
+  }
+
+  deleteConsumer(group: RedisStreamConsumerGroup, consumerId: string): number {
+    if (!group.consumers.delete(consumerId)) {
+      return 0
+    }
+
+    let removedPending = 0
+    for (const [pendingId, pending] of Array.from(group.pending)) {
+      if (pending.consumerId !== consumerId) continue
+      group.pending.delete(pendingId)
+      removedPending++
+    }
+    this.tracker.markChanged()
+    return removedPending
+  }
+}
+
+function streamIdKey(id: StreamId): string {
+  return `${id.ms}-${id.seq}`
+}

--- a/tests-integration/ioredis/watch.test.ts
+++ b/tests-integration/ioredis/watch.test.ts
@@ -1,8 +1,8 @@
 import { Cluster, Redis } from 'ioredis'
-import { after, before, describe, it } from 'node:test'
+import { after, before, describe, it, test } from 'node:test'
 import assert from 'node:assert'
 import { TestRunner } from '../test-config'
-import { connectToSlotOwner, errorWithMessage } from '../utils'
+import { connectToSlotOwner, errorWithMessage, randomKey } from '../utils'
 
 const testRunner = new TestRunner()
 
@@ -224,6 +224,96 @@ describe('WATCH/UNWATCH', () => {
     } catch (err) {
       // Expected to fail
       assert.ok(err)
+    }
+  })
+
+  test('no-op collection mutations should not dirty watched keys', async () => {
+    const cases: Array<{
+      name: string
+      initialize(client: Redis, key: string): Promise<unknown>
+      mutate(client: Redis, key: string): Promise<unknown>
+      expectedNoopReply: unknown
+    }> = [
+      {
+        name: 'HDEL missing field',
+        initialize: (client, key) => client.call('HSET', key, 'field', 'value'),
+        mutate: (client, key) => client.call('HDEL', key, 'missing'),
+        expectedNoopReply: 0,
+      },
+      {
+        name: 'HSETNX existing field',
+        initialize: (client, key) => client.call('HSET', key, 'field', 'value'),
+        mutate: (client, key) => client.call('HSETNX', key, 'field', 'other'),
+        expectedNoopReply: 0,
+      },
+      {
+        name: 'LREM missing value',
+        initialize: (client, key) => client.call('RPUSH', key, 'one', 'two'),
+        mutate: (client, key) => client.call('LREM', key, 0, 'missing'),
+        expectedNoopReply: 0,
+      },
+      {
+        name: 'SREM missing member',
+        initialize: (client, key) => client.call('SADD', key, 'member'),
+        mutate: (client, key) => client.call('SREM', key, 'missing'),
+        expectedNoopReply: 0,
+      },
+      {
+        name: 'ZREM missing member',
+        initialize: (client, key) => client.call('ZADD', key, 1, 'member'),
+        mutate: (client, key) => client.call('ZREM', key, 'missing'),
+        expectedNoopReply: 0,
+      },
+      {
+        name: 'ZADD XX missing member',
+        initialize: (client, key) => client.call('ZADD', key, 1, 'member'),
+        mutate: (client, key) => client.call('ZADD', key, 'XX', 2, 'missing'),
+        expectedNoopReply: 0,
+      },
+      {
+        name: 'XDEL missing id',
+        initialize: (client, key) =>
+          client.call('XADD', key, '1-0', 'field', 'value'),
+        mutate: (client, key) => client.call('XDEL', key, '2-0'),
+        expectedNoopReply: 0,
+      },
+      {
+        name: 'XTRIM no removed entries',
+        initialize: (client, key) =>
+          client.call('XADD', key, '1-0', 'field', 'value'),
+        mutate: (client, key) => client.call('XTRIM', key, 'MAXLEN', 10),
+        expectedNoopReply: 0,
+      },
+    ]
+
+    for (const item of cases) {
+      const key = `watch:{noop:${randomKey()}}`
+      const directClient = await connectToSlotOwner(redisClient!, key)
+
+      try {
+        await directClient.call('DEL', key)
+        await item.initialize(directClient, key)
+
+        assert.strictEqual(await directClient.call('WATCH', key), 'OK')
+        assert.strictEqual(
+          await item.mutate(directClient, key),
+          item.expectedNoopReply,
+          item.name,
+        )
+
+        assert.strictEqual(await directClient.call('MULTI'), 'OK')
+        assert.strictEqual(
+          await directClient.call('SET', key, 'after'),
+          'QUEUED',
+        )
+
+        const result = await directClient.call('EXEC')
+        assert.deepStrictEqual(result, ['OK'], item.name)
+      } finally {
+        await directClient.call('UNWATCH').catch(() => undefined)
+        await directClient.call('DEL', key).catch(() => undefined)
+        directClient.disconnect()
+      }
     }
   })
 })

--- a/tests-integration/ioredis/watch.test.ts
+++ b/tests-integration/ioredis/watch.test.ts
@@ -316,4 +316,66 @@ describe('WATCH/UNWATCH', () => {
       }
     }
   })
+
+  test('identical store writes should dirty watched destination keys', async () => {
+    const cases: Array<{
+      name: string
+      initialize(client: Redis, key: string): Promise<unknown>
+      store(client: Redis, key: string): Promise<unknown>
+      expectedStoreReply: unknown
+    }> = [
+      {
+        name: 'SINTERSTORE identical set',
+        initialize: async (client, key) => {
+          await client.call('SADD', `${key}:source`, 'a', 'b', 'c')
+          await client.call('SINTERSTORE', key, `${key}:source`)
+        },
+        store: (client, key) =>
+          client.call('SINTERSTORE', key, `${key}:source`),
+        expectedStoreReply: 3,
+      },
+      {
+        name: 'ZINTERSTORE identical sorted set',
+        initialize: async (client, key) => {
+          await client.call('ZADD', `${key}:source`, 1, 'a', 2, 'b')
+          await client.call('ZINTERSTORE', key, 1, `${key}:source`)
+        },
+        store: (client, key) =>
+          client.call('ZINTERSTORE', key, 1, `${key}:source`),
+        expectedStoreReply: 2,
+      },
+    ]
+
+    for (const item of cases) {
+      const key = `watch:{store:${randomKey()}}`
+      const directClient = await connectToSlotOwner(redisClient!, key)
+
+      try {
+        await directClient.call('DEL', key, `${key}:source`)
+        await item.initialize(directClient, key)
+
+        assert.strictEqual(await directClient.call('WATCH', key), 'OK')
+        assert.strictEqual(
+          await item.store(directClient, key),
+          item.expectedStoreReply,
+          item.name,
+        )
+
+        assert.strictEqual(await directClient.call('MULTI'), 'OK')
+        assert.strictEqual(
+          await directClient.call('SET', key, 'after'),
+          'QUEUED',
+        )
+
+        const result = await directClient.call('EXEC')
+        assert.strictEqual(result, null, item.name)
+      } finally {
+        await directClient.call('UNWATCH').catch(() => undefined)
+        await directClient
+          .call('DEL', key, `${key}:source`)
+          .catch(() => undefined)
+        directClient.disconnect()
+      }
+    }
+  })
 })

--- a/tests/commands-foundation.test.ts
+++ b/tests/commands-foundation.test.ts
@@ -240,8 +240,7 @@ describe('new foundation commands', () => {
     const { session, server } = createSession()
     const key = Buffer.from('list')
     server.getDatabase(0).updateList(key, list => {
-      list.values.push(Buffer.from('a'))
-      return { result: undefined, changed: true }
+      list.pushRight([Buffer.from('a')])
     })
 
     assert.deepStrictEqual(
@@ -288,8 +287,7 @@ describe('new foundation commands', () => {
 
     db.setString(Buffer.from('a'), Buffer.from('A'))
     db.updateList(Buffer.from('b'), list => {
-      list.values.push(Buffer.from('B'))
-      return { result: undefined, changed: true }
+      list.pushRight([Buffer.from('B')])
     })
 
     assert.deepStrictEqual(

--- a/tests/commands-foundation.test.ts
+++ b/tests/commands-foundation.test.ts
@@ -241,6 +241,7 @@ describe('new foundation commands', () => {
     const key = Buffer.from('list')
     server.getDatabase(0).updateList(key, list => {
       list.values.push(Buffer.from('a'))
+      return { result: undefined, changed: true }
     })
 
     assert.deepStrictEqual(
@@ -288,6 +289,7 @@ describe('new foundation commands', () => {
     db.setString(Buffer.from('a'), Buffer.from('A'))
     db.updateList(Buffer.from('b'), list => {
       list.values.push(Buffer.from('B'))
+      return { result: undefined, changed: true }
     })
 
     assert.deepStrictEqual(

--- a/tests/commands-transactions.test.ts
+++ b/tests/commands-transactions.test.ts
@@ -144,8 +144,7 @@ describe('new transaction commands', () => {
   test('keeps runtime command errors as EXEC array elements', async () => {
     const { session, server } = createSession()
     server.getDatabase(0).updateList(Buffer.from('list'), list => {
-      list.values.push(Buffer.from('value'))
-      return { result: undefined, changed: true }
+      list.pushRight([Buffer.from('value')])
     })
 
     assert.deepStrictEqual(await session.execute('multi', []), RedisResult.ok())

--- a/tests/commands-transactions.test.ts
+++ b/tests/commands-transactions.test.ts
@@ -145,6 +145,7 @@ describe('new transaction commands', () => {
     const { session, server } = createSession()
     server.getDatabase(0).updateList(Buffer.from('list'), list => {
       list.values.push(Buffer.from('value'))
+      return { result: undefined, changed: true }
     })
 
     assert.deepStrictEqual(await session.execute('multi', []), RedisResult.ok())

--- a/tests/keyspace-update.test.ts
+++ b/tests/keyspace-update.test.ts
@@ -50,10 +50,37 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
 
     // e.g. HDEL on a non-existent key: there is nothing to remove, the
     // collection stays empty, so the key must never appear.
-    keyspace.update<RedisHashData, void>(key, 'hash', createHashData, () => {})
+    keyspace.update<RedisHashData, void>(key, 'hash', createHashData, () => ({
+      result: undefined,
+      changed: false,
+    }))
 
     assert.strictEqual(keyspace.get(key), null)
     assert.strictEqual(keyspace.getType(key), null)
+    assert.strictEqual(events.length, 0)
+  })
+
+  test('a no-op mutation on an existing collection emits no event', () => {
+    const { keyspace, events } = setup()
+    const key = Buffer.from('h')
+
+    keyspace.update<RedisHashData, void>(key, 'hash', createHashData, hash => {
+      hash.fields.set('f', { field: Buffer.from('f'), value: Buffer.from('v') })
+      return { result: undefined, changed: true }
+    })
+    events.length = 0
+
+    keyspace.update<RedisHashData, number>(
+      key,
+      'hash',
+      createHashData,
+      hash => {
+        const deleted = hash.fields.delete('missing') ? 1 : 0
+        return { result: deleted, changed: deleted > 0 }
+      },
+    )
+
+    assert.strictEqual(keyspace.getType(key), 'hash')
     assert.strictEqual(events.length, 0)
   })
 
@@ -63,12 +90,14 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
 
     keyspace.update<RedisHashData, void>(key, 'hash', createHashData, hash => {
       hash.fields.set('f', { field: Buffer.from('f'), value: Buffer.from('v') })
+      return { result: undefined, changed: true }
     })
     assert.strictEqual(keyspace.getType(key), 'hash')
     events.length = 0
 
     keyspace.update<RedisHashData, void>(key, 'hash', createHashData, hash => {
       hash.fields.delete('f')
+      return { result: undefined, changed: true }
     })
 
     assert.strictEqual(keyspace.get(key), null)
@@ -83,6 +112,7 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
 
     keyspace.update<RedisListData, void>(key, 'list', createListData, list => {
       list.values.push(Buffer.from('a'))
+      return { result: undefined, changed: true }
     })
     assert.strictEqual(keyspace.getType(key), 'list')
     events.length = 0
@@ -90,6 +120,7 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
     // e.g. LTRIM that removes every element
     keyspace.update<RedisListData, void>(key, 'list', createListData, list => {
       list.values.length = 0
+      return { result: undefined, changed: true }
     })
 
     assert.strictEqual(keyspace.get(key), null)
@@ -108,6 +139,7 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
       createSortedSetData,
       zset => {
         zset.members.set('m', { member: Buffer.from('m'), score: 1 })
+        return { result: undefined, changed: true }
       },
     )
     assert.strictEqual(keyspace.getType(key), 'zset')
@@ -120,6 +152,7 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
       createSortedSetData,
       zset => {
         zset.members.delete('m')
+        return { result: undefined, changed: true }
       },
     )
 
@@ -135,6 +168,7 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
 
     keyspace.update<RedisSetData, void>(key, 'set', createSetData, set => {
       set.members.set('m', Buffer.from('m'))
+      return { result: undefined, changed: true }
     })
 
     assert.strictEqual(keyspace.getType(key), 'set')
@@ -152,6 +186,7 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
       () => createStringData(Buffer.alloc(0)),
       str => {
         str.value = Buffer.alloc(0)
+        return { result: undefined, changed: true }
       },
     )
 
@@ -168,6 +203,7 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
       createStreamData,
       () => {
         // Create the stream without adding entries (e.g. XGROUP CREATE MKSTREAM).
+        return { result: undefined, changed: true }
       },
     )
 

--- a/tests/keyspace-update.test.ts
+++ b/tests/keyspace-update.test.ts
@@ -50,10 +50,9 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
 
     // e.g. HDEL on a non-existent key: there is nothing to remove, the
     // collection stays empty, so the key must never appear.
-    keyspace.update<RedisHashData, void>(key, 'hash', createHashData, () => ({
-      result: undefined,
-      changed: false,
-    }))
+    keyspace.update<RedisHashData, void>(key, 'hash', createHashData, () => {
+      // no change
+    })
 
     assert.strictEqual(keyspace.get(key), null)
     assert.strictEqual(keyspace.getType(key), null)
@@ -64,10 +63,18 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
     const { keyspace, events } = setup()
     const key = Buffer.from('h')
 
-    keyspace.update<RedisHashData, void>(key, 'hash', createHashData, hash => {
-      hash.fields.set('f', { field: Buffer.from('f'), value: Buffer.from('v') })
-      return { result: undefined, changed: true }
-    })
+    keyspace.update<RedisHashData, void>(
+      key,
+      'hash',
+      createHashData,
+      (hash, tracker) => {
+        hash.fields.set('f', {
+          field: Buffer.from('f'),
+          value: Buffer.from('v'),
+        })
+        tracker.markChanged()
+      },
+    )
     events.length = 0
 
     keyspace.update<RedisHashData, number>(
@@ -76,7 +83,7 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
       createHashData,
       hash => {
         const deleted = hash.fields.delete('missing') ? 1 : 0
-        return { result: deleted, changed: deleted > 0 }
+        return deleted
       },
     )
 
@@ -88,17 +95,30 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
     const { keyspace, events } = setup()
     const key = Buffer.from('h')
 
-    keyspace.update<RedisHashData, void>(key, 'hash', createHashData, hash => {
-      hash.fields.set('f', { field: Buffer.from('f'), value: Buffer.from('v') })
-      return { result: undefined, changed: true }
-    })
+    keyspace.update<RedisHashData, void>(
+      key,
+      'hash',
+      createHashData,
+      (hash, tracker) => {
+        hash.fields.set('f', {
+          field: Buffer.from('f'),
+          value: Buffer.from('v'),
+        })
+        tracker.markChanged()
+      },
+    )
     assert.strictEqual(keyspace.getType(key), 'hash')
     events.length = 0
 
-    keyspace.update<RedisHashData, void>(key, 'hash', createHashData, hash => {
-      hash.fields.delete('f')
-      return { result: undefined, changed: true }
-    })
+    keyspace.update<RedisHashData, void>(
+      key,
+      'hash',
+      createHashData,
+      (hash, tracker) => {
+        hash.fields.delete('f')
+        tracker.markChanged()
+      },
+    )
 
     assert.strictEqual(keyspace.get(key), null)
     assert.strictEqual(keyspace.getType(key), null)
@@ -110,18 +130,28 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
     const { keyspace, events } = setup()
     const key = Buffer.from('l')
 
-    keyspace.update<RedisListData, void>(key, 'list', createListData, list => {
-      list.values.push(Buffer.from('a'))
-      return { result: undefined, changed: true }
-    })
+    keyspace.update<RedisListData, void>(
+      key,
+      'list',
+      createListData,
+      (list, tracker) => {
+        list.values.push(Buffer.from('a'))
+        tracker.markChanged()
+      },
+    )
     assert.strictEqual(keyspace.getType(key), 'list')
     events.length = 0
 
     // e.g. LTRIM that removes every element
-    keyspace.update<RedisListData, void>(key, 'list', createListData, list => {
-      list.values.length = 0
-      return { result: undefined, changed: true }
-    })
+    keyspace.update<RedisListData, void>(
+      key,
+      'list',
+      createListData,
+      (list, tracker) => {
+        list.values.length = 0
+        tracker.markChanged()
+      },
+    )
 
     assert.strictEqual(keyspace.get(key), null)
     assert.strictEqual(keyspace.getType(key), null)
@@ -137,9 +167,9 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
       key,
       'zset',
       createSortedSetData,
-      zset => {
+      (zset, tracker) => {
         zset.members.set('m', { member: Buffer.from('m'), score: 1 })
-        return { result: undefined, changed: true }
+        tracker.markChanged()
       },
     )
     assert.strictEqual(keyspace.getType(key), 'zset')
@@ -150,9 +180,9 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
       key,
       'zset',
       createSortedSetData,
-      zset => {
+      (zset, tracker) => {
         zset.members.delete('m')
-        return { result: undefined, changed: true }
+        tracker.markChanged()
       },
     )
 
@@ -166,10 +196,15 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
     const { keyspace, events } = setup()
     const key = Buffer.from('s')
 
-    keyspace.update<RedisSetData, void>(key, 'set', createSetData, set => {
-      set.members.set('m', Buffer.from('m'))
-      return { result: undefined, changed: true }
-    })
+    keyspace.update<RedisSetData, void>(
+      key,
+      'set',
+      createSetData,
+      (set, tracker) => {
+        set.members.set('m', Buffer.from('m'))
+        tracker.markChanged()
+      },
+    )
 
     assert.strictEqual(keyspace.getType(key), 'set')
     assert.strictEqual(events.length, 1)
@@ -184,9 +219,9 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
       key,
       'string',
       () => createStringData(Buffer.alloc(0)),
-      str => {
+      (str, tracker) => {
         str.value = Buffer.alloc(0)
-        return { result: undefined, changed: true }
+        tracker.markChanged()
       },
     )
 
@@ -201,9 +236,9 @@ describe('RedisKeyspace.update — ghost entries and empty-collection cleanup (#
       key,
       'stream',
       createStreamData,
-      () => {
+      (_stream, tracker) => {
         // Create the stream without adding entries (e.g. XGROUP CREATE MKSTREAM).
-        return { result: undefined, changed: true }
+        tracker.markChanged()
       },
     )
 

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -47,11 +47,9 @@ describe('new Redis state core', () => {
     db.subscribeKey(key, event => keyEvents.push(event))
 
     db.setString(Buffer.from('string'), Buffer.from('value'))
-    db.updateList(key, list => {
-      list.values.push(Buffer.from('a'))
-      list.values.push(Buffer.from('b'))
-      return { result: list.values.length, changed: true }
-    })
+    db.updateList(key, list =>
+      list.pushRight([Buffer.from('a'), Buffer.from('b')]),
+    )
 
     assert.deepStrictEqual(
       events.map(event => event.type),
@@ -99,11 +97,7 @@ describe('new Redis state core', () => {
     })
 
     db.updateHash(key, hash => {
-      hash.fields.set('field', {
-        field: Buffer.from('field'),
-        value: Buffer.from('value'),
-      })
-      return { result: undefined, changed: true }
+      hash.setField(Buffer.from('field'), Buffer.from('value'))
     })
 
     const firstRead = db.get(key)
@@ -111,14 +105,14 @@ describe('new Redis state core', () => {
       assert.fail('Expected hash value')
     }
 
-    firstRead.fields.get('field')!.value.write('x')
+    firstRead.fields.get(fieldKey('field'))!.value.write('x')
     assertHashValue(db.get(key), 'value')
 
     if (!eventValue || eventValue.type !== 'hash') {
       assert.fail('Expected hash event value')
     }
 
-    eventValue.fields.get('field')!.value.write('y')
+    eventValue.fields.get(fieldKey('field'))!.value.write('y')
     assertHashValue(db.get(key), 'value')
   })
 
@@ -131,8 +125,7 @@ describe('new Redis state core', () => {
     assert.throws(
       () =>
         db.updateList(key, list => {
-          list.values.push(Buffer.from('x'))
-          return { result: undefined, changed: true }
+          list.pushRight([Buffer.from('x')])
         }),
       WrongTypeRedisError,
     )
@@ -238,5 +231,12 @@ function assertHashValue(value: RedisDataValue | null, expected: string) {
     assert.fail('Expected hash value')
   }
 
-  assert.strictEqual(value.fields.get('field')?.value.toString(), expected)
+  assert.strictEqual(
+    value.fields.get(fieldKey('field'))?.value.toString(),
+    expected,
+  )
+}
+
+function fieldKey(field: string): string {
+  return Buffer.from(field).toString('hex')
 }

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -50,7 +50,7 @@ describe('new Redis state core', () => {
     db.updateList(key, list => {
       list.values.push(Buffer.from('a'))
       list.values.push(Buffer.from('b'))
-      return list.values.length
+      return { result: list.values.length, changed: true }
     })
 
     assert.deepStrictEqual(
@@ -103,6 +103,7 @@ describe('new Redis state core', () => {
         field: Buffer.from('field'),
         value: Buffer.from('value'),
       })
+      return { result: undefined, changed: true }
     })
 
     const firstRead = db.get(key)
@@ -128,7 +129,11 @@ describe('new Redis state core', () => {
     db.set(key, createStringData(Buffer.from('value')))
 
     assert.throws(
-      () => db.updateList(key, list => list.values.push(Buffer.from('x'))),
+      () =>
+        db.updateList(key, list => {
+          list.values.push(Buffer.from('x'))
+          return { result: undefined, changed: true }
+        }),
       WrongTypeRedisError,
     )
   })


### PR DESCRIPTION
## Summary
- Add an explicit `{ result, changed }` contract for in-place keyspace updates so `WATCH` is dirtied only by real mutation events.
- Update hash, list, set, sorted-set, and stream mutators to report true no-op removals/options without suppressing Redis-compatible write invalidation for commands Redis still treats as writes.
- Add ioredis WATCH regression coverage against no-op HDEL/HSETNX/LREM/SREM/ZREM/ZADD XX/XDEL/XTRIM paths and document the keyspace update contract.

## Root Cause
`RedisKeyspace.update()` emitted a `write` mutation after every successful mutator call, even when the mutator left the stored value unchanged. `ClientSession.watch()` subscribes to those mutation events, so no-op commands such as `HDEL` on a missing field could spuriously make `EXEC` return nil.

## Validation
- `npm test`
- `npm run build`
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test tests-integration/ioredis/watch.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test tests-integration/ioredis/watch.test.ts`
- `npm run test:integration:mock`
- `npm run clean:redis`
- `npm run test:integration:real`
- `npm run lint`

Fixes #125
Fixes #133
Fixes #134
Fixes #135
Fixes #136
Fixes #137
Fixes #138