### PR TITLE
Fix INFO replication fields

### DIFF
--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -18,6 +18,7 @@ import { array, bulk, integer, ok, simpleString } from './helpers'
 import { commandSubcommandInfo } from './introspection'
 
 const REDIS_VERSION = '7.4.4'
+const MASTER_REPLID = '0000000000000000000000000000000000000000'
 
 const clientIds = new WeakMap<RedisClientSession, number>()
 const clientNames = new WeakMap<RedisClientSession, Buffer>()
@@ -124,6 +125,9 @@ function buildInfo(ctx: RedisExecutionContext, section?: string): string {
       'role:master',
       'connected_slaves:0',
       'master_failover_state:no-failover',
+      `master_replid:${MASTER_REPLID}`,
+      'master_repl_offset:0',
+      'second_repl_offset:-1',
       'repl_backlog_active:0',
     ],
     cpu: () => [

--- a/tests-integration/ioredis/info-standalone.test.ts
+++ b/tests-integration/ioredis/info-standalone.test.ts
@@ -23,4 +23,15 @@ describe(`INFO command standalone integration (${testRunner.getBackendName()})`,
     assert.doesNotMatch(info, /^cluster_state:/m)
     assert.doesNotMatch(info, /^cluster_slots_assigned:/m)
   })
+
+  test('INFO replication exposes Redis-compatible replication identifiers', async () => {
+    const info = (await client!.call('INFO', 'replication')) as string
+
+    assert.match(info, /^role:master$/m)
+    assert.match(info, /^connected_slaves:0$/m)
+    assert.match(info, /^master_failover_state:no-failover$/m)
+    assert.match(info, /^master_replid:[0-9a-f]{40}$/m)
+    assert.match(info, /^master_repl_offset:\d+$/m)
+    assert.match(info, /^second_repl_offset:-1$/m)
+  })
 })


### PR DESCRIPTION
## Summary
- Add Redis-compatible replication identifiers and offsets to `INFO replication`.
- Cover the fields in the standalone ioredis INFO integration test.

## Root cause
`buildInfo()` populated the replication section with only role, connected slave count, failover state, and backlog activity. Real Redis also exposes `master_replid`, `master_repl_offset`, and `second_repl_offset`, and client libraries may read those fields during health checks.

## Validation
- Focused mock integration test failed before the fix on the missing replication fields.
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/info-standalone.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/info-standalone.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`
- Pre-push hook reran `npm test` successfully.

Docs checked: `README.md`, `docs/COMMANDS.md`, and `docs/ARCHITECTURE.md`; no contract update was needed because INFO is already documented as static/zeroed placeholder data for client handshakes.

Fixes #47
