### PR TITLE
fix: validate CLIENT SETNAME names

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -30,7 +30,7 @@ only a subset of the real Redis syntax, the supported syntax is shown and a
 #### CLIENT
 
 - [x] `CLIENT GETNAME` - Get the connection name
-- [x] `CLIENT SETNAME connection-name` - Set the connection name
+- [x] `CLIENT SETNAME connection-name` - Set the connection name; empty clears it, and non-empty names must contain only printable non-space ASCII bytes
 - [x] `CLIENT SETINFO LIB-NAME|LIB-VER value` - Record client library metadata
 - [x] `CLIENT ID` - Return the connection's ID
 - [x] `CLIENT INFO` - Return a single `key=value` line for the current connection

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -30,6 +30,8 @@ const clientNames = new WeakMap<RedisClientSession, Buffer>()
 const clientLibraryNames = new WeakMap<RedisClientSession, Buffer>()
 const clientLibraryVersions = new WeakMap<RedisClientSession, Buffer>()
 let nextClientId = 1
+const INVALID_CLIENT_NAME_MESSAGE =
+  'Client names cannot contain spaces, newlines or special characters.'
 
 function getClientId(session: RedisClientSession): number {
   const existing = clientIds.get(session)
@@ -40,6 +42,27 @@ function getClientId(session: RedisClientSession): number {
   const id = nextClientId++
   clientIds.set(session, id)
   return id
+}
+
+function assertValidClientName(name: Buffer): void {
+  for (const byte of name) {
+    if (byte >= 0x21 && byte <= 0x7e) {
+      continue
+    }
+
+    throw new RedisCommandError(INVALID_CLIENT_NAME_MESSAGE)
+  }
+}
+
+function setClientName(session: RedisClientSession, name: Buffer): void {
+  assertValidClientName(name)
+
+  if (name.length === 0) {
+    clientNames.delete(session)
+    return
+  }
+
+  clientNames.set(session, name)
 }
 
 function isClusterMode(ctx: RedisExecutionContext): boolean {
@@ -444,7 +467,7 @@ export const clientCommand = defineCommand({
 
     if (subcommand === 'setname') {
       expectArgCount('client|setname', args.args, 1)
-      clientNames.set(ctx.session, args.args[0])
+      setClientName(ctx.session, args.args[0])
       return ok()
     }
 
@@ -553,7 +576,7 @@ export const helloCommand = defineCommand({
     }
 
     if (pendingName !== undefined) {
-      clientNames.set(ctx.session, pendingName)
+      setClientName(ctx.session, pendingName)
     }
 
     ctx.session.setProtocolVersion(version)

--- a/tests-integration/ioredis/connection-integration.test.ts
+++ b/tests-integration/ioredis/connection-integration.test.ts
@@ -17,6 +17,8 @@ import {
 } from '../raw-tcp/raw-connection'
 
 const testRunner = new TestRunner()
+const INVALID_CLIENT_NAME_ERROR =
+  'ERR Client names cannot contain spaces, newlines or special characters.'
 
 describe(`Connection commands integration (${testRunner.getBackendName()})`, () => {
   let redisClient: Cluster | undefined
@@ -64,6 +66,69 @@ describe(`Connection commands integration (${testRunner.getBackendName()})`, () 
 
     const list = (await directClient?.call('CLIENT', 'LIST')) as string
     assert.match(list, new RegExp(`name=${name}`))
+  })
+
+  test('CLIENT SETNAME validates names like Redis', async () => {
+    const validName = `client-${randomKey()}_!~`
+    const invalidNames = [
+      'has space',
+      'line\nbreak',
+      '\u0001control',
+      String.fromCharCode(0x7f),
+      'caf\u00e9',
+    ]
+
+    assert.strictEqual(
+      await directClient?.call('CLIENT', 'SETNAME', validName),
+      'OK',
+    )
+    assert.strictEqual(await directClient?.call('CLIENT', 'GETNAME'), validName)
+
+    for (const invalidName of invalidNames) {
+      await assert.rejects(
+        () =>
+          directClient!.call(
+            'CLIENT',
+            'SETNAME',
+            invalidName,
+          ) as Promise<unknown>,
+        errorWithMessage(INVALID_CLIENT_NAME_ERROR),
+      )
+      assert.strictEqual(
+        await directClient?.call('CLIENT', 'GETNAME'),
+        validName,
+      )
+    }
+
+    assert.strictEqual(await directClient?.call('CLIENT', 'SETNAME', ''), 'OK')
+    assert.strictEqual(await directClient?.call('CLIENT', 'GETNAME'), null)
+  })
+
+  test('HELLO SETNAME validates names like CLIENT SETNAME', async () => {
+    const key = `{hello-setname:${randomKey()}}:probe`
+    const client = await connectToSlotOwner(redisClient!, key)
+    const validName = `hello-${randomKey()}`
+
+    try {
+      const hello = (await client.call(
+        'HELLO',
+        '2',
+        'SETNAME',
+        validName,
+      )) as unknown[]
+
+      assertHelloEntry(hello, 'server', 'redis')
+      assert.strictEqual(await client.call('CLIENT', 'GETNAME'), validName)
+
+      await assert.rejects(
+        () =>
+          client.call('HELLO', '2', 'SETNAME', 'has space') as Promise<unknown>,
+        errorWithMessage(INVALID_CLIENT_NAME_ERROR),
+      )
+      assert.strictEqual(await client.call('CLIENT', 'GETNAME'), validName)
+    } finally {
+      client.disconnect()
+    }
   })
 
   test('CLIENT LIST reports all active clients on the connected node', async () => {


### PR DESCRIPTION
## Summary

- Validate `CLIENT SETNAME` names against Redis-compatible printable non-space ASCII bytes.
- Treat an empty name as clearing the connection name instead of storing an empty bulk string.
- Reuse the same validation for `HELLO ... SETNAME` and document the supported behavior.

## Root Cause

`CLIENT SETNAME` and `HELLO ... SETNAME` wrote the provided bulk argument directly into session state. That accepted spaces, control bytes, DEL, and non-ASCII bytes, and also kept an empty name as `""` instead of clearing it like Redis.

## Validation

- Focused mock integration test failed before the fix for accepted invalid names.
- Focused real integration test passed before the fix, confirming the expected Redis behavior and exact error text.
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/connection-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/connection-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`

Fixes #53
