### PR TITLE
feat: implement BZPOPMIN and BZPOPMAX (#212)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -302,6 +302,8 @@ with `GT` or `LT`.
 - [x] `ZPOPMAX key [count]` - Remove and return members with the highest scores
 - [x] `ZMPOP numkeys key [key ...] MIN|MAX [COUNT count]` - Pop one or more members from the first non-empty sorted set
 - [x] `BZMPOP timeout numkeys key [key ...] MIN|MAX [COUNT count]` - Blocking multi-key sorted-set pop; returns null on timeout
+- [x] `BZPOPMIN key [key ...] timeout` - Blocking pop of the lowest-score member from the first non-empty sorted set; returns `[key, member, score]` or null on timeout
+- [x] `BZPOPMAX key [key ...] timeout` - Blocking pop of the highest-score member from the first non-empty sorted set; returns `[key, member, score]` or null on timeout
 - [x] `ZSCAN key cursor [MATCH pattern] [COUNT count]` - Incrementally iterate members and scores (see [Scan Family](#10-scan-family))
 - [x] `ZUNIONSTORE destination numkeys key [key ...] [WEIGHTS weight [weight ...]] [AGGREGATE SUM|MIN|MAX]` - Union of sorted sets (or plain sets, scored 1) into destination; empty result deletes destination
 - [x] `ZINTERSTORE destination numkeys key [key ...] [WEIGHTS weight [weight ...]] [AGGREGATE SUM|MIN|MAX]` - Intersection of sorted sets into destination; empty result deletes destination
@@ -313,13 +315,13 @@ with `GT` or `LT`.
 
 #### Notes / gaps vs. real Redis
 
-- Score replies from `ZSCORE`, `ZINCRBY`, `ZRANGE WITHSCORES`, `ZREVRANGE WITHSCORES`, `ZRANGEBYSCORE WITHSCORES`, `ZREVRANGEBYSCORE WITHSCORES`, `ZPOPMIN`, `ZPOPMAX`, `ZMPOP`, `BZMPOP`, and `ZSCAN` serialize infinite scores as `inf` / `-inf`.
+- Score replies from `ZSCORE`, `ZINCRBY`, `ZRANGE WITHSCORES`, `ZREVRANGE WITHSCORES`, `ZRANGEBYSCORE WITHSCORES`, `ZREVRANGEBYSCORE WITHSCORES`, `ZPOPMIN`, `ZPOPMAX`, `ZMPOP`, `BZMPOP`, `BZPOPMIN`, `BZPOPMAX`, and `ZSCAN` serialize infinite scores as `inf` / `-inf`.
 - [ ] `ZREVRANGE` does not support the Redis 6.2+ unified syntax (`BYSCORE`, `BYLEX`, `REV`, `LIMIT offset count`) - `start`/`stop` are always treated as indexes; use `ZRANGE ... REV` instead
 - [ ] `ZRANK`/`ZREVRANK` do not support the Redis 7.2 `WITHSCORE` option
 
 #### Not implemented
 
-- [ ] `ZRANGESTORE` / `BZPOPMIN` / `BZPOPMAX`
+- [ ] `ZRANGESTORE`
 
 ## 9. Stream Commands
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -253,6 +253,8 @@ export {
   zcountCommand,
   zpopminCommand,
   zpopmaxCommand,
+  bzpopminCommand,
+  bzpopmaxCommand,
   zmpopCommand,
   bzmpopCommand,
 } from './zsets'

--- a/src/commands/zsets/index.ts
+++ b/src/commands/zsets/index.ts
@@ -18,7 +18,12 @@ import {
   zremrangebylexCommand,
   zrevrangebylexCommand,
 } from './zrangebylex'
-import { zpopmaxCommand, zpopminCommand } from './zpop'
+import {
+  bzpopmaxCommand,
+  bzpopminCommand,
+  zpopmaxCommand,
+  zpopminCommand,
+} from './zpop'
 import { bzmpopCommand, zmpopCommand } from './zmpop'
 import {
   zdiffCommand,
@@ -53,6 +58,8 @@ export const zsetsCommands = [
   zremrangebylexCommand,
   zpopminCommand,
   zpopmaxCommand,
+  bzpopminCommand,
+  bzpopmaxCommand,
   zmpopCommand,
   bzmpopCommand,
   zunionstoreCommand,
@@ -87,6 +94,8 @@ export {
   zremrangebylexCommand,
   zpopminCommand,
   zpopmaxCommand,
+  bzpopminCommand,
+  bzpopmaxCommand,
   zmpopCommand,
   bzmpopCommand,
   zunionstoreCommand,

--- a/src/commands/zsets/zpop.ts
+++ b/src/commands/zsets/zpop.ts
@@ -1,12 +1,19 @@
 import { defineCommand } from '../../core/command-definition'
 import { t } from '../../core/command-schema'
+import type { RedisExecutionContext } from '../../core/redis-context'
 import {
   PositiveCountError,
+  TimeoutNegativeError,
+  TimeoutNotFloatError,
   WrongNumberOfArgumentsError,
 } from '../../core/redis-error'
+import { RedisResult } from '../../core/redis-result'
 import { RedisValue } from '../../core/redis-value'
+import type { RedisDatabase } from '../../state'
 import { array, scoreBuffer } from '../helpers'
 import { deleteSortedSetIfEmpty, getSortedMembers } from './helpers'
+
+type ZsetPopSide = 'min' | 'max'
 
 function parsePopCountArg(s: string): number {
   if (!/^-?\d+$/.test(s)) {
@@ -88,3 +95,130 @@ export const zpopmaxCommand = defineCommand({
     return array(items)
   },
 })
+
+type BlockingZsetPopArgs = {
+  keys: Buffer[]
+  timeout: number
+}
+
+function parseBlockingZsetPopArgs(
+  input: readonly Buffer[],
+  index: number,
+  commandName: string,
+): BlockingZsetPopArgs {
+  // BZPOPMIN/BZPOPMAX take `key [key ...] timeout` — at least one key plus the
+  // trailing timeout, so fewer than two remaining tokens is an arity error.
+  if (input.length - index < 2) {
+    throw new WrongNumberOfArgumentsError(commandName)
+  }
+
+  const timeout = Number(input[input.length - 1].toString())
+  if (isNaN(timeout)) throw new TimeoutNotFloatError()
+  if (timeout < 0) throw new TimeoutNegativeError()
+
+  const keys = Array.from(input.slice(index, input.length - 1))
+  return { keys, timeout }
+}
+
+// Pops a single min/max member from the first non-empty sorted set among the
+// keys, returning the flat `[key, member, score]` reply BZPOPMIN/BZPOPMAX use
+// (distinct from ZMPOP's nested shape). Throws WRONGTYPE via getSortedSet if a
+// scanned key holds a non-zset value, matching real Redis.
+function tryBlockingZsetPop(
+  keys: readonly Buffer[],
+  side: ZsetPopSide,
+  db: RedisDatabase,
+): RedisResult | null {
+  for (const key of keys) {
+    const zset = db.getSortedSet(key)
+    if (!zset || zset.members.size === 0) continue
+
+    const sorted = getSortedMembers(zset)
+    const entry = side === 'min' ? sorted[0] : sorted[sorted.length - 1]
+
+    db.updateSortedSet(key, z => {
+      z.deleteMember(entry.member)
+    })
+    deleteSortedSetIfEmpty(db, key)
+
+    return RedisResult.create(
+      RedisValue.array([
+        RedisValue.bulkString(key),
+        RedisValue.bulkString(entry.member),
+        RedisValue.bulkString(scoreBuffer(entry.score)),
+      ]),
+    )
+  }
+
+  return null
+}
+
+async function blockingZsetPop(
+  keys: readonly Buffer[],
+  timeoutSecs: number,
+  side: ZsetPopSide,
+  ctx: RedisExecutionContext,
+): Promise<RedisResult> {
+  const timeoutMs =
+    timeoutSecs === 0 ? undefined : Math.ceil(timeoutSecs * 1000)
+  const deadline = timeoutMs !== undefined ? Date.now() + timeoutMs : undefined
+
+  while (true) {
+    const remaining =
+      deadline !== undefined ? Math.max(0, deadline - Date.now()) : undefined
+    if (remaining === 0) return RedisResult.create(RedisValue.nullArray())
+
+    let wake!: (v: true) => void
+    const waitFor = new Promise<true>(resolve => {
+      wake = () => resolve(true)
+    })
+
+    const unsubs = keys.map(key =>
+      ctx.db.subscribeKey(key, event => {
+        if (event.type === 'write') wake(true)
+      }),
+    )
+
+    let woken: boolean | null
+    try {
+      woken = await ctx.park({
+        waitFor,
+        timeoutMs: remaining,
+        signal: ctx.signal,
+      })
+    } finally {
+      for (const unsub of unsubs) {
+        try {
+          unsub()
+        } catch {
+          // ignore errors from individual unsubscribers so all are attempted
+        }
+      }
+    }
+
+    if (woken === null) return RedisResult.create(RedisValue.nullArray())
+
+    const result = tryBlockingZsetPop(keys, side, ctx.db)
+    if (result) return result
+  }
+}
+
+function defineBlockingZsetPop(name: string, side: ZsetPopSide) {
+  return defineCommand({
+    name,
+    schema: t.custom<BlockingZsetPopArgs>((input, index, ctx) => ({
+      value: parseBlockingZsetPopArgs(input, index, ctx.commandName),
+      nextIndex: input.length,
+    })),
+    flags: ['write', 'noscript'],
+    keys: args => args.keys,
+    execute: (args, ctx) => {
+      const immediate = tryBlockingZsetPop(args.keys, side, ctx.db)
+      if (immediate) return immediate
+      return blockingZsetPop(args.keys, args.timeout, side, ctx)
+    },
+  })
+}
+
+export const bzpopminCommand = defineBlockingZsetPop('bzpopmin', 'min')
+export const bzpopmaxCommand = defineBlockingZsetPop('bzpopmax', 'max')

--- a/tests-integration/ioredis/bzpopmin-bzpopmax-integration.test.ts
+++ b/tests-integration/ioredis/bzpopmin-bzpopmax-integration.test.ts
@@ -1,0 +1,189 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { connectToSlotOwner, errorWithMessage, randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+function waitForPark(ms = 80): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe(`BZPOPMIN / BZPOPMAX Integration (${testRunner.getBackendName()})`, () => {
+  let client1: Cluster | undefined
+  let client2: Cluster | undefined
+
+  before(async () => {
+    client1 = await testRunner.setupIoredisCluster()
+    client2 = await testRunner.setupIoredisCluster()
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  test('BZPOPMIN pops the lowest-score member from the first non-empty key', async () => {
+    const tag = `{${randomKey()}}`
+    const empty = `${tag}:empty`
+    const first = `${tag}:first`
+    const second = `${tag}:second`
+
+    try {
+      await client1!.del(empty, first, second)
+      await client1!.zadd(first, 1, 'a', 2, 'b', 3, 'c')
+      await client1!.zadd(second, 10, 'x')
+
+      assert.deepStrictEqual(
+        await client1!.call('BZPOPMIN', empty, first, second, '0'),
+        [first, 'a', '1'],
+      )
+      assert.deepStrictEqual(await client1!.zrange(first, 0, -1), ['b', 'c'])
+      assert.deepStrictEqual(await client1!.zrange(second, 0, -1), ['x'])
+    } finally {
+      await client1!.del(empty, first, second)
+    }
+  })
+
+  test('BZPOPMAX pops the highest-score member and deletes the set when empty', async () => {
+    const tag = `{${randomKey()}}`
+    const zset = `${tag}:zset`
+
+    try {
+      await client1!.del(zset)
+      await client1!.zadd(zset, 1, 'a', 2, 'b')
+
+      assert.deepStrictEqual(await client1!.call('BZPOPMAX', zset, '0'), [
+        zset,
+        'b',
+        '2',
+      ])
+      assert.deepStrictEqual(await client1!.call('BZPOPMAX', zset, '0'), [
+        zset,
+        'a',
+        '1',
+      ])
+      assert.strictEqual(await client1!.exists(zset), 0)
+    } finally {
+      await client1!.del(zset)
+    }
+  })
+
+  test('BZPOPMIN times out and returns null when all keys are empty', async () => {
+    const tag = `{${randomKey()}}`
+    const first = `${tag}:first`
+    const second = `${tag}:second`
+
+    try {
+      await client1!.del(first, second)
+      assert.strictEqual(
+        await client1!.call('BZPOPMIN', first, second, '0.1'),
+        null,
+      )
+    } finally {
+      await client1!.del(first, second)
+    }
+  })
+
+  test('BZPOPMIN blocks then returns when a zadd arrives on a watched key', async () => {
+    const tag = `{${randomKey()}}`
+    const first = `${tag}:first`
+    const second = `${tag}:second`
+
+    try {
+      await client1!.del(first, second)
+
+      const blockPromise = client1!.call('BZPOPMIN', first, second, '5')
+      await waitForPark()
+      await client2!.zadd(second, 7, 'hello')
+
+      assert.deepStrictEqual(await blockPromise, [second, 'hello', '7'])
+      assert.strictEqual(await client1!.exists(second), 0)
+    } finally {
+      await client1!.del(first, second)
+    }
+  })
+
+  test('BZPOPMAX blocks then returns the highest-score member when a zadd arrives', async () => {
+    const tag = `{${randomKey()}}`
+    const zset = `${tag}:zset`
+
+    try {
+      await client1!.del(zset)
+
+      const blockPromise = client1!.call('BZPOPMAX', zset, '5')
+      await waitForPark()
+      await client2!.zadd(zset, 1, 'low', 9, 'high')
+
+      assert.deepStrictEqual(await blockPromise, [zset, 'high', '9'])
+      assert.deepStrictEqual(await client1!.zrange(zset, 0, -1), ['low'])
+    } finally {
+      await client1!.del(zset)
+    }
+  })
+
+  test('BZPOPMIN / BZPOPMAX error paths match Redis', async () => {
+    const tag = `{${randomKey()}}`
+    const zset = `${tag}:zset`
+    const stringKey = `${tag}:string`
+
+    try {
+      await client1!.del(zset, stringKey)
+      await client1!.zadd(zset, 1, 'value')
+      await client1!.set(stringKey, 'not-a-zset')
+
+      await assert.rejects(
+        () => client1!.call('BZPOPMIN'),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'bzpopmin' command",
+        ),
+      )
+      await assert.rejects(
+        () => client1!.call('BZPOPMIN', zset),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'bzpopmin' command",
+        ),
+      )
+      await assert.rejects(
+        () => client1!.call('BZPOPMAX'),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'bzpopmax' command",
+        ),
+      )
+      await assert.rejects(
+        () => client1!.call('BZPOPMIN', zset, '-1'),
+        errorWithMessage('ERR timeout is negative'),
+      )
+      await assert.rejects(
+        () => client1!.call('BZPOPMIN', zset, 'abc'),
+        errorWithMessage('ERR timeout is not a float or out of range'),
+      )
+      await assert.rejects(
+        () => client1!.call('BZPOPMIN', stringKey, '0.1'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+
+      const directClient = await connectToSlotOwner(client1!, zset)
+      try {
+        await assert.rejects(
+          () => directClient.call('BZPOPMIN', zset, 'other-slot-key', '1'),
+          errorWithMessage(
+            "CROSSSLOT Keys in request don't hash to the same slot",
+          ),
+        )
+        await assert.rejects(
+          () => directClient.call('BZPOPMAX', zset, 'other-slot-key', '1'),
+          errorWithMessage(
+            "CROSSSLOT Keys in request don't hash to the same slot",
+          ),
+        )
+      } finally {
+        directClient.disconnect()
+      }
+    } finally {
+      await client1!.del(zset, stringKey)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Implemented `BZPOPMIN key [key ...] timeout` and `BZPOPMAX key [key ...] timeout` — blocking variants of `ZPOPMIN`/`ZPOPMAX`.
- Pops the lowest/highest-score member from the first non-empty sorted set among the given keys, returning the flat `[key, member, score]` reply (score as bulk string, distinct from `ZMPOP`'s nested shape) or null on timeout.
- Timeout `0` blocks indefinitely; a `ZADD` on any watched key unblocks and re-attempts the pop.
- Reuses the existing `park`/`unpark` mechanism in `RedisExecutionContext` (same pattern as `BLPOP`/`BLMOVE`/`BZMPOP`) — implemented in [src/commands/zsets/zpop.ts](src/commands/zsets/zpop.ts), registered via `zsetsCommands`.
- Error handling matches real Redis: arity (`ERR wrong number of arguments`), `ERR timeout is negative`, `ERR timeout is not a float or out of range`, `WRONGTYPE`, and cluster `CROSSSLOT`.

Closes #212

## Test plan
- [x] New test in [tests-integration/ioredis/bzpopmin-bzpopmax-integration.test.ts](tests-integration/ioredis/bzpopmin-bzpopmax-integration.test.ts) reproduces the feature (red before fix — 6/6 failing on mock with unknown command)
- [x] Test passes against real Redis (6/6) — confirms behavior matches real Redis
- [x] Fix makes the test pass on mock too (6/6)
- [x] `npm run test:all` passes (unit 187, mock integration 462, real integration 462)
- [x] `npm run build` + `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)