### PR TITLE
feat: FLUSHDB/FLUSHALL accept ASYNC|SYNC modifier (#35)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -99,9 +99,9 @@ surface.
 
 #### FLUSHDB / FLUSHALL
 
-- [x] `FLUSHDB` - Remove all keys from the current database
-- [x] `FLUSHALL` - Remove all keys from all databases
-- [ ] `ASYNC`/`SYNC` modifiers - not accepted (any extra argument is a wrong-arity error)
+- [x] `FLUSHDB [ASYNC|SYNC]` - Remove all keys from the current database
+- [x] `FLUSHALL [ASYNC|SYNC]` - Remove all keys from all databases
+- The optional `ASYNC` / `SYNC` modifier is accepted (case-insensitive) and ignored — the in-memory keyspace is always flushed synchronously. Any other token, or more than one modifier, returns `ERR syntax error`.
 
 > `FLUSHALL`/`FLUSHDB` clear keyspace data but **not** the Lua script cache -
 > only `SCRIPT FLUSH` does.

--- a/src/commands/keys.ts
+++ b/src/commands/keys.ts
@@ -265,9 +265,33 @@ export const persistCommand = defineCommand({
   execute: (args, ctx) => integer(ctx.db.persist(args.key) ? 1 : 0),
 })
 
+// FLUSHDB/FLUSHALL accept an optional ASYNC|SYNC modifier (Redis 4.0+). The
+// keyspace is in-memory, so the flush is synchronous regardless — the keyword is
+// parsed for compatibility and otherwise ignored. Anything other than a single
+// ASYNC|SYNC token is a syntax error (matching real Redis), so the whole tail is
+// validated here rather than relying on the generic leftover-arg check, which
+// would surface a wrong-number-of-arguments error instead.
+const flushModeSchema = t.custom<'async' | 'sync' | undefined>(
+  (input, index) => {
+    const remaining = input.length - index
+    if (remaining === 0) {
+      return { value: undefined, nextIndex: index }
+    }
+
+    if (remaining === 1) {
+      const token = input[index].toString().toLowerCase()
+      if (token === 'async' || token === 'sync') {
+        return { value: token, nextIndex: index + 1 }
+      }
+    }
+
+    throw new RedisSyntaxError()
+  },
+)
+
 export const flushdbCommand = defineCommand({
   name: 'flushdb',
-  schema: t.object({}),
+  schema: t.object({ mode: flushModeSchema }),
   flags: ['write'],
   keys: () => [],
   execute: (_args, ctx) => {
@@ -278,7 +302,7 @@ export const flushdbCommand = defineCommand({
 
 export const flushallCommand = defineCommand({
   name: 'flushall',
-  schema: t.object({}),
+  schema: t.object({ mode: flushModeSchema }),
   flags: ['write'],
   keys: () => [],
   execute: (_args, ctx) => {

--- a/tests-integration/ioredis/flush-async-sync.test.ts
+++ b/tests-integration/ioredis/flush-async-sync.test.ts
@@ -1,0 +1,91 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Redis } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { errorWithMessage } from '../utils'
+
+// FLUSHDB / FLUSHALL gained an optional ASYNC | SYNC modifier in Redis 4.0.
+// The mock must accept (and ignore — the keyspace is in-memory, so the flush is
+// synchronous either way) the keyword, reject any other token with a syntax
+// error, and still work with no argument. Exercised on the standalone harness
+// because these are keyless admin commands the cluster client can't route
+// cleanly to a single node.
+const testRunner = new TestRunner()
+
+describe(`FLUSHDB/FLUSHALL ASYNC|SYNC (${testRunner.getBackendName()})`, () => {
+  let client: Redis | undefined
+
+  before(async () => {
+    client = await testRunner.setupIoredisStandalone()
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  test('FLUSHDB accepts ASYNC and clears the keyspace', async () => {
+    await client?.set('k1', 'v1')
+    const reply = await client?.call('FLUSHDB', 'ASYNC')
+    assert.strictEqual(reply, 'OK')
+    assert.strictEqual(await client?.dbsize(), 0)
+  })
+
+  test('FLUSHDB accepts SYNC', async () => {
+    await client?.set('k2', 'v2')
+    const reply = await client?.call('FLUSHDB', 'SYNC')
+    assert.strictEqual(reply, 'OK')
+    assert.strictEqual(await client?.dbsize(), 0)
+  })
+
+  test('FLUSHDB ASYNC|SYNC is case-insensitive', async () => {
+    assert.strictEqual(await client?.call('FLUSHDB', 'async'), 'OK')
+    assert.strictEqual(await client?.call('FLUSHDB', 'Sync'), 'OK')
+  })
+
+  test('FLUSHDB with no argument still works', async () => {
+    assert.strictEqual(await client?.call('FLUSHDB'), 'OK')
+  })
+
+  test('FLUSHALL accepts ASYNC and clears all databases', async () => {
+    await client?.set('k3', 'v3')
+    const reply = await client?.call('FLUSHALL', 'ASYNC')
+    assert.strictEqual(reply, 'OK')
+    assert.strictEqual(await client?.dbsize(), 0)
+  })
+
+  test('FLUSHALL accepts SYNC', async () => {
+    assert.strictEqual(await client?.call('FLUSHALL', 'SYNC'), 'OK')
+  })
+
+  test('FLUSHALL with no argument still works', async () => {
+    assert.strictEqual(await client?.call('FLUSHALL'), 'OK')
+  })
+
+  test('FLUSHDB rejects an unknown modifier with a syntax error', async () => {
+    await assert.rejects(
+      async () => client?.call('FLUSHDB', 'FOO'),
+      errorWithMessage('ERR syntax error'),
+    )
+  })
+
+  test('FLUSHDB rejects two modifiers with a syntax error', async () => {
+    await assert.rejects(
+      async () => client?.call('FLUSHDB', 'ASYNC', 'SYNC'),
+      errorWithMessage('ERR syntax error'),
+    )
+  })
+
+  test('FLUSHALL rejects an unknown modifier with a syntax error', async () => {
+    await assert.rejects(
+      async () => client?.call('FLUSHALL', 'FOO'),
+      errorWithMessage('ERR syntax error'),
+    )
+  })
+
+  test('FLUSHALL rejects two modifiers with a syntax error', async () => {
+    await assert.rejects(
+      async () => client?.call('FLUSHALL', 'ASYNC', 'SYNC'),
+      errorWithMessage('ERR syntax error'),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- `FLUSHDB`/`FLUSHALL` had schema `t.object({})`, so any argument (including the Redis 4.0+ `ASYNC`/`SYNC` modifier) was rejected with a wrong-arity error.
- Added a `flushModeSchema` custom parser wired into both command definitions. It accepts an optional single `ASYNC|SYNC` token (case-insensitive) and ignores it — the in-memory keyspace flushes synchronously either way.
- Any other token, or more than one modifier, throws `RedisSyntaxError` (`ERR syntax error`). The tail is validated in the parser rather than relying on the generic leftover-arg check, which would otherwise return a wrong-number-of-arguments error instead of the syntax error real Redis (7.2) returns.
- Updated docs/COMMANDS.md to reflect the now-supported modifier.

Closes #35

## Test plan
- [x] New test in tests-integration/ioredis/flush-async-sync.test.ts reproduces the bug (9/11 red on mock before fix)
- [x] Test passes against real Redis (mock-only bug confirmed: 11/11 green on real before fix)
- [x] Fix makes the test pass on mock too (11/11)
- [x] `npm run test:all` passes (unit 147, mock integration 426, real integration 426; all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)