### PR TITLE
fix: validate RESP3 verbatim string format is exactly 3 bytes (#12)

### DIFF
--- a/src/core/resp-encoder.ts
+++ b/src/core/resp-encoder.ts
@@ -162,6 +162,12 @@ function encodeResp3BlobString(value: Buffer | null): Buffer {
 }
 
 function encodeResp3VerbatimString(format: string, value: Buffer): Buffer {
+  if (Buffer.byteLength(format) !== 3) {
+    throw new Error(
+      `RESP3 verbatim string format must be exactly 3 bytes, got ${JSON.stringify(format)}`,
+    )
+  }
+
   const payload = Buffer.concat([Buffer.from(`${format}:`), value])
   return Buffer.concat([
     Buffer.from(`=${payload.length}\r\n`),

--- a/tests/core-resp-encoder.test.ts
+++ b/tests/core-resp-encoder.test.ts
@@ -130,4 +130,40 @@ describe('RESP encoder core', () => {
       Buffer.from('>2\r\n$7\r\nmessage\r\n$1\r\nx\r\n'),
     )
   })
+
+  test('encodes RESP3 verbatim strings with a 3-byte format prefix', () => {
+    assert.deepStrictEqual(
+      encodeRedisValue(RedisValue.verbatim('txt', Buffer.from('Some string')), {
+        version: 3,
+      }),
+      Buffer.from('=15\r\ntxt:Some string\r\n'),
+    )
+    assert.deepStrictEqual(
+      encodeRedisValue(RedisValue.verbatim('mkd', Buffer.from('# title')), {
+        version: 3,
+      }),
+      Buffer.from('=11\r\nmkd:# title\r\n'),
+    )
+  })
+
+  test('downgrades RESP3 verbatim strings to a plain RESP2 bulk string', () => {
+    assert.deepStrictEqual(
+      encodeRedisValue(RedisValue.verbatim('txt', Buffer.from('Some string'))),
+      Buffer.from('$11\r\nSome string\r\n'),
+    )
+  })
+
+  test('rejects RESP3 verbatim strings whose format is not exactly 3 bytes', () => {
+    for (const badFormat of ['', 'tx', 'text', 'txt ']) {
+      assert.throws(
+        () =>
+          encodeRedisValue(
+            RedisValue.verbatim(badFormat, Buffer.from('payload')),
+            { version: 3 },
+          ),
+        /format must be exactly 3 bytes/,
+        `format "${badFormat}" should be rejected`,
+      )
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- `encodeResp3VerbatimString` ([src/core/resp-encoder.ts](src/core/resp-encoder.ts)) silently accepted a `format` prefix of any length, producing a malformed RESP3 verbatim-string frame (`=<len>\r\n<format>:<value>\r\n`) — the receiver reads the wrong byte range as the 3-byte format and desyncs the stream.
- Per the RESP3 spec the format prefix must be exactly 3 bytes (e.g. `txt`, `mkd`). Now throws unless `Buffer.byteLength(format) === 3`.
- Internal encoder contract only — no shipped command currently emits a verbatim `RedisValue`, so there is no client-visible command behavior change. Covered by a unit test since the path isn't reachable over the wire.

Closes #12

## Test plan
- [x] New unit tests in [tests/core-resp-encoder.test.ts](tests/core-resp-encoder.test.ts): valid 3-byte format encodes correctly (RESP3 `=`-frame + RESP2 bulk-string downgrade); bad formats (`''`, `tx`, `text`, `txt `) throw — red before the fix
- [x] Fix makes the throw cases pass
- [x] `npm run test:all` passes (unit 150, mock integration 417, real integration 417)
- [x] `npm run build` + `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)