### PR TITLE
fix: INCR/DECR int64 range (#36) + INCRBYFLOAT NaN/Infinity error (#56)

### DIFF
--- a/src/commands/helpers.ts
+++ b/src/commands/helpers.ts
@@ -79,6 +79,26 @@ export function parseIntegerToken(token: Buffer): number {
   return value
 }
 
+export const INT64_MAX = 9223372036854775807n
+export const INT64_MIN = -9223372036854775808n
+
+// Parse a stored token as a signed 64-bit integer, matching Redis' int64
+// semantics for INCR/DECR. Unlike parseIntegerToken this keeps full precision
+// above 2^53 and rejects values outside the int64 range.
+export function parseInt64Token(token: Buffer): bigint {
+  const raw = token.toString()
+  if (!isIntegerToken(raw)) {
+    throw new ExpectedIntegerError()
+  }
+
+  const value = BigInt(raw)
+  if (value < INT64_MIN || value > INT64_MAX) {
+    throw new ExpectedIntegerError()
+  }
+
+  return value
+}
+
 export function parsePositiveExpireToken(
   token: Buffer,
   commandName: string,

--- a/src/commands/strings.ts
+++ b/src/commands/strings.ts
@@ -7,7 +7,7 @@ import {
 import type { RedisDatabase } from '../state'
 import {
   ExpectedFloatError,
-  ExpectedIntegerError,
+  IncrDecrOverflowError,
   InvalidExpireTimeError,
   OffsetOutOfRangeError,
   RedisSyntaxError,
@@ -19,8 +19,11 @@ import { RedisValue } from '../core/redis-value'
 import {
   bulk,
   ensureStringOrMissing,
+  INT64_MAX,
+  INT64_MIN,
   integer,
   ok,
+  parseInt64Token,
   parseIntegerToken,
   parsePositiveExpireToken,
   requireNextOptionValue,
@@ -180,7 +183,7 @@ export const incrCommand = defineCommand({
   schema: t.object({ key: t.key() }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
-  execute: (args, ctx) => incrementBy(ctx.db, args.key, 1),
+  execute: (args, ctx) => incrementBy(ctx.db, args.key, 1n),
 })
 
 export const decrCommand = defineCommand({
@@ -188,12 +191,15 @@ export const decrCommand = defineCommand({
   schema: t.object({ key: t.key() }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
-  execute: (args, ctx) => incrementBy(ctx.db, args.key, -1),
+  execute: (args, ctx) => incrementBy(ctx.db, args.key, -1n),
 })
 
 export const incrbyCommand = defineCommand({
   name: 'incrby',
-  schema: t.object({ key: t.key(), amount: t.integer() }),
+  schema: t.object({
+    key: t.key(),
+    amount: t.bigInteger({ min: INT64_MIN, max: INT64_MAX }),
+  }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => incrementBy(ctx.db, args.key, args.amount),
@@ -201,10 +207,19 @@ export const incrbyCommand = defineCommand({
 
 export const decrbyCommand = defineCommand({
   name: 'decrby',
-  schema: t.object({ key: t.key(), amount: t.integer() }),
+  schema: t.object({
+    key: t.key(),
+    amount: t.bigInteger({ min: INT64_MIN, max: INT64_MAX }),
+  }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
-  execute: (args, ctx) => incrementBy(ctx.db, args.key, -args.amount),
+  execute: (args, ctx) => {
+    // Negating INT64_MIN overflows int64, so Redis rejects it before the op.
+    if (args.amount === INT64_MIN) {
+      throw new IncrDecrOverflowError('decrement would overflow')
+    }
+    return incrementBy(ctx.db, args.key, -args.amount)
+  },
 })
 
 export const incrbyfloatCommand = defineCommand({
@@ -566,13 +581,13 @@ type GetexArgs = {
 function incrementBy(
   db: RedisDatabase,
   key: Buffer,
-  delta: number,
+  delta: bigint,
 ): RedisResult {
   const existing = ensureStringOrMissing(db, key)
-  const current = existing ? parseIntegerToken(existing) : 0
+  const current = existing ? parseInt64Token(existing) : 0n
   const next = current + delta
-  if (!Number.isSafeInteger(next)) {
-    throw new ExpectedIntegerError()
+  if (next > INT64_MAX || next < INT64_MIN) {
+    throw new IncrDecrOverflowError()
   }
   db.setString(key, Buffer.from(next.toString()), { keepTtl: true })
   return integer(next)

--- a/src/commands/strings.ts
+++ b/src/commands/strings.ts
@@ -7,6 +7,7 @@ import {
 import type { RedisDatabase } from '../state'
 import {
   ExpectedFloatError,
+  IncrByFloatNanOrInfinityError,
   IncrDecrOverflowError,
   InvalidExpireTimeError,
   OffsetOutOfRangeError,
@@ -228,24 +229,21 @@ export const incrbyfloatCommand = defineCommand({
   flags: ['write', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const increment = parseFloat(args.amount.toString())
-    if (!Number.isFinite(increment)) {
-      throw new ExpectedFloatError()
-    }
+    // Like real Redis, an infinity literal ("inf"/"+inf"/"-inf"/"infinity",
+    // any case) is a *valid* operand — it only fails the post-arithmetic
+    // NaN/Infinity check. A non-numeric or overflow-magnitude value (e.g.
+    // "nan", "abc", "1e5000") is a parse error ("value is not a valid float").
+    const increment = parseIncrByFloatValue(args.amount.toString())
 
     const existing = ensureStringOrMissing(ctx.db, args.key)
     let current = 0
     if (existing) {
-      const parsed = parseFloat(existing.toString())
-      if (!Number.isFinite(parsed)) {
-        throw new ExpectedFloatError()
-      }
-      current = parsed
+      current = parseIncrByFloatValue(existing.toString())
     }
 
     const next = current + increment
     if (!Number.isFinite(next)) {
-      throw new ExpectedFloatError()
+      throw new IncrByFloatNanOrInfinityError()
     }
 
     const valueBuf = Buffer.from(next.toString())
@@ -253,6 +251,21 @@ export const incrbyfloatCommand = defineCommand({
     return bulk(valueBuf)
   },
 })
+
+// Parses an INCRBYFLOAT operand the way real Redis does: an infinity literal
+// is accepted (and returned as +/-Infinity) so the result check can flag it,
+// while NaN and finite-overflow magnitudes are rejected as invalid floats.
+function parseIncrByFloatValue(raw: string): number {
+  if (/^\s*[+-]?inf(inity)?\s*$/i.test(raw)) {
+    return raw.trimStart().startsWith('-') ? -Infinity : Infinity
+  }
+
+  const value = parseFloat(raw)
+  if (!Number.isFinite(value)) {
+    throw new ExpectedFloatError()
+  }
+  return value
+}
 
 export const getsetCommand = defineCommand({
   name: 'getset',

--- a/src/commands/strings.ts
+++ b/src/commands/strings.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from '../core/command-definition'
 import {
+  parseFiniteFloatToken,
   t,
   type CommandSchema,
   type ParseContext,
@@ -252,16 +253,19 @@ export const incrbyfloatCommand = defineCommand({
   },
 })
 
-// Parses an INCRBYFLOAT operand the way real Redis does: an infinity literal
-// is accepted (and returned as +/-Infinity) so the result check can flag it,
-// while NaN and finite-overflow magnitudes are rejected as invalid floats.
+// Parses an INCRBYFLOAT operand the way real Redis does (strtold): an infinity
+// literal is accepted (and returned as +/-Infinity) so the result check can
+// flag it, while NaN and finite-overflow magnitudes are rejected as invalid
+// floats. No surrounding whitespace is allowed and the *whole* token must be a
+// valid decimal float — "3abc", " 3.5", and "1,5" are parse errors, not silent
+// prefix parses (unlike JS parseFloat).
 function parseIncrByFloatValue(raw: string): number {
-  if (/^\s*[+-]?inf(inity)?\s*$/i.test(raw)) {
-    return raw.trimStart().startsWith('-') ? -Infinity : Infinity
+  if (/^[+-]?inf(inity)?$/i.test(raw)) {
+    return raw.startsWith('-') ? -Infinity : Infinity
   }
 
-  const value = parseFloat(raw)
-  if (!Number.isFinite(value)) {
+  const value = parseFiniteFloatToken(raw)
+  if (value === undefined) {
     throw new ExpectedFloatError()
   }
   return value

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -61,6 +61,12 @@ export class ExpectedFloatError extends RedisCommandError {
   }
 }
 
+export class IncrByFloatNanOrInfinityError extends RedisCommandError {
+  constructor() {
+    super('increment would produce NaN or Infinity')
+  }
+}
+
 export class ResultingScoreNaNError extends RedisCommandError {
   constructor() {
     super('resulting score is not a number (NaN)')

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -49,6 +49,12 @@ export class ExpectedIntegerError extends RedisCommandError {
   }
 }
 
+export class IncrDecrOverflowError extends RedisCommandError {
+  constructor(message = 'increment or decrement would overflow') {
+    super(message)
+  }
+}
+
 export class ExpectedFloatError extends RedisCommandError {
   constructor() {
     super('value is not a valid float')

--- a/tests-integration/ioredis/string-integration.test.ts
+++ b/tests-integration/ioredis/string-integration.test.ts
@@ -44,6 +44,77 @@ describe(`String Commands Integration (${testRunner.getBackendName()})`, () => {
     assert.strictEqual(decr1, 6)
   })
 
+  test('INCR/INCRBY/DECR/DECRBY operate over the full int64 range', async () => {
+    const tag = `{int64:${randomKey()}}`
+    const key = `${tag}:counter`
+    const directClient = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      // INCR just below the int64 max reaches it exactly (precision > 2^53)
+      await directClient.set(key, '9223372036854775806')
+      await directClient.incr(key)
+      assert.strictEqual(await directClient.get(key), '9223372036854775807')
+
+      // INCR at the int64 max overflows and leaves the value untouched
+      await assert.rejects(
+        () => directClient.incr(key),
+        errorWithMessage('ERR increment or decrement would overflow'),
+      )
+      assert.strictEqual(await directClient.get(key), '9223372036854775807')
+
+      // DECR at the int64 min overflows
+      await directClient.set(key, '-9223372036854775808')
+      await assert.rejects(
+        () => directClient.decr(key),
+        errorWithMessage('ERR increment or decrement would overflow'),
+      )
+      assert.strictEqual(await directClient.get(key), '-9223372036854775808')
+
+      // INCRBY with a large in-range amount keeps full precision
+      await directClient.set(key, '1')
+      await directClient.call('INCRBY', key, '9223372036854775806')
+      assert.strictEqual(await directClient.get(key), '9223372036854775807')
+
+      // INCRBY that would cross the int64 max overflows
+      await assert.rejects(
+        () => directClient.call('INCRBY', key, '1'),
+        errorWithMessage('ERR increment or decrement would overflow'),
+      )
+
+      // INCRBY/DECRBY amount outside the int64 range is rejected outright
+      await assert.rejects(
+        () => directClient.call('INCRBY', key, '99999999999999999999999'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () => directClient.call('DECRBY', key, '99999999999999999999999'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+
+      // DECRBY by the int64 min cannot be negated -> dedicated overflow message
+      await directClient.set(key, '0')
+      await assert.rejects(
+        () => directClient.call('DECRBY', key, '-9223372036854775808'),
+        errorWithMessage('ERR decrement would overflow'),
+      )
+
+      // DECRBY large in-range amount keeps full precision
+      await directClient.set(key, '-1')
+      await directClient.call('DECRBY', key, '9223372036854775807')
+      assert.strictEqual(await directClient.get(key), '-9223372036854775808')
+
+      // INCR on a value already out of int64 range is rejected
+      await directClient.set(key, '99999999999999999999999')
+      await assert.rejects(
+        () => directClient.incr(key),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+    } finally {
+      await directClient.del(key)
+      directClient.disconnect()
+    }
+  })
+
   test('INCRBYFLOAT command', async () => {
     // INCRBYFLOAT
     const incr1 = await redisClient?.incrbyfloat('floatcounter', 1.5)

--- a/tests-integration/ioredis/string-integration.test.ts
+++ b/tests-integration/ioredis/string-integration.test.ts
@@ -179,6 +179,20 @@ describe(`String Commands Integration (${testRunner.getBackendName()})`, () => {
         errorWithMessage('ERR value is not a valid float'),
       )
 
+      // Redis parses the whole token (strtold): trailing junk, leading or
+      // trailing whitespace, and non-'.' separators are all invalid floats,
+      // not silent prefix parses.
+      for (const bad of ['3abc', '3.5x', ' 3.5', '3.5 ', '1,5', '', '0x']) {
+        await direct.set(key, '1')
+        await assert.rejects(
+          () => direct.call('INCRBYFLOAT', key, bad),
+          errorWithMessage('ERR value is not a valid float'),
+          `increment "${bad}" should be an invalid float`,
+        )
+        // The key is left untouched on a parse error.
+        assert.strictEqual(await direct.get(key), '1')
+      }
+
       // A finite increment still works normally.
       await direct.set(key, '3')
       assert.strictEqual(await direct.call('INCRBYFLOAT', key, '1.0e2'), '103')

--- a/tests-integration/ioredis/string-integration.test.ts
+++ b/tests-integration/ioredis/string-integration.test.ts
@@ -124,6 +124,78 @@ describe(`String Commands Integration (${testRunner.getBackendName()})`, () => {
     assert.strictEqual(incr2, '3.8')
   })
 
+  test('INCRBYFLOAT distinguishes invalid-float from NaN/Infinity result (#56)', async () => {
+    const tag = `{incrbyfloat-inf:${randomKey()}}`
+    const key = `${tag}:key`
+    const direct = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      // A result of +/-Infinity (an infinity increment) reports the
+      // post-arithmetic error, NOT the "value is not a valid float" parse error.
+      for (const increment of [
+        'inf',
+        '+inf',
+        '-inf',
+        'infinity',
+        'Inf',
+        'INF',
+      ]) {
+        await direct.set(key, '3.0')
+        await assert.rejects(
+          () => direct.call('INCRBYFLOAT', key, increment),
+          errorWithMessage('ERR increment would produce NaN or Infinity'),
+          `increment "${increment}" should report the NaN/Infinity error`,
+        )
+        // The key is left untouched on error.
+        assert.strictEqual(await direct.get(key), '3.0')
+      }
+
+      // A stored infinity plus a finite increment is still infinity.
+      await direct.set(key, 'inf')
+      await assert.rejects(
+        () => direct.call('INCRBYFLOAT', key, '1'),
+        errorWithMessage('ERR increment would produce NaN or Infinity'),
+      )
+
+      // inf + (-inf) = NaN — also the post-arithmetic error.
+      await direct.set(key, 'inf')
+      await assert.rejects(
+        () => direct.call('INCRBYFLOAT', key, '-inf'),
+        errorWithMessage('ERR increment would produce NaN or Infinity'),
+      )
+
+      // Genuinely non-numeric / overflow-magnitude increments are parse errors.
+      await direct.set(key, '1')
+      await assert.rejects(
+        () => direct.call('INCRBYFLOAT', key, 'nan'),
+        errorWithMessage('ERR value is not a valid float'),
+      )
+      await assert.rejects(
+        () => direct.call('INCRBYFLOAT', key, '1e5000'),
+        errorWithMessage('ERR value is not a valid float'),
+      )
+      await assert.rejects(
+        () => direct.call('INCRBYFLOAT', key, 'abc'),
+        errorWithMessage('ERR value is not a valid float'),
+      )
+
+      // A finite increment still works normally.
+      await direct.set(key, '3')
+      assert.strictEqual(await direct.call('INCRBYFLOAT', key, '1.0e2'), '103')
+
+      // Arity.
+      await assert.rejects(
+        () => direct.call('INCRBYFLOAT', key),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'incrbyfloat' command",
+        ),
+      )
+    } finally {
+      await direct.del(key)
+      direct.disconnect()
+    }
+  })
+
   test('APPEND command', async () => {
     // APPEND to non-existent key
     const append1 = await redisClient?.append('appendkey', 'hello')


### PR DESCRIPTION
String-numeric correctness fixes for INCR/DECR family and INCRBYFLOAT, in one branch.

## 1. INCR/INCRBY/DECR/DECRBY honor full int64 range (#36)
- Used JS `Number` math + `Number.isSafeInteger`, so counters overflowed at 2^53 instead of the Redis int64 limit `2^63-1`.
- `incrementBy()` now parses the stored value as a signed int64 via `parseInt64Token` (new), adds in `BigInt`, and rejects results outside `[-2^63, 2^63-1]` with the new `IncrDecrOverflowError` → `ERR increment or decrement would overflow`.
- INCRBY/DECRBY `amount` parsed via `t.bigInteger({ min: INT64_MIN, max: INT64_MAX })`; out-of-int64-range amounts → `ERR value is not an integer or out of range`.
- DECRBY by exactly `INT64_MIN` → dedicated `ERR decrement would overflow` (negating `LLONG_MIN` overflows int64) — matches real Redis.

## 2. INCRBYFLOAT result/operand parsing matches Redis (#56)
**Result error (the #56 bug):** reused `ExpectedFloatError` ("value is not a valid float") for both an unparseable operand and a non-finite *result*, and rejected infinity-literal operands at parse time.
- `inf`/`+inf`/`-inf`/`infinity` (any case) are valid operands; a non-finite result → `ERR increment would produce NaN or Infinity` (new `IncrByFloatNanOrInfinityError`). `nan` and overflow magnitudes (`1e5000`) stay `ERR value is not a valid float`.
- Note: the issue's literal repro (MAX+MAX) does not overflow real Redis (long double); JS `Number` can't represent long double, so the portable test trigger is an infinity operand.

**Operand parsing:** previously used JS `parseFloat`, which silently accepts a valid prefix (`"3abc"`→3, `"3.5x"`→3.5), trims leading whitespace (`" 3.5"`→3.5), and stops at separators (`"1,5"`→1). Real Redis (`strtold`) requires the whole token. Now parsed with the codebase's canonical decimal float-token parser (`parseFiniteFloatToken`), so all of those are `ERR value is not a valid float`, matching Redis.

Closes #36
Closes #56

## Verified against real Redis 7.2.14 (every error string/sentinel probed)
- int64: 806→807 boundary, overflow at max/min, INCRBY/DECRBY cross-bound, out-of-range amount, DECRBY-by-INT64_MIN special message, INCR on out-of-range stored value.
- incrbyfloat: inf-family + stored-inf → overflow error; `nan`/`1e5000`/`abc`/`3abc`/`3.5x`/` 3.5`/`1,5`/`0x`/empty → not-a-valid-float; normal floats + exponent forms unchanged.

## Test plan
- [x] New int64 + incrbyfloat tests in `tests-integration/ioredis/string-integration.test.ts` (red on mock before each fix)
- [x] Green against real Redis (mock-only bugs; strings probed against real `redis-cli`)
- [x] `npm run build`, `npm run lint`, unit (152), mock integration (446), real integration (446) all green

## Known micro-divergence (intentional, untested)
Real Redis `strtold` accepts C hex floats (`0x10`→16); the repo parses decimal float tokens only (consistent with `t.float()` for ZADD scores etc.), so hex INCRBYFLOAT operands are rejected. Pathological corner; can't be asserted cross-backend (mock rejects, real accepts). Left consistent with codebase-wide float handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)