### PR TITLE
fix: honor park request in MULTI/EXEC non-blocking override (#127)

### DIFF
--- a/src/core/client-session.ts
+++ b/src/core/client-session.ts
@@ -2,6 +2,7 @@ import type { CommandPlan } from './command-definition'
 import { CommandExecutor, type ExecutorResult } from './command-executor'
 import {
   createDefaultParkHandler,
+  createNonBlockingParkHandler,
   type ClientSessionMode,
   type ParkHandler,
   type ParkRequest,
@@ -273,8 +274,13 @@ export class ClientSession implements RedisClientSession {
     // Blocking commands must not park while the EXEC turn is held — that would
     // deadlock because no other session could produce the wakeup write. Override
     // park so any blocking command queued in MULTI behaves non-blocking (returns
-    // null immediately), matching real Redis BLPOP-inside-MULTI semantics.
-    const noBlockCtx = this.createExecutionContext(undefined, async () => null)
+    // null immediately), matching real Redis BLPOP-inside-MULTI semantics. The
+    // handler still consumes the park request (waitFor + abort signal) instead of
+    // discarding it — see createNonBlockingParkHandler.
+    const noBlockCtx = this.createExecutionContext(
+      undefined,
+      createNonBlockingParkHandler(),
+    )
     let currentDbId = this.selectedDatabaseId
 
     for (const plan of plans) {

--- a/src/core/redis-context.ts
+++ b/src/core/redis-context.ts
@@ -122,6 +122,41 @@ export function createNoopParkHandler(): ParkHandler {
   return createDefaultParkHandler()
 }
 
+/**
+ * Park handler for commands replayed inside MULTI/EXEC.
+ *
+ * Blocking commands (BLPOP, BLMOVE, BLMPOP, BZMPOP, XREAD BLOCK, ...) must not
+ * actually block here: real Redis runs them non-blocking inside a transaction
+ * and returns the immediate "nothing happened" result (e.g. BLPOP -> nil). This
+ * resolves `null` straight away — the same timeout sentinel a real park returns
+ * on expiry — so the command takes its non-blocking branch and its `finally`
+ * cleanup (wakeup-subscription teardown) runs.
+ *
+ * Unlike a bare `async () => null`, it still *honors* the park request:
+ *  - it attaches a no-op handler to `request.waitFor`, so a command whose wait
+ *    rejects never surfaces an unhandled promise rejection (mirrors
+ *    {@link createDefaultParkHandler}, which consumes `waitFor`);
+ *  - it rejects with an AbortError if the session signal is already aborted, so
+ *    a transaction aborted mid-EXEC propagates immediately instead of swallowing
+ *    the abort.
+ *
+ * Commands MUST release any wakeup subscription in a `finally` around
+ * `ctx.park(...)`, never by chaining off `waitFor` — a non-blocking park may
+ * resolve without `waitFor` ever settling.
+ */
+export function createNonBlockingParkHandler(): ParkHandler {
+  return request => {
+    // Consume waitFor; we never await its value but a rejection must not leak.
+    request.waitFor.catch(() => {})
+
+    if (request.signal.aborted) {
+      return Promise.reject(createAbortError())
+    }
+
+    return Promise.resolve(null)
+  }
+}
+
 function createAbortError(): Error {
   const err = new Error('The operation was aborted')
   err.name = 'AbortError'

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,7 @@ export {
 export {
   createDefaultParkHandler,
   createNoopParkHandler,
+  createNonBlockingParkHandler,
 } from './core/redis-context'
 export {
   RedisLuaRuntime,

--- a/tests/transaction-noblock-park.test.ts
+++ b/tests/transaction-noblock-park.test.ts
@@ -1,0 +1,156 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import {
+  createNonBlockingParkHandler,
+  defineCommand,
+  RedisResult,
+  RedisValue,
+  t,
+} from '../src'
+import type { RedisDatabase } from '../src'
+import { createRedisSessionHarness } from './core-session-test-helpers'
+
+function buf(...tokens: string[]): Buffer[] {
+  return tokens.map(token => Buffer.from(token))
+}
+
+// Count live per-key mutation-bus listeners on a database. A blocking command
+// subscribes one per key before parking and must release them all; a leak shows
+// up here as a non-zero count after the command finishes (issue #127).
+function keyListenerCount(db: RedisDatabase): number {
+  const map = (
+    db as unknown as {
+      mutations: { keyListeners: Map<string, Set<unknown>> }
+    }
+  ).mutations.keyListeners
+  let total = 0
+  for (const set of map.values()) {
+    total += set.size
+  }
+  return total
+}
+
+// Blocking commands that park when their keys are empty, with an invocation
+// that hits the blocking branch (all keys missing) so each one parks inside EXEC.
+const blockingInvocations: ReadonlyArray<{
+  name: string
+  args: Buffer[]
+}> = [
+  { name: 'blpop', args: buf('blpop', 'nokey', '5') },
+  { name: 'brpop', args: buf('brpop', 'nokey', '5') },
+  { name: 'blmove', args: buf('blmove', 'src', 'dst', 'LEFT', 'RIGHT', '5') },
+  { name: 'blmpop', args: buf('blmpop', '5', '1', 'nokey', 'LEFT') },
+  { name: 'bzmpop', args: buf('bzmpop', '5', '1', 'nokey', 'MIN') },
+  {
+    name: 'xread',
+    args: buf('xread', 'BLOCK', '5000', 'STREAMS', 'nostream', '$'),
+  },
+]
+
+describe('blocking commands queued in MULTI/EXEC leave no listener leak (#127)', () => {
+  for (const { name, args } of blockingInvocations) {
+    test(`${name.toUpperCase()} in MULTI/EXEC unsubscribes its wakeup listeners`, async () => {
+      const { server, session } = createRedisSessionHarness()
+      const db = server.getDatabase(0)
+
+      await session.execute('multi', buf())
+      await session.execute(name, args.slice(1))
+      const result = await session.execute('exec', buf())
+
+      // EXEC must still return a single non-blocking result (not block, not error).
+      assert.strictEqual(result.value.kind, 'array')
+      const items = (result.value as { kind: 'array'; items: RedisValue[] })
+        .items
+      assert.strictEqual(items.length, 1)
+
+      assert.strictEqual(
+        keyListenerCount(db),
+        0,
+        `${name} must release every wakeup subscription after EXEC`,
+      )
+    })
+  }
+})
+
+describe('createNonBlockingParkHandler', () => {
+  test('resolves null (timeout sentinel) when the signal is not aborted', async () => {
+    const handler = createNonBlockingParkHandler()
+    const result = await handler({
+      waitFor: new Promise<true>(() => {}),
+      signal: new AbortController().signal,
+    })
+    assert.strictEqual(result, null)
+  })
+
+  test('rejects with AbortError when the signal is already aborted', async () => {
+    const handler = createNonBlockingParkHandler()
+    const controller = new AbortController()
+    controller.abort()
+    await assert.rejects(
+      handler({
+        waitFor: new Promise<true>(() => {}),
+        signal: controller.signal,
+      }),
+      (err: Error) => err.name === 'AbortError',
+    )
+  })
+
+  test('consumes a rejecting waitFor without emitting an unhandled rejection', async () => {
+    const seen: unknown[] = []
+    const onUnhandled = (reason: unknown) => seen.push(reason)
+    process.on('unhandledRejection', onUnhandled)
+
+    const handler = createNonBlockingParkHandler()
+    const result = await handler({
+      waitFor: Promise.reject(new Error('waitfor-boom')),
+      signal: new AbortController().signal,
+    })
+
+    // Let the rejected promise reach the unhandled-rejection check.
+    await new Promise(resolve => setTimeout(resolve, 50))
+    process.off('unhandledRejection', onUnhandled)
+
+    assert.strictEqual(result, null)
+    assert.strictEqual(seen.length, 0, 'waitFor rejection must be swallowed')
+  })
+})
+
+describe('a custom blocking command with a rejecting waitFor inside MULTI/EXEC (#127)', () => {
+  // A future blocking command whose internal wait rejects must not crash the
+  // process with an unhandled rejection when queued in a transaction.
+  const probeReject = defineCommand({
+    name: 'probereject',
+    schema: t.object({}),
+    flags: ['write', 'noscript'],
+    keys: () => [],
+    execute: async (_args, ctx) => {
+      const woken = await ctx.park({
+        waitFor: Promise.reject(new Error('waitfor-boom')),
+        timeoutMs: undefined,
+        signal: ctx.signal,
+      })
+      return RedisResult.create(
+        RedisValue.bulkString(woken === null ? null : Buffer.from('x')),
+      )
+    },
+  })
+
+  test('EXEC completes without an unhandled rejection', async () => {
+    const seen: unknown[] = []
+    const onUnhandled = (reason: unknown) => seen.push(reason)
+    process.on('unhandledRejection', onUnhandled)
+
+    const { session } = createRedisSessionHarness({
+      extraCommands: [probeReject],
+    })
+    await session.execute('multi', buf())
+    await session.execute('probereject', buf())
+    const result = await session.execute('exec', buf())
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+    process.off('unhandledRejection', onUnhandled)
+
+    assert.strictEqual(result.value.kind, 'array')
+    assert.strictEqual(seen.length, 0, 'override must consume request.waitFor')
+  })
+})


### PR DESCRIPTION
## Summary

`ClientSession.executeTransaction` replayed queued commands with a park override of `async () => null`. This silently **discards the `ParkRequest`**: it never consumes `request.waitFor` and ignores `request.signal`.

- The leak #127 anticipated does **not** actually occur today: every shipped blocking command (`BLPOP`/`BRPOP`/`BLMOVE`/`BLMPOP`/`BZMPOP`/`XREAD BLOCK`) releases its wakeup subscription in a `finally` around `ctx.park(...)`, and the override resolves immediately, so that `finally` always runs. Verified — zero leaked mutation-bus listeners.
- But the override still had two real footguns it should "honor or cancel" per the issue:
  1. a future blocking command whose `waitFor` **rejects** would surface an **unhandled promise rejection** (the default handler consumes `waitFor`; this override didn't);
  2. a transaction **aborted mid-EXEC** at a parking command was swallowed (`null`) instead of propagating the abort.

### Fix
Replace the inline override with a documented `createNonBlockingParkHandler` ([src/core/redis-context.ts](src/core/redis-context.ts)) that:
- resolves `null` immediately — preserves `BLPOP`-in-MULTI → nil semantics and lets each command's `finally` cleanup run;
- attaches a no-op handler to `request.waitFor` (mirrors `createDefaultParkHandler`) so a rejecting wait never leaks;
- rejects with `AbortError` when the session signal is already aborted, so an aborted EXEC propagates immediately.

Wired into [executeTransaction](src/core/client-session.ts) and exported from the package index. No command added/removed; documented MULTI/EXEC behavior is unchanged.

Closes #127

## Test plan
- [x] New `tests/transaction-noblock-park.test.ts`: rejecting-`waitFor` blocking command queued in MULTI/EXEC produces no unhandled rejection — **red** before fix (`async () => null` → 1 unhandled rejection), green after.
- [x] Regression invariant: `BLPOP`/`BRPOP`/`BLMOVE`/`BLMPOP`/`BZMPOP`/`XREAD BLOCK` queued in MULTI/EXEC each leave **0** mutation-bus listeners after EXEC, and EXEC still returns one non-blocking result.
- [x] Direct `createNonBlockingParkHandler` unit tests: resolves null, rejects on pre-aborted signal, swallows rejecting `waitFor`.
- [x] `npm run build`, `npm run lint`, `npm run test:all` (unit + mock + **real** Redis) all pass.

## Note
This is internal/standalone behavior (park handler, mutation-bus internals, injected custom command) with no RESP-wire surface a real client can exercise, so coverage is unit-level per the integration-first guideline; the user-visible `BLPOP`-in-MULTI → nil semantics it preserves match real Redis and remain covered in `tests/commands-blocking.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)