### PR TITLE
fix: zset equal-score tie-break uses byte order not locale (#41)

### DIFF
--- a/src/commands/zsets/helpers.ts
+++ b/src/commands/zsets/helpers.ts
@@ -14,7 +14,9 @@ export function getSortedMembers(
   return Array.from(zset.members.values()).sort((a, b) =>
     a.score !== b.score
       ? a.score - b.score
-      : a.member.toString().localeCompare(b.member.toString()),
+      : // Equal scores tie-break by raw byte order (memcmp), matching Redis —
+        // not localeCompare, which would mis-sort non-ASCII members (see #41).
+        Buffer.compare(a.member, b.member),
   )
 }
 

--- a/tests-integration/ioredis/zset-byte-order-integration.test.ts
+++ b/tests-integration/ioredis/zset-byte-order-integration.test.ts
@@ -1,0 +1,75 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+// Issue #41: equal-score tie-breaking in the general sorted-set comparator must
+// use raw byte order (memcmp), not String.prototype.localeCompare. With locale
+// collation a non-ASCII member like 'é' (0xc3 0xa9) sorts *before* 'z' (0x7a);
+// real Redis sorts by raw bytes, so 'z' comes first and 'é' last.
+describe(`Sorted Set Byte-Order Tie-Breaking Integration (${testRunner.getBackendName()})`, () => {
+  let redisClient: Cluster | undefined
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster('zset-byte-order')
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  async function seedEqualScore(members: string[]): Promise<string> {
+    const key = `{bo:${randomKey()}}`
+    const args: (string | number)[] = []
+    for (const m of members) {
+      args.push(0, m)
+    }
+    await redisClient?.zadd(key, ...(args as [number, string]))
+    return key
+  }
+
+  test('ZRANGE breaks equal-score ties by raw byte order, not locale', async () => {
+    const key = await seedEqualScore(['z', 'é', 'A', 'a'])
+    try {
+      // raw byte order: 'A'(0x41) 'a'(0x61) 'z'(0x7a) 'é'(0xc3...)
+      assert.deepStrictEqual(await redisClient?.zrange(key, 0, -1), [
+        'A',
+        'a',
+        'z',
+        'é',
+      ])
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANGEBYSCORE breaks equal-score ties by raw byte order', async () => {
+    const key = await seedEqualScore(['z', 'é', 'A', 'a'])
+    try {
+      assert.deepStrictEqual(
+        await redisClient?.zrangebyscore(key, '-inf', '+inf'),
+        ['A', 'a', 'z', 'é'],
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('ZRANK reflects raw byte order for equal scores', async () => {
+    const key = await seedEqualScore(['z', 'é', 'A', 'a'])
+    try {
+      assert.strictEqual(await redisClient?.zrank(key, 'A'), 0)
+      assert.strictEqual(await redisClient?.zrank(key, 'a'), 1)
+      assert.strictEqual(await redisClient?.zrank(key, 'z'), 2)
+      assert.strictEqual(await redisClient?.zrank(key, 'é'), 3)
+      // ZREVRANK is the mirror image
+      assert.strictEqual(await redisClient?.zrevrank(key, 'é'), 0)
+      assert.strictEqual(await redisClient?.zrevrank(key, 'A'), 3)
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- `getSortedMembers` (the general sorted-set comparator in `src/commands/zsets/helpers.ts`) broke equal-score ties with `String.prototype.localeCompare`, which applies Unicode locale collation. A non-ASCII member like `é` (0xc3 0xa9) sorted *before* `z` (0x7a).
- Real Redis tie-breaks equal scores by raw byte order (memcmp), so `z` precedes `é`.
- Switched the comparator to `Buffer.compare(a.member, b.member)`. This fixes ordering for every consumer of `getSortedMembers`: ZRANGE, ZRANGEBYSCORE, ZRANK/ZREVRANK, ZPOPMIN/MAX, ZMPOP, and ZUNION/ZINTER/ZDIFF result ordering.
- The lex-range commands already byte-compared (`getLexSortedMembers`); only the general comparator was affected.

Closes #41

## Test plan
- [x] New `tests-integration/ioredis/zset-byte-order-integration.test.ts` reproduces the bug — red on mock before the fix (ZRANGE/ZRANGEBYSCORE/ZRANK with equal-score non-ASCII + mixed-case members)
- [x] Test passes against real Redis before the fix (confirms mock-only bug; expected order verified via `redis-cli` against the real cluster)
- [x] Fix makes the test pass on mock too
- [x] `npm run build`, `npm run lint`, `npm run test:all` all pass (unit 147, mock integration 412, real integration 412)

🤖 Generated with [Claude Code](https://claude.com/claude-code)