### PR TITLE
fix: INCRBYFLOAT reports NaN/Infinity result distinctly (#56)

### DIFF
--- a/src/commands/strings.ts
+++ b/src/commands/strings.ts
@@ -8,6 +8,7 @@ import type { RedisDatabase } from '../state'
 import {
   ExpectedFloatError,
   ExpectedIntegerError,
+  IncrByFloatNanOrInfinityError,
   InvalidExpireTimeError,
   OffsetOutOfRangeError,
   RedisSyntaxError,
@@ -213,24 +214,21 @@ export const incrbyfloatCommand = defineCommand({
   flags: ['write', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const increment = parseFloat(args.amount.toString())
-    if (!Number.isFinite(increment)) {
-      throw new ExpectedFloatError()
-    }
+    // Like real Redis, an infinity literal ("inf"/"+inf"/"-inf"/"infinity",
+    // any case) is a *valid* operand — it only fails the post-arithmetic
+    // NaN/Infinity check. A non-numeric or overflow-magnitude value (e.g.
+    // "nan", "abc", "1e5000") is a parse error ("value is not a valid float").
+    const increment = parseIncrByFloatValue(args.amount.toString())
 
     const existing = ensureStringOrMissing(ctx.db, args.key)
     let current = 0
     if (existing) {
-      const parsed = parseFloat(existing.toString())
-      if (!Number.isFinite(parsed)) {
-        throw new ExpectedFloatError()
-      }
-      current = parsed
+      current = parseIncrByFloatValue(existing.toString())
     }
 
     const next = current + increment
     if (!Number.isFinite(next)) {
-      throw new ExpectedFloatError()
+      throw new IncrByFloatNanOrInfinityError()
     }
 
     const valueBuf = Buffer.from(next.toString())
@@ -238,6 +236,21 @@ export const incrbyfloatCommand = defineCommand({
     return bulk(valueBuf)
   },
 })
+
+// Parses an INCRBYFLOAT operand the way real Redis does: an infinity literal
+// is accepted (and returned as +/-Infinity) so the result check can flag it,
+// while NaN and finite-overflow magnitudes are rejected as invalid floats.
+function parseIncrByFloatValue(raw: string): number {
+  if (/^\s*[+-]?inf(inity)?\s*$/i.test(raw)) {
+    return raw.trimStart().startsWith('-') ? -Infinity : Infinity
+  }
+
+  const value = parseFloat(raw)
+  if (!Number.isFinite(value)) {
+    throw new ExpectedFloatError()
+  }
+  return value
+}
 
 export const getsetCommand = defineCommand({
   name: 'getset',

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -55,6 +55,12 @@ export class ExpectedFloatError extends RedisCommandError {
   }
 }
 
+export class IncrByFloatNanOrInfinityError extends RedisCommandError {
+  constructor() {
+    super('increment would produce NaN or Infinity')
+  }
+}
+
 export class ResultingScoreNaNError extends RedisCommandError {
   constructor() {
     super('resulting score is not a number (NaN)')

--- a/tests-integration/ioredis/string-integration.test.ts
+++ b/tests-integration/ioredis/string-integration.test.ts
@@ -53,6 +53,78 @@ describe(`String Commands Integration (${testRunner.getBackendName()})`, () => {
     assert.strictEqual(incr2, '3.8')
   })
 
+  test('INCRBYFLOAT distinguishes invalid-float from NaN/Infinity result (#56)', async () => {
+    const tag = `{incrbyfloat-inf:${randomKey()}}`
+    const key = `${tag}:key`
+    const direct = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      // A result of +/-Infinity (an infinity increment) reports the
+      // post-arithmetic error, NOT the "value is not a valid float" parse error.
+      for (const increment of [
+        'inf',
+        '+inf',
+        '-inf',
+        'infinity',
+        'Inf',
+        'INF',
+      ]) {
+        await direct.set(key, '3.0')
+        await assert.rejects(
+          () => direct.call('INCRBYFLOAT', key, increment),
+          errorWithMessage('ERR increment would produce NaN or Infinity'),
+          `increment "${increment}" should report the NaN/Infinity error`,
+        )
+        // The key is left untouched on error.
+        assert.strictEqual(await direct.get(key), '3.0')
+      }
+
+      // A stored infinity plus a finite increment is still infinity.
+      await direct.set(key, 'inf')
+      await assert.rejects(
+        () => direct.call('INCRBYFLOAT', key, '1'),
+        errorWithMessage('ERR increment would produce NaN or Infinity'),
+      )
+
+      // inf + (-inf) = NaN — also the post-arithmetic error.
+      await direct.set(key, 'inf')
+      await assert.rejects(
+        () => direct.call('INCRBYFLOAT', key, '-inf'),
+        errorWithMessage('ERR increment would produce NaN or Infinity'),
+      )
+
+      // Genuinely non-numeric / overflow-magnitude increments are parse errors.
+      await direct.set(key, '1')
+      await assert.rejects(
+        () => direct.call('INCRBYFLOAT', key, 'nan'),
+        errorWithMessage('ERR value is not a valid float'),
+      )
+      await assert.rejects(
+        () => direct.call('INCRBYFLOAT', key, '1e5000'),
+        errorWithMessage('ERR value is not a valid float'),
+      )
+      await assert.rejects(
+        () => direct.call('INCRBYFLOAT', key, 'abc'),
+        errorWithMessage('ERR value is not a valid float'),
+      )
+
+      // A finite increment still works normally.
+      await direct.set(key, '3')
+      assert.strictEqual(await direct.call('INCRBYFLOAT', key, '1.0e2'), '103')
+
+      // Arity.
+      await assert.rejects(
+        () => direct.call('INCRBYFLOAT', key),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'incrbyfloat' command",
+        ),
+      )
+    } finally {
+      await direct.del(key)
+      direct.disconnect()
+    }
+  })
+
   test('APPEND command', async () => {
     // APPEND to non-existent key
     const append1 = await redisClient?.append('appendkey', 'hello')


### PR DESCRIPTION
## Summary
`INCRBYFLOAT` reused `ExpectedFloatError` (`ERR value is not a valid float`) for **both** an unparseable operand and a non-finite *result*, and it rejected infinity-literal increments at parse time. Real Redis distinguishes these:

- `inf` / `+inf` / `-inf` / `infinity` (any case) are **valid operands** — the result is infinity, reported as `ERR increment would produce NaN or Infinity`.
- A stored infinity plus a finite increment, or `inf + (-inf) = NaN`, hits the same result error.
- `nan`, non-numeric text, and overflow magnitudes like `1e5000` stay parse errors (`ERR value is not a valid float`).

### Changes
- New `IncrByFloatNanOrInfinityError` (`increment would produce NaN or Infinity`).
- New `parseIncrByFloatValue` helper: accepts infinity literals (returns ±Infinity), rejects NaN and finite-overflow magnitudes as `ExpectedFloatError`.
- The post-arithmetic check now throws the new error when the sum is non-finite.

### Note on the issue's repro
The issue's repro (`MAX + MAX`) does **not** overflow real Redis, which computes in `long double` and returns a huge number — so it can't be used in a backend-portable test. The portable trigger matching both the mock (JS `double`) and real Redis is an **infinity operand**, which the test uses. (Finite-magnitude overflow in `(1.8e308, 1.19e4932]` is an inherent mock-vs-real divergence and is intentionally not asserted.)

Closes #56

## Test plan
- [x] New test `INCRBYFLOAT distinguishes invalid-float from NaN/Infinity result` reproduces the bug (red: inf returned `value is not a valid float`)
- [x] Passes against real Redis (error strings verified via `redis-cli` probe)
- [x] Fix makes the test pass on mock too
- [x] Covers infinity literals, stored-infinity, `inf + -inf` NaN, parse errors (`nan`/`abc`/`1e5000`), normal increment, arity
- [x] `npm run test:all` passes (445/445 isolated)
- [x] `npm run build` + `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)