### PR TITLE
feat: implement SORT and SORT_RO (#204)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -161,6 +161,8 @@ surface.
 - [x] `COPY source destination [DB destination-db] [REPLACE]` - Copy a key's value (and TTL) to a destination, optionally into another database; returns `0` if the destination exists without `REPLACE`
 - [x] `KEYS pattern` - Find all keys matching a glob pattern
 - [x] `SCAN cursor [MATCH pattern] [COUNT count] [TYPE type]` - Incrementally iterate the keyspace (see [Scan Family](#10-scan-family))
+- [x] `SORT key [LIMIT offset count] [ASC | DESC] [ALPHA] [STORE destination]` - Sort a list, set, or zset (zset sorted by member value, not score); numeric by default, `ALPHA` for lexicographic; `STORE` writes the result to a destination list and returns its length
+- [x] `SORT_RO key [LIMIT offset count] [ASC | DESC] [ALPHA]` - Read-only variant of `SORT`; rejects `STORE`
 
 #### Expiration
 
@@ -177,12 +179,16 @@ surface.
 `NX`, `GT`, and `LT` follow Redis' mutual-exclusion rules; `XX` can be combined
 with `GT` or `LT`.
 
+#### Notes / gaps vs. real Redis
+
+- `SORT` / `SORT_RO` do not support the `BY` or `GET` external-key pattern
+  dereference — passing either yields a syntax error (tracked as a follow-up)
+
 #### Not implemented
 
 - [ ] `OBJECT ENCODING|REFCOUNT|IDLETIME|FREQ|HELP`
 - [ ] `MOVE`
 - [ ] `DUMP` / `RESTORE`
-- [ ] `SORT` / `SORT_RO`
 - [ ] `WAIT`
 - [ ] `MIGRATE`
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -131,6 +131,8 @@ export {
   randomkeyCommand,
   renameCommand,
   renamenxCommand,
+  sortCommand,
+  sortRoCommand,
   touchCommand,
   ttlCommand,
   typeCommand,

--- a/src/commands/keys.ts
+++ b/src/commands/keys.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from '../core/command-definition'
-import { t } from '../core/command-schema'
+import { t, type ParseContext } from '../core/command-schema'
 import {
   DbIndexOutOfRangeError,
   ExpireGtLtConflictError,
@@ -8,13 +8,19 @@ import {
   NoSuchKeyError,
   RedisSyntaxError,
   SameObjectError,
+  SortScoreNotDoubleError,
   UnsupportedOptionError,
+  WrongNumberOfArgumentsError,
+  WrongTypeRedisError,
 } from '../core/redis-error'
+import { RedisValue } from '../core/redis-value'
 import type { ExpirationState, RedisDatabase } from '../state'
 import {
+  array,
   bulk,
   integer,
   ok,
+  parseIntegerToken,
   simpleString,
   ttlMilliseconds,
   ttlSeconds,
@@ -516,6 +522,168 @@ export const copyCommand = defineCommand({
   },
 })
 
+// SORT key [LIMIT offset count] [ASC | DESC] [ALPHA] [STORE destination]
+// Sorts the elements of a list, set, or zset (zset is sorted by member value,
+// not score). Numeric by default — every element must parse as a double, or
+// the command errors; ALPHA switches to a byte-wise lexicographic sort. STORE
+// writes the sorted result to a destination list and replies with its length.
+// BY/GET external-key pattern dereference is intentionally not implemented yet
+// (tracked as a follow-up); passing either yields a syntax error.
+type SortArgs = {
+  key: Buffer
+  desc: boolean
+  alpha: boolean
+  limit?: { offset: number; count: number }
+  store?: Buffer
+}
+
+function parseSort(
+  input: readonly Buffer[],
+  index: number,
+  ctx: ParseContext,
+  allowStore: boolean,
+): SortArgs {
+  const key = input[index]
+  if (!key) throw new WrongNumberOfArgumentsError(ctx.commandName)
+
+  let cursor = index + 1
+  let desc = false
+  let alpha = false
+  let limit: { offset: number; count: number } | undefined
+  let store: Buffer | undefined
+
+  while (cursor < input.length) {
+    const option = input[cursor]!.toString().toUpperCase()
+
+    if (option === 'ASC') {
+      desc = false
+      cursor++
+      continue
+    }
+
+    if (option === 'DESC') {
+      desc = true
+      cursor++
+      continue
+    }
+
+    if (option === 'ALPHA') {
+      alpha = true
+      cursor++
+      continue
+    }
+
+    if (option === 'LIMIT') {
+      const offsetToken = input[cursor + 1]
+      const countToken = input[cursor + 2]
+      if (!offsetToken || !countToken) throw new RedisSyntaxError()
+      limit = {
+        offset: parseIntegerToken(offsetToken),
+        count: parseIntegerToken(countToken),
+      }
+      cursor += 3
+      continue
+    }
+
+    if (allowStore && option === 'STORE') {
+      const destination = input[cursor + 1]
+      if (!destination) throw new RedisSyntaxError()
+      store = destination
+      cursor += 2
+      continue
+    }
+
+    throw new RedisSyntaxError()
+  }
+
+  return { key, desc, alpha, limit, store }
+}
+
+function sortSchema(allowStore: boolean) {
+  return t.custom<SortArgs>((input, index, ctx) => ({
+    value: parseSort(input, index, ctx, allowStore),
+    nextIndex: input.length,
+  }))
+}
+
+function readSortSource(db: RedisDatabase, key: Buffer): Buffer[] {
+  const type = db.getType(key)
+  if (type === null) return []
+  if (type === 'list') return db.getList(key)!.values
+  if (type === 'set') return Array.from(db.getSet(key)!.members.values())
+  if (type === 'zset') {
+    return Array.from(db.getSortedSet(key)!.members.values(), m => m.member)
+  }
+  throw new WrongTypeRedisError()
+}
+
+function sortNumericScore(element: Buffer): number {
+  // Redis converts every element with strtod; an empty string becomes 0, and
+  // anything that does not parse as a double aborts the whole command.
+  const value = Number(element.toString())
+  if (Number.isNaN(value)) throw new SortScoreNotDoubleError()
+  return value
+}
+
+function sortElements(elements: readonly Buffer[], args: SortArgs): Buffer[] {
+  if (args.alpha) {
+    const sorted = [...elements].sort((a, b) => Buffer.compare(a, b))
+    if (args.desc) sorted.reverse()
+    return sorted
+  }
+
+  const scored = elements.map(element => ({
+    element,
+    score: sortNumericScore(element),
+  }))
+  scored.sort((a, b) => a.score - b.score)
+  if (args.desc) scored.reverse()
+  return scored.map(entry => entry.element)
+}
+
+function applySortLimit(
+  elements: Buffer[],
+  limit: SortArgs['limit'],
+): Buffer[] {
+  if (!limit) return elements
+  // Redis clamps a negative offset to 0; a negative count means "all remaining".
+  const start = Math.max(0, limit.offset)
+  if (start >= elements.length) return []
+  if (limit.count < 0) return elements.slice(start)
+  return elements.slice(start, start + limit.count)
+}
+
+function runSort(args: SortArgs, db: RedisDatabase) {
+  const source = readSortSource(db, args.key)
+  const sorted = applySortLimit(sortElements(source, args), args.limit)
+
+  if (args.store) {
+    db.delete(args.store)
+    if (sorted.length > 0) {
+      db.updateList(args.store, list => list.pushRight(sorted))
+    }
+    return integer(sorted.length)
+  }
+
+  return array(sorted.map(element => RedisValue.bulkString(element)))
+}
+
+export const sortCommand = defineCommand({
+  name: 'sort',
+  schema: sortSchema(true),
+  flags: ['write', 'denyoom'],
+  keys: args => (args.store ? [args.key, args.store] : [args.key]),
+  execute: (args, ctx) => runSort(args, ctx.db),
+})
+
+export const sortRoCommand = defineCommand({
+  name: 'sort_ro',
+  schema: sortSchema(false),
+  flags: ['readonly'],
+  keys: args => [args.key],
+  execute: (args, ctx) => runSort(args, ctx.db),
+})
+
 export const keysCommands = [
   delCommand,
   unlinkCommand,
@@ -538,6 +706,8 @@ export const keysCommands = [
   renameCommand,
   renamenxCommand,
   copyCommand,
+  sortCommand,
+  sortRoCommand,
 ]
 
 function expireKey(

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -81,6 +81,13 @@ export class IncrByFloatNanOrInfinityError extends RedisCommandError {
   }
 }
 
+/** A non-ALPHA SORT met an element that does not parse as a double. */
+export class SortScoreNotDoubleError extends RedisCommandError {
+  constructor() {
+    super("One or more scores can't be converted into double")
+  }
+}
+
 export class ResultingScoreNaNError extends RedisCommandError {
   constructor() {
     super('resulting score is not a number (NaN)')

--- a/tests-integration/ioredis/sort-integration.test.ts
+++ b/tests-integration/ioredis/sort-integration.test.ts
@@ -1,0 +1,273 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster, Redis } from 'ioredis'
+import { TestRunner } from '../test-config'
+import { connectToSlotOwner, errorWithMessage, randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+describe(`SORT / SORT_RO (${testRunner.getBackendName()})`, () => {
+  let redisClient: Cluster | undefined
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster('sort-integration')
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  // Source key and STORE destination must hash to the same slot, so every test
+  // shares a hash tag and talks to that slot's owner through a prefix-free
+  // directClient.
+  async function withOps(
+    fn: (client: Redis, k: (name: string) => string) => Promise<void>,
+  ): Promise<void> {
+    assert.ok(redisClient)
+    const tag = `{sort:${randomKey()}}`
+    const k = (name: string) => `${tag}:${name}`
+    const directClient = await connectToSlotOwner(redisClient, k('seed'))
+    try {
+      await fn(directClient, k)
+    } finally {
+      directClient.disconnect()
+    }
+  }
+
+  // ------------------------------------------------------------------ numeric
+
+  test('SORT numerically ascending by default', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), '3', '1', '2', '5', '4')
+      assert.deepStrictEqual(await c.call('SORT', k('l')), [
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+      ])
+    })
+  })
+
+  test('SORT DESC reverses numeric order', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), '3', '1', '2')
+      assert.deepStrictEqual(await c.call('SORT', k('l'), 'DESC'), [
+        '3',
+        '2',
+        '1',
+      ])
+    })
+  })
+
+  test('SORT sorts floats numerically', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), '1.5', '1.1', '1.05', '2')
+      assert.deepStrictEqual(await c.call('SORT', k('l')), [
+        '1.05',
+        '1.1',
+        '1.5',
+        '2',
+      ])
+    })
+  })
+
+  test('SORT keeps duplicate list elements', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), '3', '1', '1', '2')
+      assert.deepStrictEqual(await c.call('SORT', k('l')), ['1', '1', '2', '3'])
+    })
+  })
+
+  test('SORT treats an empty-string element as numeric zero', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), '', '2', '1')
+      assert.deepStrictEqual(await c.call('SORT', k('l')), ['', '1', '2'])
+    })
+  })
+
+  // -------------------------------------------------------------------- ALPHA
+
+  test('SORT ALPHA sorts lexicographically', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), 'banana', 'apple', 'cherry')
+      assert.deepStrictEqual(await c.call('SORT', k('l'), 'ALPHA'), [
+        'apple',
+        'banana',
+        'cherry',
+      ])
+    })
+  })
+
+  test('SORT ALPHA DESC reverses lexicographic order', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), 'b', 'a', 'c')
+      assert.deepStrictEqual(await c.call('SORT', k('l'), 'ALPHA', 'DESC'), [
+        'c',
+        'b',
+        'a',
+      ])
+    })
+  })
+
+  test('SORT without ALPHA rejects non-numeric elements', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), 'apple', 'banana')
+      await assert.rejects(
+        () => c.call('SORT', k('l')),
+        errorWithMessage(
+          "ERR One or more scores can't be converted into double",
+        ),
+      )
+    })
+  })
+
+  // -------------------------------------------------------------------- LIMIT
+
+  test('SORT LIMIT offset count paginates', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), '3', '1', '2', '5', '4')
+      assert.deepStrictEqual(await c.call('SORT', k('l'), 'LIMIT', '1', '2'), [
+        '2',
+        '3',
+      ])
+    })
+  })
+
+  test('SORT LIMIT with negative count returns all remaining', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), '3', '1', '2', '5', '4')
+      assert.deepStrictEqual(await c.call('SORT', k('l'), 'LIMIT', '1', '-1'), [
+        '2',
+        '3',
+        '4',
+        '5',
+      ])
+    })
+  })
+
+  test('SORT LIMIT offset past the end returns empty', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), '3', '1', '2')
+      assert.deepStrictEqual(
+        await c.call('SORT', k('l'), 'LIMIT', '10', '5'),
+        [],
+      )
+    })
+  })
+
+  test('SORT LIMIT rejects a non-integer bound', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), '1', '2')
+      await assert.rejects(
+        () => c.call('SORT', k('l'), 'LIMIT', 'a', 'b'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+    })
+  })
+
+  // ------------------------------------------------------------- set / zset
+
+  test('SORT sorts a set numerically', async () => {
+    await withOps(async (c, k) => {
+      await c.sadd(k('s'), '10', '2', '33', '4')
+      assert.deepStrictEqual(await c.call('SORT', k('s')), [
+        '2',
+        '4',
+        '10',
+        '33',
+      ])
+    })
+  })
+
+  test('SORT sorts a zset by member, not score', async () => {
+    await withOps(async (c, k) => {
+      // scores chosen so score-order and member-order disagree
+      await c.zadd(k('z'), '5', '30', '1', '20', '9', '10')
+      assert.deepStrictEqual(await c.call('SORT', k('z')), ['10', '20', '30'])
+    })
+  })
+
+  // -------------------------------------------------------------------- STORE
+
+  test('SORT STORE writes the result as a list and returns its length', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), '3', '1', '2')
+      const n = await c.call('SORT', k('l'), 'STORE', k('dst'))
+      assert.strictEqual(n, 3)
+      assert.strictEqual(await c.call('TYPE', k('dst')), 'list')
+      assert.deepStrictEqual(await c.call('LRANGE', k('dst'), '0', '-1'), [
+        '1',
+        '2',
+        '3',
+      ])
+    })
+  })
+
+  test('SORT STORE with an empty result deletes the destination', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('dst'), 'pre-existing')
+      const n = await c.call('SORT', k('missing'), 'STORE', k('dst'))
+      assert.strictEqual(n, 0)
+      assert.strictEqual(await c.exists(k('dst')), 0)
+    })
+  })
+
+  // --------------------------------------------------------------- edge cases
+
+  test('SORT on a missing key returns an empty array', async () => {
+    await withOps(async (c, k) => {
+      assert.deepStrictEqual(await c.call('SORT', k('missing')), [])
+    })
+  })
+
+  test('SORT against a string key fails with WRONGTYPE', async () => {
+    await withOps(async (c, k) => {
+      await c.set(k('str'), 'hello')
+      await assert.rejects(
+        () => c.call('SORT', k('str')),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+    })
+  })
+
+  test('SORT with no key fails with wrong number of arguments', async () => {
+    await withOps(async c => {
+      await assert.rejects(
+        () => c.call('SORT'),
+        errorWithMessage("ERR wrong number of arguments for 'sort' command"),
+      )
+    })
+  })
+
+  test('SORT with an unknown option fails with a syntax error', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), '1', '2')
+      await assert.rejects(
+        () => c.call('SORT', k('l'), 'FOO'),
+        errorWithMessage('ERR syntax error'),
+      )
+    })
+  })
+
+  // ------------------------------------------------------------------ SORT_RO
+
+  test('SORT_RO sorts like SORT', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), '3', '1', '2')
+      assert.deepStrictEqual(await c.call('SORT_RO', k('l')), ['1', '2', '3'])
+    })
+  })
+
+  test('SORT_RO rejects STORE with a syntax error', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('l'), '1', '2')
+      await assert.rejects(
+        () => c.call('SORT_RO', k('l'), 'STORE', k('dst')),
+        errorWithMessage('ERR syntax error'),
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Implements the `SORT` and `SORT_RO` generic key commands (issue #204).
- `SORT key [LIMIT offset count] [ASC | DESC] [ALPHA] [STORE destination]` — sorts the elements of a list, set, or zset (zset is sorted by **member value**, not score). Numeric by default (every element must parse as a double, else `ERR One or more scores can't be converted into double`); `ALPHA` switches to a byte-wise lexicographic sort.
- `LIMIT` paginates the result — negative offset clamps to `0`, negative count means "all remaining".
- `STORE destination` writes the sorted result to a destination **list** and replies with its length; an empty result deletes the destination.
- `SORT_RO` is the readonly variant (flagged `readonly`) and rejects `STORE` with a syntax error.
- `BY` / `GET` external-key pattern dereference is intentionally deferred to a follow-up (per the issue's acceptance criteria); passing either yields a syntax error.
- Added `SortScoreNotDoubleError`; updated docs/COMMANDS.md.

Closes #204

## Test plan
- [x] New integration test `tests-integration/ioredis/sort-integration.test.ts` reproduces the missing feature (22 subtests red before fix — unknown command)
- [x] Test passes against real Redis (`TEST_BACKEND=real`), confirming the spec matches real Redis (numeric/alpha/desc, LIMIT incl. negative count & clamped offset, set/zset sources, STORE, SORT_RO, error & wrong-type & arity paths)
- [x] Fix makes all 22 subtests pass on mock too
- [x] `npm run build`, `npm run lint`, and `npm run test:all` (unit + mock + real) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)