### PR TITLE
Implement RANDOMKEY

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -149,6 +149,7 @@ surface.
 - [x] `UNLINK key [key ...]` - Delete one or more keys without blocking (same as `DEL` in this mock)
 - [x] `EXISTS key [key ...]` - Determine how many of the given keys exist
 - [x] `TYPE key` - Return the type of the value stored at key
+- [x] `RANDOMKEY` - Return a random key from the selected database, or nil when empty
 - [x] `RENAME key newkey` - Rename a key
 - [x] `RENAMENX key newkey` - Rename a key only if the new key does not exist
 - [x] `COPY source destination [DB destination-db] [REPLACE]` - Copy a key's value (and TTL) to a destination, optionally into another database; returns `0` if the destination exists without `REPLACE`
@@ -173,7 +174,6 @@ with `GT` or `LT`.
 #### Not implemented
 
 - [ ] `OBJECT ENCODING|REFCOUNT|IDLETIME|FREQ|HELP`
-- [ ] `RANDOMKEY`
 - [ ] `MOVE`
 - [ ] `DUMP` / `RESTORE`
 - [ ] `TOUCH`

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -128,6 +128,7 @@ export {
   pexpireCommand,
   pexpireatCommand,
   pttlCommand,
+  randomkeyCommand,
   renameCommand,
   renamenxCommand,
   ttlCommand,

--- a/src/commands/keys.ts
+++ b/src/commands/keys.ts
@@ -12,6 +12,7 @@ import {
 } from '../core/redis-error'
 import type { ExpirationState, RedisDatabase } from '../state'
 import {
+  bulk,
   integer,
   ok,
   simpleString,
@@ -79,6 +80,22 @@ export const dbsizeCommand = defineCommand({
   flags: ['readonly', 'fast'],
   keys: () => [],
   execute: (_args, ctx) => integer(ctx.db.size()),
+})
+
+export const randomkeyCommand = defineCommand({
+  name: 'randomkey',
+  schema: t.object({}),
+  flags: ['readonly', 'random', 'fast'],
+  keys: () => [],
+  execute: (_args, ctx) => {
+    const entries = ctx.db.entriesSnapshot()
+    if (entries.length === 0) {
+      return bulk(null)
+    }
+
+    const index = Math.floor(Math.random() * entries.length)
+    return bulk(entries[index].key)
+  },
 })
 
 export const ttlCommand = defineCommand({
@@ -486,6 +503,7 @@ export const keysCommands = [
   existsCommand,
   typeCommand,
   dbsizeCommand,
+  randomkeyCommand,
   ttlCommand,
   pttlCommand,
   expiretimeCommand,

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,6 +184,7 @@ export {
   pingCommand,
   pttlCommand,
   quitCommand,
+  randomkeyCommand,
   readonlyCommand,
   readwriteCommand,
   redisCommandDefinitions,

--- a/tests-integration/ioredis/randomkey-integration.test.ts
+++ b/tests-integration/ioredis/randomkey-integration.test.ts
@@ -1,0 +1,70 @@
+import { after, afterEach, before, beforeEach, describe, test } from 'node:test'
+import assert from 'node:assert'
+import { setTimeout as delay } from 'node:timers/promises'
+import { Redis } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { errorWithMessage, randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+describe(`RANDOMKEY integration (${testRunner.getBackendName()})`, () => {
+  let client: Redis | undefined
+
+  before(async () => {
+    client = await testRunner.setupIoredisStandalone()
+  })
+
+  beforeEach(async () => {
+    await client?.call('FLUSHALL')
+    await client?.select(0)
+  })
+
+  afterEach(async () => {
+    await client?.call('FLUSHALL')
+    await client?.select(0)
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  test('returns null when the selected database is empty', async () => {
+    assert.strictEqual(await client?.call('RANDOMKEY'), null)
+  })
+
+  test('returns a key from the currently selected database', async () => {
+    const first = `randomkey:${randomKey()}:first`
+    const second = `randomkey:${randomKey()}:second`
+    const otherDb = `randomkey:${randomKey()}:other-db`
+
+    await client?.set(first, 'one')
+    await client?.set(second, 'two')
+
+    assert.ok(
+      [first, second].includes((await client?.call('RANDOMKEY')) as string),
+    )
+
+    await client?.select(1)
+    assert.strictEqual(await client?.call('RANDOMKEY'), null)
+
+    await client?.set(otherDb, 'other')
+    assert.strictEqual(await client?.call('RANDOMKEY'), otherDb)
+  })
+
+  test('does not return lazily expired keys', async () => {
+    const key = `randomkey-expired:${randomKey()}`
+
+    await client?.set(key, 'expired', 'PX', 1)
+    await delay(50)
+
+    assert.strictEqual(await client?.call('RANDOMKEY'), null)
+    assert.strictEqual(await client?.exists(key), 0)
+  })
+
+  test('rejects extra arguments', async () => {
+    await assert.rejects(
+      () => client!.call('RANDOMKEY', 'extra'),
+      errorWithMessage("ERR wrong number of arguments for 'randomkey' command"),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Implement `RANDOMKEY` as a readonly/random/fast key command using the live keyspace snapshot so lazy-expired keys are evicted before selection.
- Export `randomkeyCommand` through command and package indexes.
- Add ioredis standalone integration coverage for empty DBs, current DB isolation, lazy expiration, and wrong arity.
- Update `docs/COMMANDS.md` to mark `RANDOMKEY` supported.

## Root Cause
`RANDOMKEY` was absent from the command registry, so clients received `ERR unknown command` instead of Redis-compatible replies.

## Validation
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/randomkey-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/randomkey-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`

Fixes #200