### PR TITLE
fix: drain ResponseStream off the RESP2 frame loop so MONITOR connections stay usable (#126)

### DIFF
--- a/src/core/transports/resp2/session-adapter.ts
+++ b/src/core/transports/resp2/session-adapter.ts
@@ -3,6 +3,7 @@ import { RedisCommandError } from '../../redis-error'
 import { RedisResult } from '../../redis-result'
 import { encodeRedisResult } from '../../resp-encoder'
 import { isResponseStream } from '../../response-stream'
+import type { ResponseStream } from '../../response-stream'
 import type { ExecutorResult } from '../../command-executor'
 import type { RespEncodeOptions } from '../../resp-encoder'
 import type { Logger } from '../../../logger'
@@ -27,6 +28,7 @@ export class Resp2SessionAdapter {
   private readonly logger?: Pick<Logger, 'error'>
   private readonly encoder?: RespEncodeOptions
   private writeChain: Promise<void> = Promise.resolve()
+  private readonly activeStreams = new Set<Promise<void>>()
 
   constructor(options: Resp2SessionAdapterOptions) {
     this.transport = options.transport
@@ -64,6 +66,10 @@ export class Resp2SessionAdapter {
     } finally {
       this.session.close()
       await pushWriter
+      // Streams are torn down by session.close() (resetResponseStreams aborts
+      // them); wait for their drain tasks to settle so nothing writes after we
+      // return.
+      await Promise.allSettled(this.activeStreams)
     }
   }
 
@@ -74,17 +80,42 @@ export class Resp2SessionAdapter {
 
   private async writeExecutorResult(result: ExecutorResult): Promise<void> {
     if (isResponseStream(result)) {
-      for await (const frame of result.frames(this.transport.signal)) {
-        await this.writeRedisResult(frame)
-        if (this.transport.signal.aborted) {
-          result.close('transport closed')
-          return
-        }
-      }
+      // A ResponseStream can be long-lived (MONITOR, future SUBSCRIBE). Draining
+      // it inline would pin the frame loop until the stream closed, so the
+      // connection could never send another command. Drain it as a background
+      // task instead, multiplexed onto the shared writeChain, while run() keeps
+      // reading and dispatching subsequent frames.
+      this.spawnStreamDrain(result)
       return
     }
 
     await this.writeRedisResult(result)
+  }
+
+  private spawnStreamDrain(stream: ResponseStream): void {
+    const drain = this.drainStream(stream)
+    this.activeStreams.add(drain)
+    void drain.finally(() => {
+      this.activeStreams.delete(drain)
+    })
+  }
+
+  private async drainStream(stream: ResponseStream): Promise<void> {
+    try {
+      for await (const frame of stream.frames(this.transport.signal)) {
+        await this.writeRedisResult(frame)
+        if (this.transport.signal.aborted) {
+          stream.close('transport closed')
+          return
+        }
+      }
+    } catch (err) {
+      stream.close('resp2 stream error')
+      if (!this.transport.signal.aborted) {
+        this.logger?.error(err)
+        this.transport.close('resp2 stream error')
+      }
+    }
   }
 
   private async writeRedisResult(result: RedisResult): Promise<void> {

--- a/tests-integration/raw-tcp/monitor-protocol.test.ts
+++ b/tests-integration/raw-tcp/monitor-protocol.test.ts
@@ -309,7 +309,94 @@ describe(`Raw TCP MONITOR protocol (${testRunner.getBackendName()})`, () => {
       /^ERR This Redis command is not allowed from script/,
     )
   })
+
+  test('keeps the monitoring connection itself usable for further commands (#126)', async () => {
+    const monitor = await connect()
+
+    monitor.write(commandFrame('MONITOR'))
+    assert.deepStrictEqual(await monitor.readRawFrame(), Buffer.from('+OK\r\n'))
+
+    // Draining the long-lived MONITOR stream must not block the connection's
+    // frame loop: the same connection can still issue commands and read their
+    // replies (real Redis lets a monitoring client keep sending commands).
+    monitor.write(commandFrame('PING'))
+    assert.deepStrictEqual(
+      await readMonitorReply(monitor),
+      Buffer.from('+PONG\r\n'),
+    )
+
+    // A second round proves the loop keeps flowing, not just a one-shot.
+    monitor.write(commandFrame('PING', 'hello'))
+    assert.deepStrictEqual(
+      await readMonitorReply(monitor),
+      Buffer.from('$5\r\nhello\r\n'),
+    )
+  })
+
+  test('RESET on a monitoring connection exits monitor mode (#126)', async () => {
+    const monitor = await connect()
+
+    monitor.write(commandFrame('MONITOR'))
+    assert.deepStrictEqual(await monitor.readRawFrame(), Buffer.from('+OK\r\n'))
+
+    monitor.write(commandFrame('RESET'))
+    assert.deepStrictEqual(
+      await readMonitorReply(monitor),
+      Buffer.from('+RESET\r\n'),
+    )
+
+    // Back in normal mode: a command on this connection still works.
+    monitor.write(commandFrame('PING'))
+    assert.deepStrictEqual(
+      await readMonitorReply(monitor),
+      Buffer.from('+PONG\r\n'),
+    )
+  })
 })
+
+/**
+ * Read the next command reply on a monitoring connection, skipping any monitor
+ * feed lines that interleave with it. Feed lines are simple strings beginning
+ * with a timestamp (`+<digits>.<digits> [...]`), so a reply is any frame whose
+ * second byte is not a digit. Times out instead of hanging forever so a blocked
+ * frame loop surfaces as a test failure rather than a stuck process.
+ */
+async function readMonitorReply(
+  connection: RawRedisConnection,
+): Promise<Buffer> {
+  for (let i = 0; i < 32; i++) {
+    const raw = await withTimeout(
+      connection.readRawFrame(),
+      2000,
+      'monitor connection reply',
+    )
+    if (raw[0] === PLUS && raw[1] >= ZERO && raw[1] <= NINE) {
+      continue
+    }
+    return raw
+  }
+  assert.fail('no non-monitor reply arrived on the monitoring connection')
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      setTimeout(
+        () => reject(new Error(`timed out waiting for ${label}`)),
+        ms,
+      ).unref()
+    }),
+  ])
+}
+
+const PLUS = '+'.charCodeAt(0)
+const ZERO = '0'.charCodeAt(0)
+const NINE = '9'.charCodeAt(0)
 
 function assertMonitorLine(
   line: string,


### PR DESCRIPTION
## Summary
- `Resp2SessionAdapter.writeExecutorResult` drained a `ResponseStream` to completion **inline**, so `run()`'s frame loop never read the next frame. A long-lived stream (`MONITOR`, future `SUBSCRIBE`) froze the connection — it could no longer send `UNSUBSCRIBE`/`PING`/`RESET`/anything on the same socket.
- Root cause: `for await (...result.frames())` inside `handleFrame` blocks the read loop until the stream closes.
- Fix: spawn the stream drain as a **background task** multiplexed onto the existing `writeChain`, while `run()` keeps reading and dispatching subsequent frames. Active drains are tracked and awaited in `run()`'s `finally`; `session.close()` (`resetResponseStreams`) and `RESET` already abort the streams, so the tasks settle cleanly on disconnect/close.

Closes #126

## Test plan
- [x] New raw-TCP tests in `tests-integration/raw-tcp/monitor-protocol.test.ts`: a `MONITOR` connection can still issue `PING` (and a 2nd command), and `RESET` exits monitor mode — both reproduce the freeze (red on mock before the fix; the existing-loop block surfaces as a 2s timeout).
- [x] Both new tests pass against **real Redis** (`REDIS_STANDALONE_PORT=6399`) — confirms the freeze was our bug, matching real Redis (monitoring client stays usable, `RESET` → `+RESET`).
- [x] Fix makes both tests pass on mock too.
- [x] `npm run test:all` passes — unit 155/155, mock integration 448/448, real integration 448/448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)