### PR TITLE
fix: INFO returns empty bulk string for unknown section (#51)

### DIFF
--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -177,7 +177,10 @@ function buildInfo(ctx: RedisExecutionContext, section?: string): string {
   } else if (requestedSection in sectionBuilders) {
     selectedSections = [requestedSection]
   } else {
-    throw new RedisCommandError('Invalid section name')
+    // Real Redis replies with an empty bulk string for an unrecognized
+    // section name rather than an error (clients like ioredis probe with
+    // arbitrary section names during connection setup).
+    return ''
   }
 
   const lines: string[] = []

--- a/tests-integration/ioredis/info-standalone.test.ts
+++ b/tests-integration/ioredis/info-standalone.test.ts
@@ -34,4 +34,25 @@ describe(`INFO command standalone integration (${testRunner.getBackendName()})`,
     assert.match(info, /^master_repl_offset:\d+$/m)
     assert.match(info, /^second_repl_offset:-1$/m)
   })
+
+  test('INFO with an unknown section returns an empty bulk string, not an error', async () => {
+    const info = (await client!.call('INFO', 'nonexistent')) as string
+
+    assert.strictEqual(info, '')
+  })
+
+  test('INFO unknown section is case-insensitive and still returns empty', async () => {
+    const info = (await client!.call('INFO', 'NoSuchSection')) as string
+
+    assert.strictEqual(info, '')
+  })
+
+  test('INFO still serves a known section after an unknown one', async () => {
+    const unknown = (await client!.call('INFO', 'bogus')) as string
+    assert.strictEqual(unknown, '')
+
+    const server = (await client!.call('INFO', 'server')) as string
+    assert.match(server, /^# Server$/m)
+    assert.match(server, /^redis_version:/m)
+  })
 })


### PR DESCRIPTION
## Summary
- `INFO <unknown section>` threw `-ERR Invalid section name`; real Redis 7.x returns an **empty bulk string** (`$0\r\n\r\n`) instead.
- ioredis probes with arbitrary section names during connection setup, so the error broke client startup against the mock.
- Root cause: the `else` branch in `buildInfo` ([src/commands/connection.ts](src/commands/connection.ts)) threw instead of returning `''`.

Closes #51

## Test plan
- [x] New tests in tests-integration/ioredis/info-standalone.test.ts reproduce the bug (red on mock before fix: `ERR Invalid section name`)
- [x] Tests pass against real Redis (mock-only bug confirmed)
- [x] Fix makes the tests pass on mock too
- [x] `npm run test:all` passes (465/465)

🤖 Generated with [Claude Code](https://claude.com/claude-code)