### PR TITLE
fix: RENAME key key is a no-op and does not invalidate WATCH (#61)

### DIFF
--- a/src/commands/keys.ts
+++ b/src/commands/keys.ts
@@ -324,6 +324,11 @@ export const renameCommand = defineCommand({
     const value = ctx.db.get(args.key)
     if (!value) throw new NoSuchKeyError()
 
+    // Renaming a key to itself is a true no-op in Redis: it replies +OK
+    // without touching the keyspace, so it must not emit a mutation event
+    // that would invalidate a WATCH on the key.
+    if (args.key.equals(args.newKey)) return ok()
+
     const expiration = ctx.db.getExpiration(args.key)
     const expiresAt =
       expiration.kind === 'expires' ? expiration.expiresAt : undefined

--- a/tests-integration/ioredis/watch.test.ts
+++ b/tests-integration/ioredis/watch.test.ts
@@ -317,6 +317,64 @@ describe('WATCH/UNWATCH', () => {
     }
   })
 
+  test('RENAME key key self-rename is a no-op and does not dirty a watched key', async () => {
+    const key = `watch:{selfrename:${randomKey()}}`
+    const directClient = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      await directClient.call('DEL', key)
+      await directClient.call('SET', key, 'value')
+
+      assert.strictEqual(await directClient.call('WATCH', key), 'OK')
+
+      // Renaming a key to itself is a true no-op: +OK, value preserved,
+      // and no keyspace mutation that would invalidate the WATCH.
+      assert.strictEqual(await directClient.call('RENAME', key, key), 'OK')
+      assert.strictEqual(await directClient.call('GET', key), 'value')
+
+      assert.strictEqual(await directClient.call('MULTI'), 'OK')
+      assert.strictEqual(await directClient.call('SET', key, 'after'), 'QUEUED')
+
+      // Transaction must NOT be aborted by the self-rename.
+      const result = await directClient.call('EXEC')
+      assert.deepStrictEqual(result, ['OK'])
+      assert.strictEqual(await directClient.call('GET', key), 'after')
+    } finally {
+      await directClient.call('UNWATCH').catch(() => undefined)
+      await directClient.call('DEL', key).catch(() => undefined)
+      directClient.disconnect()
+    }
+  })
+
+  test('RENAME key key on a missing key still errors with no such key', async () => {
+    const key = `watch:{selfrename:missing:${randomKey()}}`
+    const directClient = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      await directClient.call('DEL', key)
+      await assert.rejects(
+        () => directClient.call('RENAME', key, key),
+        errorWithMessage('ERR no such key'),
+      )
+    } finally {
+      directClient.disconnect()
+    }
+  })
+
+  test('RENAME with wrong number of arguments errors', async () => {
+    const key = `watch:{selfrename:arity:${randomKey()}}`
+    const directClient = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      await assert.rejects(
+        () => directClient.call('RENAME', key),
+        errorWithMessage("ERR wrong number of arguments for 'rename' command"),
+      )
+    } finally {
+      directClient.disconnect()
+    }
+  })
+
   test('identical store writes should dirty watched destination keys', async () => {
     const cases: Array<{
       name: string


### PR DESCRIPTION
## Summary
- `RENAME x x` (renaming a key to itself) unconditionally called `ctx.db.delete(args.key)` before re-setting, emitting a spurious `delete` mutation event. That marked any `WATCH`ing session dirty and aborted the surrounding `MULTI`/`EXEC`.
- Real Redis treats `RENAME x x` as a true no-op: replies `+OK`, preserves the value, emits no keyspace notification, does not invalidate `WATCH`.
- Fix: early-return `ok()` when `args.key.equals(args.newKey)`, placed **after** the existence check so `RENAME missing missing` still errors with `ERR no such key`. (`RENAMENX x x` was already correct — it returns `0` because `newKey` already exists, before any mutation.)

Closes #61

## Test plan
- [x] New tests in `tests-integration/ioredis/watch.test.ts`:
  - `RENAME x x` self-rename: `+OK`, value preserved, WATCH not invalidated, `EXEC` runs (red before fix)
  - `RENAME missing missing` still errors `ERR no such key`
  - `RENAME` wrong arity errors
- [x] No-op test fails on mock before the fix; all three pass on real Redis (bug confirmed mock-only)
- [x] Fix makes all three pass on mock too
- [x] `npm run build`, `npm run lint`, `npm run test:all` pass (unit 147, mock 415, real 415)