### PR TITLE
feat: publish keyspace notifications to pub/sub channels (#87)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -307,7 +307,7 @@ flowchart LR
     ME --> DT["RedisDataValue<br/>string · hash · list · set · zset · stream"]
     KS -- "emit on write/delete/expire/<br/>persist/evict/flush" --> MB[RedisMutationBus]
 
-    MB -- "global listeners" --> GL["e.g. future keyspace notifications"]
+    MB -- "global listeners" --> KN["KeyspaceNotifier<br/>→ PubSubBroker (keyspace/keyevent)"]
     MB -- "per-key listeners" --> WL["ClientSession WATCH<br/>→ marks session dirty"]
 ```
 
@@ -333,6 +333,12 @@ emitting an `evict` mutation event so `WATCH` observes expiry exactly like a
 real delete. Every mutation (`write`/`delete`/`expire`/`persist`/`evict`/`flush`)
 flows through [`RedisMutationBus.emit`](../src/state/mutation-events.ts#L68),
 which clones values before fan-out so subscribers can never mutate shared state.
+The [`KeyspaceNotifier`](../src/state/keyspace-notifier.ts) subscribes to this
+bus and republishes mutations as Redis keyspace/keyevent notifications through
+the `RedisPubSubBroker` when `notify-keyspace-events` is enabled. Lifecycle
+events (`del`/`expire`/`persist`/`expired`) come straight from the mutation
+type; write event names (`set`/`lpush`/…) come from the active command, which
+the `CommandExecutor` records on the `RedisDatabase` around `execute`.
 In-place collection updates run through a keyspace-owned mutation tracker and
 typed helpers such as `TrackedHashData.setField()` and
 `TrackedListData.trim()`. Dirty tracking is operation-based rather than a

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -91,7 +91,12 @@ surface.
 > There is no real configuration subsystem behind this - values are an
 > in-memory per-server store seeded with plausible defaults (`maxmemory`,
 > `appendonly`, `save`, listpack thresholds, etc.), enough to satisfy client
-> library initialization. `CONFIG SET` does not change server behavior.
+> library initialization. Most parameters are inert: `CONFIG SET` stores the
+> value but does not change server behavior. The exception is
+> `notify-keyspace-events`, which is a real, behavior-driving setting — see
+> [Keyspace notifications](#14-pubsub-commands). Its value is validated and
+> normalized exactly like Redis (e.g. `CONFIG SET ... KEA` reads back as `AKE`;
+> an unknown class character is rejected).
 
 #### DBSIZE
 
@@ -437,6 +442,30 @@ Subscribed connections enforce Redis' restricted command mode: only subscribe,
 unsubscribe, `PING`, `RESET`, and `QUIT` are accepted until all subscriptions
 are removed. Pub/Sub state is process-local to the `RedisServerState` instance;
 cluster-wide fan-out between separate mock cluster nodes is not implemented.
+
+#### Keyspace notifications
+
+Key mutations are published to the standard `__keyspace@<db>__:<key>` (event in
+the message) and `__keyevent@<db>__:<event>` (key in the message) channels when
+enabled via `CONFIG SET notify-keyspace-events <flags>`. The flag string uses
+Redis' class characters (`K`, `E`, `A`, `g`, `$`, `l`, `s`, `h`, `z`, `x`, `e`,
+`t`, `m`, `n`, `d`); it is validated and normalized like real Redis.
+
+- [x] Lifecycle events derived from the keyspace itself: `del`, `expire`,
+      `persist`, and `expired` (fired when a key is lazily evicted on access).
+- [x] Write events named after the originating command, matching real Redis:
+      `set` (and `setnx`/`setex`/`getset`/`mset` → `set`), `incrby`
+      (`incr`/`decr`/`decrby` → `incrby`), `append`, `setrange`, `lpush`/`rpush`
+      (`lpushx`/`rpushx` too), `lpop`, `lset`, `linsert`, `hset`
+      (`hmset`/`hsetnx` → `hset`), `hdel`, `sadd`, `srem`, `spop`, `zadd`,
+      `zincr` (from `ZINCRBY`), `zrem`, `xadd`, etc.
+- [x] `RENAME`/`RENAMENX` emit `rename_from` + `rename_to`; `COPY` emits
+      `copy_to`.
+
+> Known gaps: `SET ... EX`/`SETEX` emit only `set` (real Redis also emits a
+> secondary `expire`); `FLUSHDB`/`FLUSHALL` emit no per-key events; cross-DB
+> `COPY` does not name the destination event. Notifications are process-local to
+> the `RedisServerState`, so they are not delivered across mock cluster nodes.
 
 ## 15. Persistence Commands
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -7,8 +7,13 @@ import {
 } from '../core/redis-error'
 import { RedisResult } from '../core/redis-result'
 import { RedisValue } from '../core/redis-value'
+import { normalizeKeyspaceNotifyConfig } from '../state'
 import { ok } from './helpers'
 import { commandSubcommandInfo } from './introspection'
+
+// Behavior-driving parameters whose authoritative value lives on the server
+// state (not the inert defaults map below), so other subsystems can read them.
+const KEYSPACE_NOTIFY_PARAM = 'notify-keyspace-events'
 
 /**
  * Plausible Redis defaults for the parameters client libraries probe during
@@ -79,9 +84,13 @@ function configGet(
   }
 
   const store = getConfigStore(ctx)
+  // Overlay server-backed params so CONFIG GET reflects their live values.
+  const effective = new Map(store)
+  effective.set(KEYSPACE_NOTIFY_PARAM, ctx.server.notifyKeyspaceEvents)
+
   const patterns = args.map(arg => arg.toString())
   const matched = new Map<string, string>()
-  for (const [name, value] of store) {
+  for (const [name, value] of effective) {
     if (patterns.some(pattern => globMatches(pattern, name))) {
       matched.set(name, value)
     }
@@ -110,6 +119,11 @@ function configSet(
   for (let i = 0; i < args.length; i += 2) {
     const name = args[i].toString().toLowerCase()
     const value = args[i + 1].toString()
+    if (name === KEYSPACE_NOTIFY_PARAM) {
+      // Validate + normalize now so the whole SET aborts before applying any.
+      updates.push([name, normalizeKeyspaceNotifyConfig(value)])
+      continue
+    }
     if (!store.has(name)) {
       throw new RedisCommandError(
         `Unknown option or number of arguments for CONFIG SET - '${args[i].toString()}'`,
@@ -120,6 +134,10 @@ function configSet(
 
   // Validate every parameter before applying any — CONFIG SET is atomic.
   for (const [name, value] of updates) {
+    if (name === KEYSPACE_NOTIFY_PARAM) {
+      ctx.server.notifyKeyspaceEvents = value
+      continue
+    }
     store.set(name, value)
   }
   return ok()

--- a/src/core/command-executor.ts
+++ b/src/core/command-executor.ts
@@ -194,28 +194,37 @@ export class CommandExecutor {
         }
       }
 
-      const rawResult = plan.definition.execute(plan.args, ctx)
+      // Tag the database with the active command so keyspace notifications can
+      // name write events after the originating command. Saved/restored so
+      // nested (Lua redis.call) and parked/interleaved commands stay correct.
+      const prevNotifyCommand = ctx.db.activeNotifyCommand
+      ctx.db.activeNotifyCommand = plan.definition.name
+      try {
+        const rawResult = plan.definition.execute(plan.args, ctx)
 
-      if (isResponseStream(rawResult)) {
-        let finalStream = ensureNonThenableStream(rawResult)
-        for (const policy of this.policies) {
-          finalStream =
-            (await policy.onStream?.(plan, ctx, finalStream)) ?? finalStream
-          finalStream = ensureNonThenableStream(finalStream)
+        if (isResponseStream(rawResult)) {
+          let finalStream = ensureNonThenableStream(rawResult)
+          for (const policy of this.policies) {
+            finalStream =
+              (await policy.onStream?.(plan, ctx, finalStream)) ?? finalStream
+            finalStream = ensureNonThenableStream(finalStream)
+          }
+
+          return finalStream
         }
 
-        return finalStream
+        const result = await rawResult
+
+        let finalResult = result
+        for (const policy of this.policies) {
+          finalResult =
+            (await policy.afterExecute?.(plan, ctx, finalResult)) ?? finalResult
+        }
+
+        return finalResult
+      } finally {
+        ctx.db.activeNotifyCommand = prevNotifyCommand
       }
-
-      const result = await rawResult
-
-      let finalResult = result
-      for (const policy of this.policies) {
-        finalResult =
-          (await policy.afterExecute?.(plan, ctx, finalResult)) ?? finalResult
-      }
-
-      return finalResult
     } catch (err) {
       if (err instanceof RedisCommandError) {
         if (shouldDirtyTransaction(plan, ctx)) {
@@ -272,20 +281,27 @@ export class CommandExecutor {
       }
 
       assertSyncCommandDefinition(plan)
-      const rawResult = plan.definition.execute(plan.args, ctx)
-      const result = assertSyncCommandResult(plan, rawResult)
 
-      let finalResult = result
-      for (const policy of this.policies) {
-        finalResult =
-          assertSyncPolicyResult(
-            policy.name,
-            'afterExecute',
-            policy.afterExecute?.(plan, ctx, finalResult),
-          ) ?? finalResult
+      const prevNotifyCommand = ctx.db.activeNotifyCommand
+      ctx.db.activeNotifyCommand = plan.definition.name
+      try {
+        const rawResult = plan.definition.execute(plan.args, ctx)
+        const result = assertSyncCommandResult(plan, rawResult)
+
+        let finalResult = result
+        for (const policy of this.policies) {
+          finalResult =
+            assertSyncPolicyResult(
+              policy.name,
+              'afterExecute',
+              policy.afterExecute?.(plan, ctx, finalResult),
+            ) ?? finalResult
+        }
+
+        return finalResult
+      } finally {
+        ctx.db.activeNotifyCommand = prevNotifyCommand
       }
-
-      return finalResult
     } catch (err) {
       if (err instanceof RedisCommandError) {
         if (shouldDirtyTransaction(plan, ctx)) {

--- a/src/state/database.ts
+++ b/src/state/database.ts
@@ -46,6 +46,14 @@ export class RedisDatabase {
    * serialization in tests.
    */
   readonly turnQueue: RedisTurnQueue = new SerialTurnQueue()
+  /**
+   * Name of the command currently executing against this database, set by the
+   * CommandExecutor around `definition.execute`. Keyspace notifications read it
+   * to name write events after the originating command (e.g. LPUSH → `lpush`),
+   * which the mutation bus itself does not carry. `null` outside command
+   * execution.
+   */
+  activeNotifyCommand: string | null = null
   private readonly keyspace: RedisKeyspace
 
   constructor(public readonly id: number) {

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -36,6 +36,13 @@ export type { ExpirationState, KeyspaceEntry, SetOptions } from './keyspace'
 export { RedisKeyspace, WrongRedisTypeError } from './keyspace'
 
 export { RedisDatabase } from './database'
+export {
+  KeyspaceNotifier,
+  keyspaceNotifyFlagsToString,
+  normalizeKeyspaceNotifyConfig,
+  parseKeyspaceNotifyFlags,
+  type KeyspaceNotifyFlags,
+} from './keyspace-notifier'
 export { RedisScriptCache } from './script-cache'
 export {
   RedisPubSubBroker,

--- a/src/state/keyspace-notifier.ts
+++ b/src/state/keyspace-notifier.ts
@@ -27,7 +27,8 @@ export type KeyspaceNotifyFlags = {
 }
 
 // The classes that 'A' (NOTIFY_ALL) expands to — everything except the
-// key-miss (m), new-key (n) and module (d) classes, matching Redis.
+// key-miss (m) and new-key (n) classes, matching Redis. Note `module` (d) IS
+// part of 'A': `Ad` collapses to `A`, while `g$lshzxet` (no d) stays expanded.
 const ALL_CLASS_KEYS = [
   'generic',
   'string',
@@ -38,6 +39,7 @@ const ALL_CLASS_KEYS = [
   'expired',
   'evicted',
   'stream',
+  'module',
 ] as const satisfies readonly (keyof KeyspaceNotifyFlags)[]
 
 function emptyFlags(): KeyspaceNotifyFlags {
@@ -124,9 +126,13 @@ export function parseKeyspaceNotifyFlags(value: string): KeyspaceNotifyFlags {
 }
 
 /**
- * Render flags back to Redis' canonical string form. When every class that 'A'
- * covers is set, those classes collapse to a single 'A' (matching Redis'
- * `keyspaceEventsFlagsToString`), e.g. parsing `"KEA"` normalizes to `"AKE"`.
+ * Render flags back to Redis' canonical string form, matching Redis 7.2's
+ * `keyspaceEventsFlagsToString` exactly. When every class 'A' covers
+ * (`g$lshzxetd`) is set they collapse to a single 'A'; otherwise the type
+ * classes (including `d`) plus `n` are emitted, then `K`/`E`, then `m` last.
+ * Note `n` is only emitted when the type classes are NOT collapsed to 'A'
+ * (e.g. `KEn` → `nKE`, but `And` → `A`), while `m` is always emitted last
+ * (e.g. `Adm` → `Am`). Examples: `KEA` → `AKE`, `KEgnd$` → `g$dnKE`.
  */
 export function keyspaceNotifyFlagsToString(
   flags: KeyspaceNotifyFlags,
@@ -144,12 +150,12 @@ export function keyspaceNotifyFlagsToString(
     if (flags.expired) result += 'x'
     if (flags.evicted) result += 'e'
     if (flags.stream) result += 't'
+    if (flags.module) result += 'd'
+    if (flags.newKey) result += 'n'
   }
-  if (flags.keyMiss) result += 'm'
-  if (flags.newKey) result += 'n'
-  if (flags.module) result += 'd'
   if (flags.keyspace) result += 'K'
   if (flags.keyevent) result += 'E'
+  if (flags.keyMiss) result += 'm'
   return result
 }
 
@@ -191,19 +197,17 @@ const WRITE_EVENT_OVERRIDES: Readonly<Record<string, string>> = {
   rename: 'rename_to',
   renamenx: 'rename_to',
   copy: 'copy_to',
-  move: 'move_to',
 }
 
-// Commands that delete a key as part of a rename/move emit a dedicated event
+// Commands that delete a key as part of a rename emit a dedicated event
 // instead of the default `del`.
 const DELETE_EVENT_OVERRIDES: Readonly<Record<string, string>> = {
   rename: 'rename_from',
   renamenx: 'rename_from',
-  move: 'move_from',
 }
 
 // Write events whose class is generic (g) rather than the value's data type.
-const GENERIC_WRITE_COMMANDS = new Set(['rename', 'renamenx', 'copy', 'move'])
+const GENERIC_WRITE_COMMANDS = new Set(['rename', 'renamenx', 'copy'])
 
 function classForType(type: RedisDataValue['type']): NotifyClass {
   switch (type) {

--- a/src/state/keyspace-notifier.ts
+++ b/src/state/keyspace-notifier.ts
@@ -1,0 +1,359 @@
+import type { RedisDataValue } from './data-types'
+import type { RedisMutationEvent } from './mutation-events'
+import type { RedisPubSubBroker } from './pubsub-broker'
+import { RedisCommandError } from '../core/redis-error'
+
+/**
+ * Parsed `notify-keyspace-events` configuration, mirroring Redis' per-class
+ * notification flags. `keyspace`/`keyevent` select the delivery channels
+ * (`__keyspace@<db>__:<key>` / `__keyevent@<db>__:<event>`); the remaining
+ * booleans gate which event classes are published.
+ */
+export type KeyspaceNotifyFlags = {
+  keyspace: boolean // K
+  keyevent: boolean // E
+  generic: boolean // g
+  string: boolean // $
+  list: boolean // l
+  set: boolean // s
+  hash: boolean // h
+  zset: boolean // z
+  expired: boolean // x
+  evicted: boolean // e
+  stream: boolean // t
+  keyMiss: boolean // m
+  newKey: boolean // n
+  module: boolean // d
+}
+
+// The classes that 'A' (NOTIFY_ALL) expands to — everything except the
+// key-miss (m), new-key (n) and module (d) classes, matching Redis.
+const ALL_CLASS_KEYS = [
+  'generic',
+  'string',
+  'list',
+  'set',
+  'hash',
+  'zset',
+  'expired',
+  'evicted',
+  'stream',
+] as const satisfies readonly (keyof KeyspaceNotifyFlags)[]
+
+function emptyFlags(): KeyspaceNotifyFlags {
+  return {
+    keyspace: false,
+    keyevent: false,
+    generic: false,
+    string: false,
+    list: false,
+    set: false,
+    hash: false,
+    zset: false,
+    expired: false,
+    evicted: false,
+    stream: false,
+    keyMiss: false,
+    newKey: false,
+    module: false,
+  }
+}
+
+/**
+ * Parse a raw `notify-keyspace-events` flag string (e.g. `"KEA"`, `"Ex"`) into
+ * structured flags. Throws the exact Redis error on an unrecognized character.
+ */
+export function parseKeyspaceNotifyFlags(value: string): KeyspaceNotifyFlags {
+  const flags = emptyFlags()
+  for (const char of value) {
+    switch (char) {
+      case 'A':
+        for (const key of ALL_CLASS_KEYS) flags[key] = true
+        break
+      case 'K':
+        flags.keyspace = true
+        break
+      case 'E':
+        flags.keyevent = true
+        break
+      case 'g':
+        flags.generic = true
+        break
+      case '$':
+        flags.string = true
+        break
+      case 'l':
+        flags.list = true
+        break
+      case 's':
+        flags.set = true
+        break
+      case 'h':
+        flags.hash = true
+        break
+      case 'z':
+        flags.zset = true
+        break
+      case 'x':
+        flags.expired = true
+        break
+      case 'e':
+        flags.evicted = true
+        break
+      case 't':
+        flags.stream = true
+        break
+      case 'm':
+        flags.keyMiss = true
+        break
+      case 'n':
+        flags.newKey = true
+        break
+      case 'd':
+        flags.module = true
+        break
+      default:
+        throw new RedisCommandError(
+          'CONFIG SET failed (possibly related to argument ' +
+            "'notify-keyspace-events') - Invalid event class character. " +
+            "Use 'Ag$lshzxeKEtmdn'.",
+        )
+    }
+  }
+  return flags
+}
+
+/**
+ * Render flags back to Redis' canonical string form. When every class that 'A'
+ * covers is set, those classes collapse to a single 'A' (matching Redis'
+ * `keyspaceEventsFlagsToString`), e.g. parsing `"KEA"` normalizes to `"AKE"`.
+ */
+export function keyspaceNotifyFlagsToString(
+  flags: KeyspaceNotifyFlags,
+): string {
+  let result = ''
+  if (ALL_CLASS_KEYS.every(key => flags[key])) {
+    result += 'A'
+  } else {
+    if (flags.generic) result += 'g'
+    if (flags.string) result += '$'
+    if (flags.list) result += 'l'
+    if (flags.set) result += 's'
+    if (flags.hash) result += 'h'
+    if (flags.zset) result += 'z'
+    if (flags.expired) result += 'x'
+    if (flags.evicted) result += 'e'
+    if (flags.stream) result += 't'
+  }
+  if (flags.keyMiss) result += 'm'
+  if (flags.newKey) result += 'n'
+  if (flags.module) result += 'd'
+  if (flags.keyspace) result += 'K'
+  if (flags.keyevent) result += 'E'
+  return result
+}
+
+/**
+ * Validate and normalize a `notify-keyspace-events` value for CONFIG SET.
+ * Returns the canonical string; throws {@link RedisCommandError} on bad input.
+ */
+export function normalizeKeyspaceNotifyConfig(value: string): string {
+  return keyspaceNotifyFlagsToString(parseKeyspaceNotifyFlags(value))
+}
+
+type NotifyClass = 'g' | '$' | 'l' | 's' | 'h' | 'z' | 'x' | 'e' | 't'
+
+type ResolvedNotification = {
+  database: number
+  key: Buffer
+  event: string
+  eventClass: NotifyClass
+}
+
+// Commands whose write event name differs from the command name (Redis names
+// notifications after a canonical operation, not the literal command).
+const WRITE_EVENT_OVERRIDES: Readonly<Record<string, string>> = {
+  setnx: 'set',
+  setex: 'set',
+  psetex: 'set',
+  getset: 'set',
+  mset: 'set',
+  msetnx: 'set',
+  incr: 'incrby',
+  incrby: 'incrby',
+  decr: 'incrby',
+  decrby: 'incrby',
+  lpushx: 'lpush',
+  rpushx: 'rpush',
+  hmset: 'hset',
+  hsetnx: 'hset',
+  zincrby: 'zincr',
+  rename: 'rename_to',
+  renamenx: 'rename_to',
+  copy: 'copy_to',
+  move: 'move_to',
+}
+
+// Commands that delete a key as part of a rename/move emit a dedicated event
+// instead of the default `del`.
+const DELETE_EVENT_OVERRIDES: Readonly<Record<string, string>> = {
+  rename: 'rename_from',
+  renamenx: 'rename_from',
+  move: 'move_from',
+}
+
+// Write events whose class is generic (g) rather than the value's data type.
+const GENERIC_WRITE_COMMANDS = new Set(['rename', 'renamenx', 'copy', 'move'])
+
+function classForType(type: RedisDataValue['type']): NotifyClass {
+  switch (type) {
+    case 'string':
+      return '$'
+    case 'list':
+      return 'l'
+    case 'set':
+      return 's'
+    case 'hash':
+      return 'h'
+    case 'zset':
+      return 'z'
+    case 'stream':
+      return 't'
+  }
+}
+
+function classEnabled(
+  flags: KeyspaceNotifyFlags,
+  eventClass: NotifyClass,
+): boolean {
+  switch (eventClass) {
+    case 'g':
+      return flags.generic
+    case '$':
+      return flags.string
+    case 'l':
+      return flags.list
+    case 's':
+      return flags.set
+    case 'h':
+      return flags.hash
+    case 'z':
+      return flags.zset
+    case 'x':
+      return flags.expired
+    case 'e':
+      return flags.evicted
+    case 't':
+      return flags.stream
+  }
+}
+
+/**
+ * Bridges keyspace mutation events to the Pub/Sub broker as Redis keyspace and
+ * keyevent notifications.
+ *
+ * Lifecycle events (`del`, `expire`, `persist`, `expired`) are derived purely
+ * from the mutation type, so they are always correct. Write event names
+ * (`set`, `lpush`, `hset`, ...) depend on the originating command, which the
+ * mutation bus does not carry — so the executor records the active command name
+ * on the database and it is passed in here. Commands that map one logical
+ * operation onto several mutations with special names (RENAME → rename_from /
+ * rename_to) are handled via the override tables above.
+ */
+export class KeyspaceNotifier {
+  constructor(private readonly broker: RedisPubSubBroker) {}
+
+  handle(
+    event: RedisMutationEvent,
+    activeCommand: string | null,
+    rawFlags: string,
+  ): void {
+    if (rawFlags.length === 0) {
+      return
+    }
+
+    const flags = parseKeyspaceNotifyFlags(rawFlags)
+    if (!flags.keyspace && !flags.keyevent) {
+      return
+    }
+
+    const notification = this.resolve(event, activeCommand)
+    if (!notification) {
+      return
+    }
+
+    if (!classEnabled(flags, notification.eventClass)) {
+      return
+    }
+
+    const { database, key, event: name } = notification
+    if (flags.keyspace) {
+      this.broker.publish(
+        Buffer.concat([Buffer.from(`__keyspace@${database}__:`), key]),
+        Buffer.from(name),
+      )
+    }
+    if (flags.keyevent) {
+      this.broker.publish(
+        Buffer.from(`__keyevent@${database}__:${name}`),
+        Buffer.from(key),
+      )
+    }
+  }
+
+  private resolve(
+    event: RedisMutationEvent,
+    activeCommand: string | null,
+  ): ResolvedNotification | null {
+    switch (event.type) {
+      case 'write': {
+        if (!activeCommand) {
+          return null
+        }
+        const name = WRITE_EVENT_OVERRIDES[activeCommand] ?? activeCommand
+        const eventClass = GENERIC_WRITE_COMMANDS.has(activeCommand)
+          ? 'g'
+          : classForType(event.value.type)
+        return {
+          database: event.database,
+          key: event.key,
+          event: name,
+          eventClass,
+        }
+      }
+      case 'delete': {
+        const name =
+          (activeCommand && DELETE_EVENT_OVERRIDES[activeCommand]) ?? 'del'
+        return {
+          database: event.database,
+          key: event.key,
+          event: name,
+          eventClass: 'g',
+        }
+      }
+      case 'expire':
+        return {
+          database: event.database,
+          key: event.key,
+          event: 'expire',
+          eventClass: 'g',
+        }
+      case 'persist':
+        return {
+          database: event.database,
+          key: event.key,
+          event: 'persist',
+          eventClass: 'g',
+        }
+      case 'evict':
+        return {
+          database: event.database,
+          key: event.key,
+          event: 'expired',
+          eventClass: 'x',
+        }
+      case 'flush':
+        return null
+    }
+  }
+}

--- a/src/state/server-state.ts
+++ b/src/state/server-state.ts
@@ -1,5 +1,6 @@
 import { RedisClusterTopology } from './cluster-topology'
 import { RedisDatabase } from './database'
+import { KeyspaceNotifier } from './keyspace-notifier'
 import { RedisMonitorFeed } from './monitor-feed'
 import type { Unsubscribe } from './mutation-events'
 import { RedisPubSubBroker } from './pubsub-broker'
@@ -31,6 +32,12 @@ export class RedisServerState {
   readonly pubsubBroker: RedisPubSubBroker
   readonly clusterTopology: RedisClusterTopology
   readonly requirepass?: string
+  /**
+   * Normalized `notify-keyspace-events` flag string (Redis canonical form, e.g.
+   * `"AKE"`). Empty string disables keyspace notifications. Managed via
+   * CONFIG GET/SET; read by the wired {@link KeyspaceNotifier} on each mutation.
+   */
+  notifyKeyspaceEvents = ''
   private readonly clientSessions = new Set<RedisClientSession>()
   private luaRuntimePromise: Promise<RedisLuaRuntime> | null = null
 
@@ -50,6 +57,20 @@ export class RedisServerState {
     this.pubsubBroker = options?.pubsubBroker ?? new RedisPubSubBroker()
     this.clusterTopology =
       options?.clusterTopology ?? new RedisClusterTopology()
+
+    // Bridge every database's mutation bus to the Pub/Sub broker so key
+    // mutations surface as Redis keyspace/keyevent notifications. The bridge is
+    // always wired; it is a cheap no-op while `notifyKeyspaceEvents` is empty.
+    const notifier = new KeyspaceNotifier(this.pubsubBroker)
+    for (const database of this.databases) {
+      database.subscribe(event =>
+        notifier.handle(
+          event,
+          database.activeNotifyCommand,
+          this.notifyKeyspaceEvents,
+        ),
+      )
+    }
   }
 
   /**

--- a/tests-integration/ioredis/keyspace-notifications-integration.test.ts
+++ b/tests-integration/ioredis/keyspace-notifications-integration.test.ts
@@ -1,0 +1,270 @@
+import { after, before, describe, test } from 'node:test'
+import assert from 'node:assert'
+import { Redis } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+describe(`Keyspace notifications (${testRunner.getBackendName()})`, () => {
+  let port: number
+  const clients: Redis[] = []
+
+  before(async () => {
+    port = await testRunner.setupRawStandalone()
+  })
+
+  after(async () => {
+    for (const client of clients) {
+      client.disconnect()
+    }
+    clients.length = 0
+    await testRunner.cleanup()
+  })
+
+  test('publishes set keyspace and keyevent notifications', async () => {
+    const actor = await connect()
+    const subscriber = await connect()
+    await actor.config('SET', 'notify-keyspace-events', 'KEA')
+    const key = randomKey()
+
+    await subscriber.psubscribe(`__keyspace@0__:*`, `__keyevent@0__:*`)
+    await settle()
+
+    const keyspace = waitForEvent(subscriber, `__keyspace@0__:${key}`, 'set')
+    const keyevent = waitForEvent(subscriber, `__keyevent@0__:set`, key)
+    await actor.set(key, 'v')
+
+    assert.strictEqual(await keyspace, true)
+    assert.strictEqual(await keyevent, true)
+  })
+
+  test('publishes del, expire and persist generic notifications', async () => {
+    const actor = await connect()
+    const subscriber = await connect()
+    await actor.config('SET', 'notify-keyspace-events', 'KEA')
+    const key = randomKey()
+    await actor.set(key, 'v')
+
+    await subscriber.psubscribe(`__keyevent@0__:*`)
+    await settle()
+
+    const expired = waitForEvent(subscriber, `__keyevent@0__:expire`, key)
+    await actor.expire(key, 100)
+    assert.strictEqual(await expired, true)
+
+    const persisted = waitForEvent(subscriber, `__keyevent@0__:persist`, key)
+    await actor.persist(key)
+    assert.strictEqual(await persisted, true)
+
+    const deleted = waitForEvent(subscriber, `__keyevent@0__:del`, key)
+    await actor.del(key)
+    assert.strictEqual(await deleted, true)
+  })
+
+  test('names write events after the originating command', async () => {
+    const actor = await connect()
+    const subscriber = await connect()
+    await actor.config('SET', 'notify-keyspace-events', 'KEA')
+    await subscriber.psubscribe(`__keyevent@0__:*`)
+    await settle()
+
+    const listKey = randomKey()
+    const hashKey = randomKey()
+    const setKey = randomKey()
+    const zsetKey = randomKey()
+    const counterKey = randomKey()
+
+    const lpush = waitForEvent(subscriber, `__keyevent@0__:lpush`, listKey)
+    await actor.lpush(listKey, 'a')
+    assert.strictEqual(await lpush, true)
+
+    const hset = waitForEvent(subscriber, `__keyevent@0__:hset`, hashKey)
+    await actor.hset(hashKey, 'f', 'v')
+    assert.strictEqual(await hset, true)
+
+    const sadd = waitForEvent(subscriber, `__keyevent@0__:sadd`, setKey)
+    await actor.sadd(setKey, 'm')
+    assert.strictEqual(await sadd, true)
+
+    const zadd = waitForEvent(subscriber, `__keyevent@0__:zadd`, zsetKey)
+    await actor.zadd(zsetKey, '1', 'm')
+    assert.strictEqual(await zadd, true)
+
+    // INCR reports as `incrby`, matching real Redis.
+    const incrby = waitForEvent(subscriber, `__keyevent@0__:incrby`, counterKey)
+    await actor.incr(counterKey)
+    assert.strictEqual(await incrby, true)
+  })
+
+  test('publishes expired event when a key lazily expires', async () => {
+    const actor = await connect()
+    const subscriber = await connect()
+    await actor.config('SET', 'notify-keyspace-events', 'KEA')
+    const key = randomKey()
+
+    await subscriber.psubscribe(`__keyevent@0__:*`)
+    await settle()
+
+    const expired = waitForEvent(
+      subscriber,
+      `__keyevent@0__:expired`,
+      key,
+      3000,
+    )
+    await actor.set(key, 'v', 'PX', 50)
+    // Force a read after the TTL so a lazy backend evicts and notifies.
+    await new Promise(resolve => setTimeout(resolve, 120))
+    await actor.get(key)
+
+    assert.strictEqual(await expired, true)
+  })
+
+  test('translates RENAME into rename_from and rename_to', async () => {
+    const actor = await connect()
+    const subscriber = await connect()
+    await actor.config('SET', 'notify-keyspace-events', 'KEA')
+    const src = randomKey()
+    const dst = randomKey()
+    await actor.set(src, 'v')
+
+    await subscriber.psubscribe(`__keyevent@0__:*`)
+    await settle()
+
+    const renameFrom = waitForEvent(
+      subscriber,
+      `__keyevent@0__:rename_from`,
+      src,
+    )
+    const renameTo = waitForEvent(subscriber, `__keyevent@0__:rename_to`, dst)
+    await actor.rename(src, dst)
+
+    assert.strictEqual(await renameFrom, true)
+    assert.strictEqual(await renameTo, true)
+  })
+
+  test('delivers nothing when notify-keyspace-events is disabled', async () => {
+    const actor = await connect()
+    const subscriber = await connect()
+    await actor.config('SET', 'notify-keyspace-events', '')
+    const key = randomKey()
+
+    await subscriber.psubscribe(`__keyspace@0__:*`, `__keyevent@0__:*`)
+    await settle()
+
+    const events = collect(subscriber)
+    await actor.set(key, 'v')
+    await actor.del(key)
+    await new Promise(resolve => setTimeout(resolve, 300))
+
+    assert.deepStrictEqual(events, [])
+  })
+
+  test('gates events by configured class', async () => {
+    const actor = await connect()
+    const subscriber = await connect()
+    // Keyevent channel + expired class only — string `set` must not deliver.
+    await actor.config('SET', 'notify-keyspace-events', 'Ex')
+    const setKey = randomKey()
+    const expiringKey = randomKey()
+
+    await subscriber.psubscribe(`__keyevent@0__:*`)
+    await settle()
+
+    const setEvents = collect(subscriber)
+    await actor.set(setKey, 'v')
+    await new Promise(resolve => setTimeout(resolve, 250))
+    assert.strictEqual(
+      setEvents.some(e => e.channel === `__keyevent@0__:set`),
+      false,
+      'set event must be gated out under class "x"',
+    )
+
+    const expired = waitForEvent(
+      subscriber,
+      `__keyevent@0__:expired`,
+      expiringKey,
+      3000,
+    )
+    await actor.set(expiringKey, 'v', 'PX', 50)
+    await new Promise(resolve => setTimeout(resolve, 120))
+    await actor.get(expiringKey)
+    assert.strictEqual(await expired, true)
+  })
+
+  test('CONFIG normalizes flags and rejects invalid characters', async () => {
+    const actor = await connect()
+
+    await actor.config('SET', 'notify-keyspace-events', 'KEA')
+    assert.deepStrictEqual(
+      await actor.config('GET', 'notify-keyspace-events'),
+      ['notify-keyspace-events', 'AKE'],
+    )
+
+    await actor.config('SET', 'notify-keyspace-events', 'KEg$')
+    assert.deepStrictEqual(
+      await actor.config('GET', 'notify-keyspace-events'),
+      ['notify-keyspace-events', 'g$KE'],
+    )
+
+    await assert.rejects(
+      actor.config('SET', 'notify-keyspace-events', 'Z'),
+      /Invalid event class character/,
+    )
+
+    await actor.config('SET', 'notify-keyspace-events', '')
+  })
+
+  async function connect(): Promise<Redis> {
+    const client = new Redis({ host: '127.0.0.1', port, lazyConnect: true })
+    await client.connect()
+    clients.push(client)
+    return client
+  }
+})
+
+function settle(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 50))
+}
+
+function collect(client: Redis): { channel: string; message: string }[] {
+  const events: { channel: string; message: string }[] = []
+  client.on('pmessage', (_pattern, channel, message) => {
+    events.push({ channel, message })
+  })
+  return events
+}
+
+function waitForEvent(
+  client: Redis,
+  channel: string,
+  message: string,
+  timeout = 1000,
+): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup()
+      reject(new Error(`Timed out waiting for ${channel} = ${message}`))
+    }, timeout)
+
+    const onMessage = (
+      _pattern: string,
+      actualChannel: string,
+      actualMessage: string,
+    ) => {
+      if (actualChannel !== channel || actualMessage !== message) {
+        return
+      }
+
+      cleanup()
+      resolve(true)
+    }
+
+    const cleanup = () => {
+      clearTimeout(timer)
+      client.off('pmessage', onMessage)
+    }
+
+    client.on('pmessage', onMessage)
+  })
+}

--- a/tests/keyspace-notifier.test.ts
+++ b/tests/keyspace-notifier.test.ts
@@ -1,0 +1,71 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import {
+  keyspaceNotifyFlagsToString,
+  normalizeKeyspaceNotifyConfig,
+  parseKeyspaceNotifyFlags,
+} from '../src/state/keyspace-notifier'
+
+describe('keyspace notify flag parsing', () => {
+  test('parses individual class characters', () => {
+    const flags = parseKeyspaceNotifyFlags('KEg$x')
+    assert.strictEqual(flags.keyspace, true)
+    assert.strictEqual(flags.keyevent, true)
+    assert.strictEqual(flags.generic, true)
+    assert.strictEqual(flags.string, true)
+    assert.strictEqual(flags.expired, true)
+    assert.strictEqual(flags.list, false)
+  })
+
+  test("'A' expands to every class except m, n and d", () => {
+    const flags = parseKeyspaceNotifyFlags('A')
+    for (const key of [
+      'generic',
+      'string',
+      'list',
+      'set',
+      'hash',
+      'zset',
+      'expired',
+      'evicted',
+      'stream',
+    ] as const) {
+      assert.strictEqual(flags[key], true, `${key} should be set by A`)
+    }
+    assert.strictEqual(flags.keyMiss, false)
+    assert.strictEqual(flags.newKey, false)
+    assert.strictEqual(flags.module, false)
+  })
+
+  test('rejects an unknown class character with the Redis error', () => {
+    assert.throws(
+      () => parseKeyspaceNotifyFlags('Z'),
+      /Invalid event class character. Use 'Ag\$lshzxeKEtmdn'\./,
+    )
+  })
+})
+
+describe('keyspace notify flag normalization', () => {
+  // Each pair mirrors output observed from a real Redis CONFIG SET/GET probe.
+  const cases: [string, string][] = [
+    ['', ''],
+    ['KEA', 'AKE'],
+    ['AKE', 'AKE'],
+    ['gxE', 'gxE'],
+    ['KEg$', 'g$KE'],
+    ['Elx', 'lxE'],
+    ['KExe', 'xeKE'],
+    ['AKEt', 'AKE'],
+  ]
+
+  for (const [input, expected] of cases) {
+    test(`'${input}' normalizes to '${expected}'`, () => {
+      assert.strictEqual(normalizeKeyspaceNotifyConfig(input), expected)
+    })
+  }
+
+  test('round-trips a parsed value back to canonical form', () => {
+    const flags = parseKeyspaceNotifyFlags('Ex')
+    assert.strictEqual(keyspaceNotifyFlagsToString(flags), 'xE')
+  })
+})

--- a/tests/keyspace-notifier.test.ts
+++ b/tests/keyspace-notifier.test.ts
@@ -17,7 +17,7 @@ describe('keyspace notify flag parsing', () => {
     assert.strictEqual(flags.list, false)
   })
 
-  test("'A' expands to every class except m, n and d", () => {
+  test("'A' expands to every class except m and n (module IS included)", () => {
     const flags = parseKeyspaceNotifyFlags('A')
     for (const key of [
       'generic',
@@ -29,12 +29,12 @@ describe('keyspace notify flag parsing', () => {
       'expired',
       'evicted',
       'stream',
+      'module',
     ] as const) {
       assert.strictEqual(flags[key], true, `${key} should be set by A`)
     }
     assert.strictEqual(flags.keyMiss, false)
     assert.strictEqual(flags.newKey, false)
-    assert.strictEqual(flags.module, false)
   })
 
   test('rejects an unknown class character with the Redis error', () => {
@@ -56,6 +56,18 @@ describe('keyspace notify flag normalization', () => {
     ['Elx', 'lxE'],
     ['KExe', 'xeKE'],
     ['AKEt', 'AKE'],
+    // m / n / d edge cases (module is part of 'A'; n only when not collapsed;
+    // m always last). Verified against redis-server 7.2.14.
+    ['Km', 'Km'],
+    ['KEm', 'KEm'],
+    ['Ad', 'A'],
+    ['g$lshzxet', 'g$lshzxet'],
+    ['g$lshzxetd', 'A'],
+    ['KEn', 'nKE'],
+    ['And', 'A'],
+    ['KEgnd$', 'g$dnKE'],
+    ['Adm', 'Am'],
+    ['dKEmn', 'dnKEm'],
   ]
 
   for (const [input, expected] of cases) {


### PR DESCRIPTION
## Summary
Real Redis publishes keyspace/keyevent notifications on key mutations when `notify-keyspace-events` is configured; the mock's `MutationBus` had no bridge to the `PubSubBroker`, so `__keyspace@<db>__:<key>` / `__keyevent@<db>__:<event>` channels were always empty (silent failure for apps relying on e.g. `expired` cache-invalidation events).

This wires a `KeyspaceNotifier` from each database's mutation bus to the broker:

- **Lifecycle events** (`del`, `expire`, `persist`, `expired`) derive purely from the mutation type — always correct, no command knowledge needed. `expired` fires when a key is lazily evicted on access.
- **Write event names** (`set`, `lpush`, `hset`, `sadd`, `zadd`, `incrby`, `append`, …) are named after the originating command. The mutation bus doesn't carry the command, so the `CommandExecutor` records the active command on the `RedisDatabase` around `execute` (saved/restored for Lua nesting and parked commands). Override table matches real Redis: `INCR`/`DECR` → `incrby`, `LPUSHX` → `lpush`, `ZINCRBY` → `zincr`, `RENAME`/`RENAMENX` → `rename_from`+`rename_to`, `COPY` → `copy_to`.
- **Config** `notify-keyspace-events` lives on `RedisServerState`; `CONFIG GET`/`SET` parse, validate (exact Redis error on bad class char) and normalize the flag string (`KEA` → `AKE`). Class gating (`K`/`E`/`A`/`g`/`$`/`l`/`s`/`h`/`z`/`x`/`e`/`t`/…) matches Redis. No-op commands emit no mutation, hence no notification — matching Redis.

All event names, config normalization, and the invalid-char error were verified against a real Redis instance.

Known gaps (documented in COMMANDS.md): `SETEX`/`SET ... EX` emit only `set` (real Redis also emits a secondary `expire`); cross-DB `COPY` doesn't name the destination event; notifications are process-local to a `RedisServerState`.

Closes #87

## Test plan
- [x] New integration test `tests-integration/ioredis/keyspace-notifications-integration.test.ts` (set/del/expire/persist, type-specific write events, `expired`, RENAME, disabled, class gating, CONFIG normalization)
- [x] Test passes against **real** Redis (proves assertions match ground truth)
- [x] Test passes on **mock** (proves the implementation matches)
- [x] Unit test `tests/keyspace-notifier.test.ts` for flag parse/normalize edge cases
- [x] `npm run test:all` passes (unit 177, mock 456, real 456) + build + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)