### PR TITLE
fix: scope Lua runtime per RedisServerState (#130)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -410,8 +410,16 @@ Cluster only exposes database 0); any non-zero index is rejected.
 
 ## Lua scripting
 
-[`RedisLuaRuntime`](../src/core/lua-runtime.ts#L24) wraps `lua-redis-wasm` and
-exposes `redis.call`/`redis.pcall` to scripts via a host callback
+Each [`RedisServerState`](../src/state/server-state.ts#L13) owns its own
+[`RedisLuaRuntime`](../src/core/lua-runtime.ts#L24), created lazily and
+memoized via [`getLuaRuntime()`](../src/state/server-state.ts#L62) on first
+`EVAL`/`EVALSHA`. The runtime is **not** a process-wide singleton — scoping it
+per server state keeps each logical node's `LuaEngine` and script
+re-entrancy guard isolated, so concurrent `EVAL`s on independent
+server/cluster nodes never share Lua state.
+
+`RedisLuaRuntime` wraps `lua-redis-wasm` and exposes `redis.call`/`redis.pcall`
+to scripts via a host callback
 ([`runRedisCommand`](../src/core/lua-runtime.ts#L58)) that:
 
 1. builds a `CommandPlan` with `ctx.executor.plan(name, args)` — the _exact_

--- a/src/commands/scripts.ts
+++ b/src/commands/scripts.ts
@@ -9,10 +9,7 @@ import {
   WrongNumberOfKeysError,
   WrongNumberOfArgumentsError,
 } from '../core/redis-error'
-import {
-  getDefaultRedisLuaRuntime,
-  luaReplyToRedisValue,
-} from '../core/lua-runtime'
+import { luaReplyToRedisValue } from '../core/lua-runtime'
 import type { RedisExecutionContext } from '../core/redis-context'
 import { RedisResult } from '../core/redis-result'
 import { RedisValue } from '../core/redis-value'
@@ -246,7 +243,7 @@ async function runLuaScript(
   argv: readonly Buffer[],
   ctx: RedisExecutionContext,
 ): Promise<RedisResult> {
-  const runtime = await getDefaultRedisLuaRuntime()
+  const runtime = await ctx.server.getLuaRuntime()
 
   try {
     const reply = runtime.eval(script, keys, argv, ctx)

--- a/src/core/lua-runtime.ts
+++ b/src/core/lua-runtime.ts
@@ -113,13 +113,12 @@ function createLuaMonitorContext(
   }
 }
 
-let defaultRuntimePromise: Promise<RedisLuaRuntime> | null = null
-
-export async function getDefaultRedisLuaRuntime(): Promise<RedisLuaRuntime> {
-  defaultRuntimePromise ??= createRedisLuaRuntime()
-  return defaultRuntimePromise
-}
-
+// Each RedisLuaRuntime gets its own freshly-loaded WASM module + LuaEngine +
+// hostState. A LuaWasmModule is single-use (module.create() consumes it), so it
+// cannot be shared between engines. Scoping a runtime per RedisServerState (see
+// RedisServerState.getLuaRuntime) keeps each logical node's script re-entrancy
+// guard isolated, so concurrent EVALs on independent server/cluster nodes never
+// collide (issue #130).
 export async function createRedisLuaRuntime(): Promise<RedisLuaRuntime> {
   const module = await load()
   return new RedisLuaRuntime(module)

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,6 @@ export {
 export {
   RedisLuaRuntime,
   createRedisLuaRuntime,
-  getDefaultRedisLuaRuntime,
   luaReplyToRedisValue,
   type LuaReplyValue,
 } from './core/lua-runtime'

--- a/src/state/server-state.ts
+++ b/src/state/server-state.ts
@@ -5,6 +5,10 @@ import type { Unsubscribe } from './mutation-events'
 import { RedisPubSubBroker } from './pubsub-broker'
 import { RedisScriptCache } from './script-cache'
 import type { RedisClientSession } from '../core/redis-context'
+import {
+  createRedisLuaRuntime,
+  type RedisLuaRuntime,
+} from '../core/lua-runtime'
 
 export type RedisServerStateOptions = {
   databaseCount?: number
@@ -28,6 +32,7 @@ export class RedisServerState {
   readonly clusterTopology: RedisClusterTopology
   readonly requirepass?: string
   private readonly clientSessions = new Set<RedisClientSession>()
+  private luaRuntimePromise: Promise<RedisLuaRuntime> | null = null
 
   constructor(options?: RedisServerStateOptions) {
     this.requirepass = options?.requirepass
@@ -45,6 +50,18 @@ export class RedisServerState {
     this.pubsubBroker = options?.pubsubBroker ?? new RedisPubSubBroker()
     this.clusterTopology =
       options?.clusterTopology ?? new RedisClusterTopology()
+  }
+
+  /**
+   * Returns this server's own Lua runtime, created lazily and memoized per
+   * RedisServerState instance. Scoping the runtime here (rather than a
+   * process-wide singleton) keeps each logical node's LuaEngine + script
+   * re-entrancy guard isolated, so concurrent EVALs on independent
+   * server/cluster nodes never collide (issue #130).
+   */
+  getLuaRuntime(): Promise<RedisLuaRuntime> {
+    this.luaRuntimePromise ??= createRedisLuaRuntime()
+    return this.luaRuntimePromise
   }
 
   getDatabase(id: number): RedisDatabase {

--- a/tests/lua-runtime-isolation.test.ts
+++ b/tests/lua-runtime-isolation.test.ts
@@ -1,0 +1,84 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import {
+  RedisLuaRuntime,
+  RedisServerState,
+  RedisResult,
+  RedisValue,
+} from '../src'
+import { createRedisSessionHarness as createSession } from './core-session-test-helpers'
+
+// Issue #130: RedisLuaRuntime used to be a process-wide module-level singleton
+// (`getDefaultRedisLuaRuntime`), so every EVAL/EVALSHA across logically
+// independent server/cluster-node instances shared one LuaEngine + hostState.
+// The runtime must instead be scoped per RedisServerState so concurrent scripts
+// on separate nodes can never collide on the single-script re-entrancy guard.
+describe('RedisLuaRuntime per-server isolation (#130)', () => {
+  test('each RedisServerState owns a distinct Lua runtime, not a shared singleton', async () => {
+    const serverA = new RedisServerState()
+    const serverB = new RedisServerState()
+
+    const runtimeA = await serverA.getLuaRuntime()
+    const runtimeB = await serverB.getLuaRuntime()
+
+    assert.ok(runtimeA instanceof RedisLuaRuntime)
+    assert.ok(runtimeB instanceof RedisLuaRuntime)
+    assert.notStrictEqual(
+      runtimeA,
+      runtimeB,
+      'separate server instances must not share one Lua runtime',
+    )
+  })
+
+  test('the same RedisServerState memoizes its Lua runtime', async () => {
+    const server = new RedisServerState()
+
+    const first = await server.getLuaRuntime()
+    const second = await server.getLuaRuntime()
+
+    assert.strictEqual(first, second)
+  })
+
+  test('EVAL on two independent servers runs through each server own runtime', async () => {
+    const a = createSession()
+    const b = createSession()
+    const key = Buffer.from('shared-key-name')
+
+    // Same key name on two independent servers must stay independent — each
+    // server resolves its own runtime via ctx.server.getLuaRuntime().
+    const [resA, resB] = await Promise.all([
+      a.session.execute('eval', [
+        Buffer.from('return redis.call("set", KEYS[1], ARGV[1])'),
+        Buffer.from('1'),
+        key,
+        Buffer.from('from-A'),
+      ]),
+      b.session.execute('eval', [
+        Buffer.from('return redis.call("set", KEYS[1], ARGV[1])'),
+        Buffer.from('1'),
+        key,
+        Buffer.from('from-B'),
+      ]),
+    ])
+
+    assert.deepStrictEqual(resA, RedisResult.ok())
+    assert.deepStrictEqual(resB, RedisResult.ok())
+    assert.deepStrictEqual(
+      a.server.getDatabase(0).getString(key),
+      Buffer.from('from-A'),
+    )
+    assert.deepStrictEqual(
+      b.server.getDatabase(0).getString(key),
+      Buffer.from('from-B'),
+    )
+
+    assert.deepStrictEqual(
+      await a.session.execute('eval', [
+        Buffer.from('return redis.call("get", KEYS[1])'),
+        Buffer.from('1'),
+        key,
+      ]),
+      RedisResult.create(RedisValue.bulkString(Buffer.from('from-A'))),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- `RedisLuaRuntime` was a process-wide module-level singleton (`getDefaultRedisLuaRuntime` in `src/core/lua-runtime.ts`), so every `EVAL`/`EVALSHA` across logically independent server/cluster-node instances shared one `LuaEngine` + `hostState`.
- Two nodes mid-script could collide on the single-script re-entrancy guard and spuriously fail with `Lua runtime is already executing a script`, even though the nodes are logically independent.
- Root cause: a single `(name, args) -> runtime` resolved from module scope regardless of which `RedisServerState` is executing.
- Fix: scope the runtime to `RedisServerState` via a lazy, memoized `getLuaRuntime()`; `runLuaScript` now resolves it through `ctx.server.getLuaRuntime()`. Each logical node gets its own `LuaEngine` + re-entrancy guard.
- A `LuaWasmModule` is single-use (`module.create()` consumes it), so each runtime still loads its own module — the singleton (and its public `getDefaultRedisLuaRuntime` export) is removed.
- Doc: `docs/ARCHITECTURE.md` "Lua scripting" now states the runtime is per-`RedisServerState`, not a process-wide singleton.

Closes #130

## Test plan
- [x] New unit test `tests/lua-runtime-isolation.test.ts` asserts each `RedisServerState` owns a distinct runtime and memoizes it per instance (RED before fix: `getLuaRuntime is not a function`)
- [x] Unit test (not integration): single-threaded JS cannot observably interleave two synchronous `runtime.eval` calls, so the collision is an internal-module isolation invariant with no wire-visible effect — the skill's documented unit-test exception
- [x] Fix makes the new tests pass
- [x] `npm run build`, `npm run lint` clean
- [x] `npm run test:all` passes — unit 155, mock integration 446, real integration 446, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)