### PR TITLE
fix: allow SELECT 0 in cluster mode (#54)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -405,8 +405,8 @@ genuinely partitioned) but **sharing** the topology object, registered with:
 
 There is no separate "cluster commander" type — cluster mode is the same
 `Resp2Server` + `CommandExecutor` core, configured with one extra command and
-one extra policy. `SELECT` is rejected in cluster mode (Redis Cluster only
-exposes database 0).
+one extra policy. `SELECT 0` is accepted as a no-op in cluster mode (Redis
+Cluster only exposes database 0); any non-zero index is rejected.
 
 ## Lua scripting
 

--- a/src/core/execution-policies/cluster-policy.ts
+++ b/src/core/execution-policies/cluster-policy.ts
@@ -34,7 +34,12 @@ export function createClusterPolicy(
       }
 
       if (plan.definition.name === 'select') {
-        throw new RedisCommandError('SELECT is not allowed in cluster mode')
+        // Cluster mode has a single logical database (0). SELECT 0 is a no-op
+        // and accepted; any non-zero index is rejected like real Redis.
+        const index = (plan.args as { database: number }).database
+        if (index !== 0) {
+          throw new RedisCommandError('SELECT is not allowed in cluster mode')
+        }
       }
 
       if (

--- a/tests-integration/ioredis/connection-integration.test.ts
+++ b/tests-integration/ioredis/connection-integration.test.ts
@@ -182,10 +182,25 @@ describe(`Connection commands integration (${testRunner.getBackendName()})`, () 
     assert.strictEqual(await directClient?.call('CLIENT', 'GETNAME'), null)
   })
 
-  test('SELECT is rejected in cluster mode', async () => {
+  test('SELECT 0 is allowed in cluster mode (no-op DB switch)', async () => {
+    assert.strictEqual(await directClient?.select(0), 'OK')
+  })
+
+  test('SELECT of a non-zero DB is rejected in cluster mode', async () => {
     await assert.rejects(
       () => directClient?.select(1),
       errorWithMessage('ERR SELECT is not allowed in cluster mode'),
+    )
+    await assert.rejects(
+      () => directClient?.select(99),
+      errorWithMessage('ERR SELECT is not allowed in cluster mode'),
+    )
+  })
+
+  test('SELECT with a non-integer index is a value error in cluster mode', async () => {
+    await assert.rejects(
+      () => directClient?.call('SELECT', 'abc'),
+      errorWithMessage('ERR value is not an integer or out of range'),
     )
   })
 })


### PR DESCRIPTION
## Summary
- `ClusterPolicy.beforeExecute` rejected **every** `SELECT` with `ERR SELECT is not allowed in cluster mode`, including `SELECT 0`.
- Redis Cluster exposes a single logical database (0), so real Redis accepts `SELECT 0` as a no-op (`+OK`) and only rejects non-zero indices.
- Fix: guard the throw on `index !== 0`. `SELECT 0` now falls through to normal execution; `SELECT 1`/`SELECT 99`/… still rejected. A non-integer index continues to return `ERR value is not an integer or out of range` (schema parse, before the policy).

Verified against real Redis cluster: `SELECT 0` → `OK`, `SELECT 1`/`99` → not allowed, `SELECT abc` → value-not-integer.

Closes #54

## Test plan
- [x] New cases in `tests-integration/ioredis/connection-integration.test.ts` reproduce the bug (`SELECT 0` red before fix on mock)
- [x] Tests pass against real Redis (`TEST_BACKEND=real`) — confirms our impl was wrong, not a misread of Redis
- [x] Fix makes the test pass on mock too
- [x] `npm run build`, `npm run lint`, `npm run test:all` all pass (unit + mock 417/0 + real 417/0)
- [x] Docs: updated `docs/ARCHITECTURE.md` stale "SELECT is rejected in cluster mode" claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)