### PR TITLE
fix: correct CLUSTER NODES bus port and single-slot range format (#55, #63)

### DIFF
--- a/src/commands/cluster.ts
+++ b/src/commands/cluster.ts
@@ -249,14 +249,16 @@ function formatNodeLine(
   localNodeId: string,
   configEpoch: number,
 ): string {
-  const connection = `${formatHostPort(node.host, node.port)}@${node.port}`
+  const connection = `${formatHostPort(node.host, node.port)}@${node.port + 10000}`
   const myself = node.id === localNodeId ? 'myself,' : ''
   const roleField =
     node.role === 'master' ? 'master -' : `slave ${node.masterId}`
   const ping = `0 ${Date.now()}`
   const slots =
     node.role === 'master'
-      ? node.slots.map(([min, max]) => ` ${min}-${max}`).join('')
+      ? node.slots
+          .map(([min, max]) => (min === max ? ` ${min}` : ` ${min}-${max}`))
+          .join('')
       : ''
   return `${node.id} ${connection} ${myself}${roleField} ${ping} ${configEpoch} connected${slots}\n`
 }

--- a/tests-integration/ioredis/cluster-integration.test.ts
+++ b/tests-integration/ioredis/cluster-integration.test.ts
@@ -294,6 +294,28 @@ describe(`Cluster protocol integration (${testRunner.getBackendName()})`, () => 
       connection.close()
     }
   })
+
+  test('CLUSTER NODES reports bus port as client port + 10000', async () => {
+    const port = testRunner.getClusterPorts()[0]
+    assert.notStrictEqual(port, undefined)
+    const connection = await RawRedisConnection.connect('127.0.0.1', port!)
+
+    try {
+      connection.write(commandFrame('CLUSTER', 'NODES'))
+      const text = respText(await connection.readFrame())
+      const lines = text.split('\n').filter(line => line.trim().length > 0)
+      assert.ok(lines.length > 0)
+
+      for (const line of lines) {
+        const address = line.split(' ')[1]
+        const match = address.match(/^(.+):(\d+)@(\d+)$/)
+        assert.ok(match, `address field malformed: ${address}`)
+        assert.strictEqual(Number(match[3]), Number(match[2]) + 10000)
+      }
+    } finally {
+      connection.close()
+    }
+  })
 })
 
 async function findKeyOwnedByDifferentMaster(

--- a/tests/cluster-nodes-format.test.ts
+++ b/tests/cluster-nodes-format.test.ts
@@ -1,0 +1,71 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import {
+  ClientSession,
+  RedisClusterTopology,
+  RedisServerState,
+  createClusterCommand,
+  createClusterPolicy,
+  createRedisCommandExecutor,
+} from '../src'
+
+describe('CLUSTER NODES output format', () => {
+  test('reports bus port as client port + 10000 (#55)', async () => {
+    const text = await clusterNodes()
+
+    for (const line of text.split('\n').filter(l => l.trim().length > 0)) {
+      const address = line.split(' ')[1]
+      const match = address.match(/^(.+):(\d+)@(\d+)$/)
+      assert.ok(match, `address field malformed: ${address}`)
+      const clientPort = Number(match[2])
+      const busPort = Number(match[3])
+      assert.strictEqual(busPort, clientPort + 10000)
+    }
+  })
+
+  test('formats a single-slot range as a bare integer, not N-N (#63)', async () => {
+    const text = await clusterNodes()
+
+    // local owns exactly one slot (100) plus a multi-slot range (200-300)
+    const localLine = text.split('\n').find(line => line.startsWith('local '))
+    assert.ok(localLine, 'expected a line for the local node')
+
+    const slotFields = localLine.trim().split(' ').slice(8)
+    assert.deepStrictEqual(slotFields, ['100', '200-300'])
+  })
+})
+
+async function clusterNodes(): Promise<string> {
+  const topology = new RedisClusterTopology([
+    {
+      id: 'local',
+      role: 'master',
+      host: '127.0.0.1',
+      port: 7000,
+      slots: [
+        [100, 100],
+        [200, 300],
+      ],
+    },
+    {
+      id: 'remote',
+      role: 'master',
+      host: '127.0.0.1',
+      port: 7001,
+      slots: [[8192, 16383]],
+    },
+  ])
+  const server = new RedisServerState({ clusterTopology: topology })
+  const executor = createRedisCommandExecutor({
+    extraCommands: [createClusterCommand('local')],
+    policies: [createClusterPolicy({ localNodeId: 'local' })],
+  })
+  const session = new ClientSession({ server, executor })
+
+  const result = await session.execute('cluster', [Buffer.from('nodes')])
+  const value = result.value
+  if (value.kind !== 'bulk-string' || value.value === null) {
+    throw new Error(`expected a non-null bulk string, got ${value.kind}`)
+  }
+  return value.value.toString()
+}


### PR DESCRIPTION
## Summary
`formatNodeLine` (the `CLUSTER NODES` output builder in `src/commands/cluster.ts`) had two format bugs:

- **#55** — the `@cport` bus-port field used the client port instead of client port + 10000 (e.g. `127.0.0.1:7000@7000` instead of `@17000`).
- **#63** — a master owning a single slot was rendered as `N-N` instead of the bare integer `N`.

Both now match real Redis `CLUSTER NODES` output: bus port = client port + 10000, single-slot range = `N`, multi-slot range = `N-M`.

Closes #55
Closes #63

## Test plan
- [x] Unit test `tests/cluster-nodes-format.test.ts` builds a topology with a single-slot master (slot 100) + multi-slot range (200-300); asserts bare `100` (#63) and `@cport = port + 10000` (#55) — red before fix.
- [x] Integration test in `tests-integration/ioredis/cluster-integration.test.ts` asserts every `CLUSTER NODES` line's bus port = client port + 10000 (#55) — red on mock, green on real Redis before fix.
- [x] Fix makes both green on mock; integration stays green on real Redis.
- [x] `npm run test:all` passes (149 unit + 429 mock + 429 real, 0 fail), build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)