### PR TITLE
feat: implement TIME and LASTSAVE (#118)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -108,7 +108,7 @@ surface.
 
 #### TIME
 
-- [ ] `TIME` - Return the current server time as a two-element array `[unix-time-seconds, microseconds]`
+- [x] `TIME` - Return the current server time as a two-element array `[unix-time-seconds, microseconds]`
 
 #### MEMORY
 
@@ -443,7 +443,7 @@ cluster-wide fan-out between separate mock cluster nodes is not implemented.
 - [ ] `SAVE` - Synchronously save the dataset to disk
 - [ ] `BGSAVE [SCHEDULE]` - Asynchronously save the dataset to disk in the background
 - [ ] `BGREWRITEAOF` - Asynchronously rewrite the append-only file
-- [ ] `LASTSAVE` - Return the Unix timestamp of the last successful save
+- [x] `LASTSAVE` - Return the Unix timestamp of the last successful save (returns process start time, since there is no persistence)
 - [ ] `SHUTDOWN [NOSAVE|SAVE|ABORT]` - Synchronously save and shut down the server
 
 ## 16. ACL Commands

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -20,6 +20,9 @@ import { commandSubcommandInfo } from './introspection'
 const REDIS_VERSION = '7.4.4'
 const MASTER_REPLID = '0000000000000000000000000000000000000000'
 
+// There is no persistence, so LASTSAVE reports the process/server start time.
+const serverStartTimeSeconds = Math.floor(Date.now() / 1000)
+
 const clientIds = new WeakMap<RedisClientSession, number>()
 const clientNames = new WeakMap<RedisClientSession, Buffer>()
 const clientLibraryNames = new WeakMap<RedisClientSession, Buffer>()
@@ -600,6 +603,30 @@ export const resetCommand = defineCommand({
   },
 })
 
+export const timeCommand = defineCommand({
+  name: 'time',
+  schema: t.object({}),
+  flags: ['readonly', 'random', 'fast'],
+  keys: () => [],
+  execute: () => {
+    const now = Date.now()
+    const seconds = Math.floor(now / 1000)
+    const microseconds = (now % 1000) * 1000
+    return array([
+      RedisValue.bulkString(Buffer.from(seconds.toString())),
+      RedisValue.bulkString(Buffer.from(microseconds.toString())),
+    ])
+  },
+})
+
+export const lastsaveCommand = defineCommand({
+  name: 'lastsave',
+  schema: t.object({}),
+  flags: ['readonly', 'fast'],
+  keys: () => [],
+  execute: () => integer(serverStartTimeSeconds),
+})
+
 export const connectionCommands = [
   pingCommand,
   quitCommand,
@@ -609,4 +636,6 @@ export const connectionCommands = [
   helloCommand,
   authCommand,
   resetCommand,
+  timeCommand,
+  lastsaveCommand,
 ]

--- a/tests-integration/ioredis/time-lastsave-integration.test.ts
+++ b/tests-integration/ioredis/time-lastsave-integration.test.ts
@@ -1,0 +1,72 @@
+import { after, before, describe, test } from 'node:test'
+import assert from 'node:assert'
+import { Redis } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { errorWithMessage } from '../utils'
+
+const testRunner = new TestRunner()
+
+describe(`TIME / LASTSAVE integration (${testRunner.getBackendName()})`, () => {
+  let client: Redis | undefined
+
+  before(async () => {
+    client = await testRunner.setupIoredisStandalone()
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  test('TIME returns [seconds, microseconds] close to current time', async () => {
+    const before = Math.floor(Date.now() / 1000)
+    const reply = (await client?.call('TIME')) as [string, string]
+    const after = Math.floor(Date.now() / 1000)
+
+    assert.ok(Array.isArray(reply), 'TIME must return an array')
+    assert.strictEqual(reply.length, 2, 'TIME must return two elements')
+
+    const seconds = Number(reply[0])
+    const micros = Number(reply[1])
+
+    assert.ok(Number.isInteger(seconds), 'seconds must be an integer string')
+    assert.ok(
+      Number.isInteger(micros),
+      'microseconds must be an integer string',
+    )
+    assert.ok(
+      seconds >= before - 1 && seconds <= after + 1,
+      `seconds ${seconds} should be near ${before}..${after}`,
+    )
+    assert.ok(
+      micros >= 0 && micros <= 999999,
+      `microseconds ${micros} must be in [0, 999999]`,
+    )
+  })
+
+  test('TIME rejects extra arguments', async () => {
+    await assert.rejects(
+      () => client!.call('TIME', 'extra'),
+      errorWithMessage("ERR wrong number of arguments for 'time' command"),
+    )
+  })
+
+  test('LASTSAVE returns a Unix timestamp integer not in the future', async () => {
+    const reply = await client?.call('LASTSAVE')
+    const now = Math.floor(Date.now() / 1000)
+
+    const timestamp = Number(reply)
+    assert.ok(Number.isInteger(timestamp), 'LASTSAVE must return an integer')
+    assert.ok(timestamp > 0, 'LASTSAVE timestamp must be positive')
+    assert.ok(
+      timestamp <= now + 1,
+      `LASTSAVE timestamp ${timestamp} must not be in the future (now ${now})`,
+    )
+  })
+
+  test('LASTSAVE rejects extra arguments', async () => {
+    await assert.rejects(
+      () => client!.call('LASTSAVE', 'extra'),
+      errorWithMessage("ERR wrong number of arguments for 'lastsave' command"),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- `TIME` and `LASTSAVE` were unimplemented — both returned `ERR unknown command`.
- `TIME` now returns the current server time as a two-element array `[seconds, microseconds]` (bulk strings), matching real Redis. Microsecond precision is derived from the millisecond clock (`(Date.now() % 1000) * 1000`).
- `LASTSAVE` now returns a Unix timestamp integer. With no persistence layer, it reports the server/process start time (captured at module load).
- Both added to `src/commands/connection.ts` alongside `INFO`, registered via the `connectionCommands` array. Flags: `TIME` → `readonly, random, fast`; `LASTSAVE` → `readonly, fast`.
- Updated `docs/COMMANDS.md` to mark both as implemented.

Closes #118

## Test plan
- [x] New test in `tests-integration/ioredis/time-lastsave-integration.test.ts` reproduces the bug (red on mock before fix)
- [x] Test passes against real Redis (confirms our impl was the gap, format/errors match)
- [x] Fix makes the test pass on mock too
- [x] Covers arity errors for both (`ERR wrong number of arguments for '<cmd>' command`), TIME array shape + microsecond range, LASTSAVE not-in-future
- [x] `npm run test:all` passes (unit 152, mock 444, real 444)

🤖 Generated with [Claude Code](https://claude.com/claude-code)