### PR TITLE
Implement TOUCH command

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -148,6 +148,7 @@ surface.
 - [x] `DEL key [key ...]` - Delete one or more keys
 - [x] `UNLINK key [key ...]` - Delete one or more keys without blocking (same as `DEL` in this mock)
 - [x] `EXISTS key [key ...]` - Determine how many of the given keys exist
+- [x] `TOUCH key [key ...]` - Count the given keys that exist without changing key values
 - [x] `TYPE key` - Return the type of the value stored at key
 - [x] `RENAME key newkey` - Rename a key
 - [x] `RENAMENX key newkey` - Rename a key only if the new key does not exist
@@ -176,7 +177,6 @@ with `GT` or `LT`.
 - [ ] `RANDOMKEY`
 - [ ] `MOVE`
 - [ ] `DUMP` / `RESTORE`
-- [ ] `TOUCH`
 - [ ] `SORT` / `SORT_RO`
 - [ ] `WAIT`
 - [ ] `MIGRATE`

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -130,6 +130,7 @@ export {
   pttlCommand,
   renameCommand,
   renamenxCommand,
+  touchCommand,
   ttlCommand,
   typeCommand,
   unlinkCommand,

--- a/src/commands/keys.ts
+++ b/src/commands/keys.ts
@@ -63,6 +63,25 @@ export const existsCommand = defineCommand({
   },
 })
 
+export const touchCommand = defineCommand({
+  name: 'touch',
+  schema: t.object({
+    keys: t.variadic(t.key(), { min: 1 }),
+  }),
+  flags: ['readonly', 'fast'],
+  keys: args => args.keys,
+  execute: (args, ctx) => {
+    let count = 0
+    for (const key of args.keys) {
+      if (ctx.db.getType(key) !== null) {
+        count += 1
+      }
+    }
+
+    return integer(count)
+  },
+})
+
 export const typeCommand = defineCommand({
   name: 'type',
   schema: t.object({
@@ -484,6 +503,7 @@ export const keysCommands = [
   delCommand,
   unlinkCommand,
   existsCommand,
+  touchCommand,
   typeCommand,
   dbsizeCommand,
   ttlCommand,

--- a/tests-integration/ioredis/key-integration.test.ts
+++ b/tests-integration/ioredis/key-integration.test.ts
@@ -48,6 +48,55 @@ describe(`Key Commands Integration (${testRunner.getBackendName()})`, () => {
     assert.strictEqual(existsMultiple, 3) // 3 out of 4 keys exist
   })
 
+  test('TOUCH command counts live keys without mutating keyspace', async () => {
+    const tag = `{touch:${randomKey()}}`
+    const stringKey = `${tag}:string`
+    const hashKey = `${tag}:hash`
+    const expiringKey = `${tag}:expired`
+    const missingKey = `${tag}:missing`
+    const crossSlotA = `{touch-cross-a:${randomKey()}}:key`
+    const crossSlotB = `{touch-cross-b:${randomKey()}}:key`
+    const directClient = await connectToSlotOwner(redisClient!, stringKey)
+
+    try {
+      await directClient.set(stringKey, 'value')
+      await directClient.hset(hashKey, 'field', 'value')
+      await directClient.set(expiringKey, 'value', 'PX', 1)
+      await new Promise(resolve => setTimeout(resolve, 20))
+
+      assert.strictEqual(
+        await directClient.call(
+          'TOUCH',
+          stringKey,
+          hashKey,
+          missingKey,
+          expiringKey,
+        ),
+        2,
+      )
+      assert.strictEqual(
+        await directClient.exists(stringKey, hashKey, expiringKey),
+        2,
+      )
+      assert.strictEqual(await directClient.type(hashKey), 'hash')
+      assert.strictEqual(await directClient.call('TOUCH', missingKey), 0)
+
+      await assert.rejects(
+        () => directClient.call('TOUCH'),
+        errorWithMessage("ERR wrong number of arguments for 'touch' command"),
+      )
+      await assert.rejects(
+        () => directClient.call('TOUCH', crossSlotA, crossSlotB),
+        errorWithMessage(
+          "CROSSSLOT Keys in request don't hash to the same slot",
+        ),
+      )
+    } finally {
+      await directClient.del(stringKey, hashKey, expiringKey, missingKey)
+      directClient.disconnect()
+    }
+  })
+
   test('TYPE command', async () => {
     // Set up test data of different types
     await redisClient?.set('{test}string_key', 'value')


### PR DESCRIPTION
## Summary
- Implement `TOUCH key [key ...]` as a read-style key command that counts live keys without mutating values
- Register/export the command and update the command support docs
- Add ioredis integration coverage for live, missing, expired, wrong-arity, and cross-slot behavior

## Root cause
`TOUCH` was listed as missing and was not registered in the command registry, so clients received `ERR unknown command`.

## Validation
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/key-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/key-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`

Fixes #203