### PR TITLE
fix: implement LINSERT

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -241,6 +241,7 @@ with `GT` or `LT`.
 - [x] `LLEN key` - Return the length of the list
 - [x] `LRANGE key start stop` - Get a range of elements
 - [x] `LINDEX key index` - Get an element by index
+- [x] `LINSERT key BEFORE | AFTER pivot element` - Insert an element before or after the first matching pivot
 - [x] `LSET key index element` - Set the value of an element by index
 - [x] `LREM key count element` - Remove elements matching a value
 - [x] `LTRIM key start stop` - Trim a list to the specified range
@@ -252,10 +253,6 @@ with `GT` or `LT`.
 - [x] `BLMOVE source destination LEFT | RIGHT LEFT | RIGHT timeout` - Blocking variant of `LMOVE`
 - [x] `LMPOP numkeys key [key ...] LEFT | RIGHT [COUNT count]` - Pop from the first non-empty list
 - [x] `BLMPOP timeout numkeys key [key ...] LEFT | RIGHT [COUNT count]` - Blocking variant of `LMPOP`
-
-#### Not implemented
-
-- [ ] `LINSERT`
 
 ## 7. Set Commands
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -150,6 +150,7 @@ export {
   blpopCommand,
   brpopCommand,
   lindexCommand,
+  linsertCommand,
   llenCommand,
   lmoveCommand,
   lmpopCommand,

--- a/src/commands/lists/index.ts
+++ b/src/commands/lists/index.ts
@@ -9,6 +9,7 @@ import {
   lsetCommand,
   ltrimCommand,
 } from './access'
+import { linsertCommand } from './insert'
 import { lposCommand } from './lpos'
 import { lpopCommand, rpopCommand } from './pop'
 import {
@@ -27,6 +28,7 @@ export const listsCommands = [
   llenCommand,
   lrangeCommand,
   lindexCommand,
+  linsertCommand,
   lsetCommand,
   lremCommand,
   ltrimCommand,
@@ -48,6 +50,7 @@ export {
   blpopCommand,
   brpopCommand,
   lindexCommand,
+  linsertCommand,
   llenCommand,
   lmoveCommand,
   lmpopCommand,

--- a/src/commands/lists/insert.ts
+++ b/src/commands/lists/insert.ts
@@ -1,0 +1,47 @@
+import { defineCommand } from '../../core/command-definition'
+import { t } from '../../core/command-schema'
+import {
+  RedisSyntaxError,
+  WrongNumberOfArgumentsError,
+} from '../../core/redis-error'
+import { integer } from '../helpers'
+
+function insertPosition(): ReturnType<typeof t.custom<'before' | 'after'>> {
+  return t.custom<'before' | 'after'>((input, index, ctx) => {
+    const token = input[index]
+    if (!token) {
+      throw new WrongNumberOfArgumentsError(ctx.commandName)
+    }
+
+    const position = token.toString().toUpperCase()
+    if (position !== 'BEFORE' && position !== 'AFTER') {
+      throw new RedisSyntaxError()
+    }
+
+    return {
+      value: position === 'BEFORE' ? 'before' : 'after',
+      nextIndex: index + 1,
+    }
+  })
+}
+
+export const linsertCommand = defineCommand({
+  name: 'linsert',
+  schema: t.object({
+    key: t.key(),
+    position: insertPosition(),
+    pivot: t.key(),
+    element: t.key(),
+  }),
+  flags: ['write', 'denyoom'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const list = ctx.db.getList(args.key)
+    if (!list) return integer(0)
+
+    const length = ctx.db.updateList(args.key, list =>
+      list.insertRelativeTo(args.pivot, args.element, args.position),
+    )
+    return integer(length)
+  },
+})

--- a/src/state/tracked-values.ts
+++ b/src/state/tracked-values.ts
@@ -128,6 +128,22 @@ export class TrackedListData {
     this.tracker.markChanged()
   }
 
+  insertRelativeTo(
+    pivot: Buffer,
+    element: Buffer,
+    position: 'before' | 'after',
+  ): number {
+    const pivotIndex = this.list.values.findIndex(value => value.equals(pivot))
+    if (pivotIndex === -1) {
+      return -1
+    }
+
+    const insertIndex = position === 'before' ? pivotIndex : pivotIndex + 1
+    this.list.values.splice(insertIndex, 0, element)
+    this.tracker.markChanged()
+    return this.list.values.length
+  }
+
   removeMatching(count: number, element: Buffer): number {
     const target = element.toString('binary')
     let removed = 0

--- a/tests-integration/ioredis/linsert-integration.test.ts
+++ b/tests-integration/ioredis/linsert-integration.test.ts
@@ -1,0 +1,123 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { connectToSlotOwner, errorWithMessage, randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+describe(`LINSERT Integration (${testRunner.getBackendName()})`, () => {
+  let redisClient: Cluster | undefined
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster('linsert-integration')
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  test('inserts before and after the first matching pivot', async () => {
+    const tag = `{linsert:${randomKey()}}`
+    const key = `${tag}:list`
+    const client = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      await client.del(key)
+      await client.rpush(key, 'a', 'b', 'c', 'b')
+
+      assert.strictEqual(
+        await client.call('LINSERT', key, 'BEFORE', 'b', 'x'),
+        5,
+      )
+      assert.deepStrictEqual(await client.lrange(key, 0, -1), [
+        'a',
+        'x',
+        'b',
+        'c',
+        'b',
+      ])
+
+      assert.strictEqual(
+        await client.call('LINSERT', key, 'after', 'b', 'y'),
+        6,
+      )
+      assert.deepStrictEqual(await client.lrange(key, 0, -1), [
+        'a',
+        'x',
+        'b',
+        'y',
+        'c',
+        'b',
+      ])
+    } finally {
+      await client.del(key)
+      client.disconnect()
+    }
+  })
+
+  test('returns Redis-compatible values for missing keys and pivots', async () => {
+    const tag = `{linsert-missing:${randomKey()}}`
+    const key = `${tag}:list`
+    const missing = `${tag}:missing`
+    const client = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      await client.del(key, missing)
+      await client.rpush(key, 'a', 'b', 'c')
+
+      assert.strictEqual(
+        await client.call('LINSERT', key, 'BEFORE', 'z', 'x'),
+        -1,
+      )
+      assert.deepStrictEqual(await client.lrange(key, 0, -1), ['a', 'b', 'c'])
+
+      assert.strictEqual(
+        await client.call('LINSERT', missing, 'AFTER', 'z', 'x'),
+        0,
+      )
+      assert.strictEqual(await client.exists(missing), 0)
+    } finally {
+      await client.del(key, missing)
+      client.disconnect()
+    }
+  })
+
+  test('error paths match Redis', async () => {
+    const tag = `{linsert-err:${randomKey()}}`
+    const key = `${tag}:list`
+    const stringKey = `${tag}:string`
+    const client = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      await client.del(key, stringKey)
+      await client.rpush(key, 'pivot')
+
+      await assert.rejects(
+        () => client.call('LINSERT', key, 'AROUND', 'pivot', 'x'),
+        errorWithMessage('ERR syntax error'),
+      )
+
+      await assert.rejects(
+        () => client.call('LINSERT', key, 'BEFORE', 'pivot'),
+        errorWithMessage("ERR wrong number of arguments for 'linsert' command"),
+      )
+
+      await assert.rejects(
+        () => client.call('LINSERT', key, 'BEFORE', 'pivot', 'x', 'extra'),
+        errorWithMessage("ERR wrong number of arguments for 'linsert' command"),
+      )
+
+      await client.set(stringKey, 'value')
+      await assert.rejects(
+        () => client.call('LINSERT', stringKey, 'BEFORE', 'pivot', 'x'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+    } finally {
+      await client.del(key, stringKey)
+      client.disconnect()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add the Redis-compatible `LINSERT key BEFORE|AFTER pivot element` command
- insert before/after the first matching pivot with Redis return values for missing keys and pivot misses
- document `LINSERT` as supported in the command matrix

## Root cause
`LINSERT` was not registered in the list command set, so Redis clients received `ERR unknown command` for a supported Redis list operation.

## Validation
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/linsert-integration.test.ts`
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/linsert-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`

Fixes #208