### PR TITLE
fix: RESET executes immediately inside MULTI (#80)

### DIFF
--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -578,7 +578,11 @@ export const authCommand = defineCommand({
 export const resetCommand = defineCommand({
   name: 'reset',
   schema: t.object({}),
-  flags: ['admin', 'subscribed'],
+  // 'transaction' makes RESET bypass MULTI queueing and run immediately, like
+  // EXEC/DISCARD/WATCH — it aborts the in-flight transaction via
+  // discardTransaction() instead of being queued until EXEC (matches real
+  // Redis, which excludes RESET from queueMultiCommand).
+  flags: ['admin', 'subscribed', 'transaction'],
   keys: () => [],
   execute: (_args, ctx) => {
     clientNames.delete(ctx.session)

--- a/tests-integration/raw-tcp/protocol.test.ts
+++ b/tests-integration/raw-tcp/protocol.test.ts
@@ -132,4 +132,40 @@ describe(`Raw TCP protocol integration (${testRunner.getBackendName()})`, () => 
 
     assert.deepStrictEqual(await conn.readRawFrame(), Buffer.from('$-1\r\n'))
   })
+
+  // #80: RESET must execute immediately inside MULTI (like EXEC/DISCARD/WATCH),
+  // aborting the transaction — it must not be queued.
+  test('RESET inside MULTI executes immediately and aborts the transaction', async () => {
+    const conn = await connect()
+    const key = `${randomKey()}:reset-multi`
+
+    conn.write(commandFrame('MULTI'))
+    assert.deepStrictEqual(await conn.readRawFrame(), Buffer.from('+OK\r\n'))
+
+    // A normal command is queued.
+    conn.write(commandFrame('SET', key, 'queued'))
+    assert.deepStrictEqual(
+      await conn.readRawFrame(),
+      Buffer.from('+QUEUED\r\n'),
+    )
+
+    // RESET is NOT queued — it runs now and replies +RESET.
+    conn.write(commandFrame('RESET'))
+    assert.deepStrictEqual(await conn.readRawFrame(), Buffer.from('+RESET\r\n'))
+
+    // The transaction was discarded, so EXEC has nothing to run.
+    conn.write(commandFrame('EXEC'))
+    assert.deepStrictEqual(
+      await conn.readRawFrame(),
+      Buffer.from('-ERR EXEC without MULTI\r\n'),
+    )
+
+    // The queued SET never executed.
+    conn.write(commandFrame('GET', key))
+    assert.deepStrictEqual(await conn.readRawFrame(), Buffer.from('$-1\r\n'))
+
+    // The session is back to normal mode — ordinary commands run, not queued.
+    conn.write(commandFrame('SET', key, 'normal'))
+    assert.deepStrictEqual(await conn.readRawFrame(), Buffer.from('+OK\r\n'))
+  })
 })


### PR DESCRIPTION
## Summary
- `resetCommand` lacked the `transaction` flag, so inside a `MULTI` block it was **queued** (`+QUEUED`) like an ordinary command instead of running immediately.
- Real Redis excludes `RESET` from `queueMultiCommand` (alongside `EXEC`/`DISCARD`/`WATCH`/`QUIT`): `RESET` runs *now*, aborts the in-flight transaction, replies `+RESET`, and returns the session to normal mode.
- Fix: add the `transaction` flag to `resetCommand` so `TransactionPolicy` lets it through in transaction mode; it then calls `discardTransaction()` as it already did.

### On the pub/sub dimension of #80
The issue's title ("RESET does not cancel pub/sub subscriptions") and its "Root Cause" were already addressed before this PR: `resetCommand` calls `session.resetPubSub()`, which unsubscribes every channel/pattern from the broker and exits subscribed mode. I verified against **real Redis** that `RESET` cancels subscriptions **silently** — it sends *no* per-channel `unsubscribe` push (real Redis calls `unsubscribeAllChannels(c, 0)`, `notify=0`), contrary to the issue's "Expected behaviour" note which claimed unsubscribe messages are pushed. The existing raw-tcp test `RESET exits subscribed mode and removes all subscriptions` already covers this correct behavior (only `+RESET`, broker stops delivering, session back to normal mode).

The remaining real bug was the MULTI queueing, found during the issue's runtime-verification comment — that's what this PR fixes.

Closes #80

## Test plan
- [x] New raw-tcp test `RESET inside MULTI executes immediately and aborts the transaction` reproduces the bug (red: RESET returned `+QUEUED`)
- [x] Test passes against real Redis (verified: `MULTI`→`+OK`, `RESET`→`+RESET`, `EXEC`→`-ERR EXEC without MULTI`)
- [x] Fix (`transaction` flag) makes the test pass on mock too
- [x] Pub/sub cancellation already covered by existing `RESET exits subscribed mode...` test
- [x] `npm run test:all` passes (439/439)
- [x] `npm run build` + `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)