### PR TITLE
fix: HELLO returns NOPROTO for unsupported protocol versions (#67)

### DIFF
--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -1,12 +1,14 @@
 import { defineCommand } from '../core/command-definition'
-import { t } from '../core/command-schema'
+import { isIntegerToken, t } from '../core/command-schema'
 import type {
   RedisClientSession,
   RedisExecutionContext,
 } from '../core/redis-context'
 import {
+  HelloProtocolNotIntegerError,
   NoAuthError,
   NoPasswordConfiguredError,
+  NoProtoError,
   RedisCommandError,
   RedisSyntaxError,
   WrongNumberOfArgumentsError,
@@ -499,10 +501,35 @@ export const clientCommand = defineCommand({
   },
 })
 
+/**
+ * Parse HELLO's protocol-version token. Unlike a generic `t.integer()` field,
+ * an out-of-range-but-valid integer (e.g. `4`, `0`, `-1`) must produce the
+ * protocol-specific `NOPROTO` error rather than the generic `ERR ... out of
+ * range`, and a genuinely non-integer token gets HELLO's own wording for the
+ * `ERR` case — both only discoverable by checking real Redis's wire replies.
+ */
+function parseHelloVersion(token: Buffer): 2 | 3 {
+  const raw = token.toString()
+  if (!isIntegerToken(raw)) {
+    throw new HelloProtocolNotIntegerError()
+  }
+
+  const parsed = Number(raw)
+  if (!Number.isSafeInteger(parsed)) {
+    throw new HelloProtocolNotIntegerError()
+  }
+
+  if (parsed !== 2 && parsed !== 3) {
+    throw new NoProtoError()
+  }
+
+  return parsed
+}
+
 export const helloCommand = defineCommand({
   name: 'hello',
   schema: t.object({
-    version: t.optional(t.integer({ min: 2, max: 3 })),
+    version: t.optional(t.bulk()),
     args: t.variadic(t.bulk()),
   }),
   flags: ['noscript'],
@@ -514,9 +541,7 @@ export const helloCommand = defineCommand({
     const version =
       args.version === undefined
         ? ctx.session.protocolVersion
-        : args.version === 3
-          ? 3
-          : 2
+        : parseHelloVersion(args.version)
     const { pendingName } = parseHelloOptions(ctx, args.args)
 
     // A password-protected server rejects HELLO unless the client is already

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -43,6 +43,20 @@ export class NoAuthError extends RedisCommandError {
   }
 }
 
+/** `HELLO <version>` with a syntactically valid but unsupported protocol version. */
+export class NoProtoError extends RedisCommandError {
+  constructor() {
+    super('unsupported protocol version', 'NOPROTO')
+  }
+}
+
+/** `HELLO <version>` where version is not a valid integer at all. */
+export class HelloProtocolNotIntegerError extends RedisCommandError {
+  constructor() {
+    super('Protocol version is not an integer or out of range')
+  }
+}
+
 export class ExpectedIntegerError extends RedisCommandError {
   constructor() {
     super('value is not an integer or out of range')

--- a/tests-integration/ioredis/connection-integration.test.ts
+++ b/tests-integration/ioredis/connection-integration.test.ts
@@ -114,6 +114,30 @@ describe(`Connection commands integration (${testRunner.getBackendName()})`, () 
     assert.strictEqual(await directClient?.call('CLIENT', 'GETNAME'), name)
   })
 
+  test('HELLO with an unsupported protocol version returns NOPROTO', async () => {
+    await assert.rejects(
+      () => directClient!.call('HELLO', '4') as Promise<unknown>,
+      errorWithMessage('NOPROTO unsupported protocol version'),
+    )
+    await assert.rejects(
+      () => directClient!.call('HELLO', '0') as Promise<unknown>,
+      errorWithMessage('NOPROTO unsupported protocol version'),
+    )
+    await assert.rejects(
+      () => directClient!.call('HELLO', '-1') as Promise<unknown>,
+      errorWithMessage('NOPROTO unsupported protocol version'),
+    )
+  })
+
+  test('HELLO with a non-integer protocol version returns the HELLO-specific ERR', async () => {
+    await assert.rejects(
+      () => directClient!.call('HELLO', 'abc') as Promise<unknown>,
+      errorWithMessage(
+        'ERR Protocol version is not an integer or out of range',
+      ),
+    )
+  })
+
   test('HELLO 3 switches the connection to RESP3 replies', async () => {
     const port = testRunner.getClusterPorts()[0]
     assert.notStrictEqual(port, undefined)


### PR DESCRIPTION
## Summary
- `HELLO`'s protocol-version argument was validated by a generic `t.integer({ min: 2, max: 3 })` schema, so any syntactically valid but unsupported version (e.g. `HELLO 4`, `HELLO 0`, `HELLO -1`) failed schema parsing with the generic `ERR value is not an integer or out of range` before the command's own logic ever ran.
- Client libraries pattern-match the `NOPROTO` error prefix to trigger RESP2 fallback negotiation, so receiving a generic `ERR` broke that downgrade path.
- Fix: parse the version argument as a raw token in `src/commands/connection.ts` and validate it manually — a non-integer token now throws the HELLO-specific `ERR Protocol version is not an integer or out of range` (verified to match real Redis's exact wording), and a valid-but-unsupported integer throws the new `NoProtoError` (`-NOPROTO unsupported protocol version`, also verified against real Redis's wire bytes).
- Added `NoProtoError` and `HelloProtocolNotIntegerError` to `src/core/redis-error.ts` following the existing per-command error-class convention (e.g. `NoAuthError`).

Closes #67

## Test plan
- [x] New integration tests in `tests-integration/ioredis/connection-integration.test.ts` reproduce the bug (red before the fix: both returned the generic `ERR value is not an integer or out of range`)
- [x] Tests pass against real Redis (confirmed `NOPROTO unsupported protocol version` and `ERR Protocol version is not an integer or out of range` wording/wire bytes via `redis-cli`/raw TCP probe against a local Redis 7.2 instance)
- [x] Fix makes the tests pass on mock backend too
- [x] `npm run build`, `npm run lint`, `npm run test:all` (unit + mock integration + real integration) all pass