### PR TITLE
fix: add ZRANGESTORE support

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -292,6 +292,7 @@ with `GT` or `LT`.
 - [x] `ZRANK key member` - Get the index of a member, lowest score first
 - [x] `ZREVRANK key member` - Get the index of a member, highest score first
 - [x] `ZRANGE key min max [BYSCORE | BYLEX] [REV] [LIMIT offset count] [WITHSCORES]` - Return a range of members by index, score, or lexicographic range, optionally reversed
+- [x] `ZRANGESTORE destination source min max [BYSCORE | BYLEX] [REV] [LIMIT offset count]` - Store a `ZRANGE`-style result in destination; empty result deletes destination
 - [x] `ZREVRANGE key start stop [WITHSCORES]` - Return a range of members by index, high to low
 - [x] `ZMSCORE key member [member ...]` - Get the scores of multiple members (nil per missing member)
 - [x] `ZRANDMEMBER key [count [WITHSCORES]]` - Get one or more random members, optionally with their scores
@@ -324,10 +325,6 @@ with `GT` or `LT`.
 - Score replies from `ZSCORE`, `ZINCRBY`, `ZRANGE WITHSCORES`, `ZREVRANGE WITHSCORES`, `ZRANGEBYSCORE WITHSCORES`, `ZREVRANGEBYSCORE WITHSCORES`, `ZPOPMIN`, `ZPOPMAX`, `ZMPOP`, `BZMPOP`, `BZPOPMIN`, `BZPOPMAX`, and `ZSCAN` serialize infinite scores as `inf` / `-inf`.
 - [ ] `ZREVRANGE` does not support the Redis 6.2+ unified syntax (`BYSCORE`, `BYLEX`, `REV`, `LIMIT offset count`) - `start`/`stop` are always treated as indexes; use `ZRANGE ... REV` instead
 - [ ] `ZRANK`/`ZREVRANK` do not support the Redis 7.2 `WITHSCORE` option
-
-#### Not implemented
-
-- [ ] `ZRANGESTORE`
 
 ## 9. Stream Commands
 

--- a/src/commands/zsets/index.ts
+++ b/src/commands/zsets/index.ts
@@ -4,7 +4,7 @@ import { zrankCommand, zrevrankCommand } from './zrank'
 import { zmscoreCommand, zscoreCommand } from './zscore'
 import { zrandmemberCommand } from './zrandmember'
 import { zincrbyCommand } from './zincrby'
-import { zrangeCommand, zrevrangeCommand } from './zrange'
+import { zrangeCommand, zrangestoreCommand, zrevrangeCommand } from './zrange'
 import {
   zcountCommand,
   zrangebyscoreCommand,
@@ -46,6 +46,7 @@ export const zsetsCommands = [
   zrandmemberCommand,
   zincrbyCommand,
   zrangeCommand,
+  zrangestoreCommand,
   zrevrangeCommand,
   zrangebyscoreCommand,
   zrevrangebyscoreCommand,
@@ -82,6 +83,7 @@ export {
   zrandmemberCommand,
   zincrbyCommand,
   zrangeCommand,
+  zrangestoreCommand,
   zrevrangeCommand,
   zrangebyscoreCommand,
   zrevrangebyscoreCommand,

--- a/src/commands/zsets/zrange.ts
+++ b/src/commands/zsets/zrange.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from '../../core/command-definition'
 import { t } from '../../core/command-schema'
+import type { RedisExecutionContext } from '../../core/redis-context'
 import {
   RedisSyntaxError,
   WrongNumberOfArgumentsError,
@@ -8,7 +9,7 @@ import {
 } from '../../core/redis-error'
 import { RedisValue } from '../../core/redis-value'
 import type { RedisSortedSetMember } from '../../state/data-types'
-import { array, scoreBuffer } from '../helpers'
+import { array, integer, scoreBuffer } from '../helpers'
 import {
   applyLexLimit,
   getLexSortedMembers,
@@ -28,14 +29,89 @@ import { parseScoreBoundArg, scoreWithinBounds } from './score'
 // reverse order (max then min), matching ZREVRANGEBYSCORE/ZREVRANGEBYLEX.
 type ZrangeBy = 'index' | 'score' | 'lex'
 
-type ZrangeArgs = {
+type ZrangeSelectionArgs = {
   key: Buffer
   min: Buffer
   max: Buffer
   by: ZrangeBy
   rev: boolean
   limit?: LexLimit
+}
+
+type ZrangeArgs = ZrangeSelectionArgs & {
   withScores: boolean
+}
+
+type ZrangestoreArgs = ZrangeSelectionArgs & {
+  destination: Buffer
+}
+
+type ParsedZrangeOptions = {
+  by: ZrangeBy
+  rev: boolean
+  limit?: LexLimit
+  withScores: boolean
+}
+
+function parseZrangeOptions(
+  input: readonly Buffer[],
+  cursor: number,
+  options: { allowWithScores: boolean },
+): ParsedZrangeOptions {
+  let by: ZrangeBy = 'index'
+  let rev = false
+  let withScores = false
+  let limit: LexLimit | undefined
+
+  while (cursor < input.length) {
+    const option = input[cursor]!.toString().toUpperCase()
+
+    if (option === 'BYSCORE') {
+      if (by === 'lex') throw new RedisSyntaxError()
+      by = 'score'
+      cursor++
+      continue
+    }
+
+    if (option === 'BYLEX') {
+      if (by === 'score') throw new RedisSyntaxError()
+      by = 'lex'
+      cursor++
+      continue
+    }
+
+    if (option === 'REV') {
+      rev = true
+      cursor++
+      continue
+    }
+
+    if (option === 'WITHSCORES') {
+      if (!options.allowWithScores) throw new RedisSyntaxError()
+      withScores = true
+      cursor++
+      continue
+    }
+
+    if (option === 'LIMIT') {
+      const offsetTok = input[cursor + 1]
+      const countTok = input[cursor + 2]
+      if (!offsetTok || !countTok) throw new RedisSyntaxError()
+      limit = {
+        offset: parseLexLimitInt(offsetTok),
+        count: parseLexLimitInt(countTok),
+      }
+      cursor += 3
+      continue
+    }
+
+    throw new RedisSyntaxError()
+  }
+
+  if (limit && by === 'index') throw new ZrangeLimitWithoutByError()
+  if (withScores && by === 'lex') throw new ZrangeWithScoresByLexError()
+
+  return { by, rev, limit, withScores }
 }
 
 function createZrangeSchema() {
@@ -47,64 +123,89 @@ function createZrangeSchema() {
       throw new WrongNumberOfArgumentsError(ctx.commandName)
     }
 
-    let by: ZrangeBy = 'index'
-    let rev = false
-    let withScores = false
-    let limit: LexLimit | undefined
-
-    let cursor = index + 3
-    while (cursor < input.length) {
-      const option = input[cursor]!.toString().toUpperCase()
-
-      if (option === 'BYSCORE') {
-        if (by === 'lex') throw new RedisSyntaxError()
-        by = 'score'
-        cursor++
-        continue
-      }
-
-      if (option === 'BYLEX') {
-        if (by === 'score') throw new RedisSyntaxError()
-        by = 'lex'
-        cursor++
-        continue
-      }
-
-      if (option === 'REV') {
-        rev = true
-        cursor++
-        continue
-      }
-
-      if (option === 'WITHSCORES') {
-        withScores = true
-        cursor++
-        continue
-      }
-
-      if (option === 'LIMIT') {
-        const offsetTok = input[cursor + 1]
-        const countTok = input[cursor + 2]
-        if (!offsetTok || !countTok) throw new RedisSyntaxError()
-        limit = {
-          offset: parseLexLimitInt(offsetTok),
-          count: parseLexLimitInt(countTok),
-        }
-        cursor += 3
-        continue
-      }
-
-      throw new RedisSyntaxError()
-    }
-
-    if (limit && by === 'index') throw new ZrangeLimitWithoutByError()
-    if (withScores && by === 'lex') throw new ZrangeWithScoresByLexError()
-
     return {
-      value: { key, min, max, by, rev, limit, withScores },
+      value: {
+        key,
+        min,
+        max,
+        ...parseZrangeOptions(input, index + 3, { allowWithScores: true }),
+      },
       nextIndex: input.length,
     }
   })
+}
+
+function createZrangestoreSchema() {
+  return t.custom<ZrangestoreArgs>((input, index, ctx) => {
+    const destination = input[index]
+    const key = input[index + 1]
+    const min = input[index + 2]
+    const max = input[index + 3]
+    if (!destination || !key || !min || !max) {
+      throw new WrongNumberOfArgumentsError(ctx.commandName)
+    }
+
+    const { by, rev, limit } = parseZrangeOptions(input, index + 4, {
+      allowWithScores: false,
+    })
+
+    return {
+      value: { destination, key, min, max, by, rev, limit },
+      nextIndex: input.length,
+    }
+  })
+}
+
+function selectZrangeMembers(
+  args: ZrangeSelectionArgs,
+  ctx: RedisExecutionContext,
+): RedisSortedSetMember[] {
+  // With REV the bounds are supplied as `max min`, so swap before parsing.
+  const minTok = args.rev ? args.max : args.min
+  const maxTok = args.rev ? args.min : args.max
+
+  if (args.by === 'index') {
+    // parse index bounds up front so a bad index errors even on a missing key
+    const startIdx = parseLexLimitInt(args.min)
+    const stopIdx = parseLexLimitInt(args.max)
+    const zset = ctx.db.getSortedSet(args.key)
+    if (!zset) return []
+    return sliceByIndex(getSortedMembers(zset), startIdx, stopIdx, args.rev)
+  }
+
+  if (args.by === 'score') {
+    const min = parseScoreBoundArg(minTok.toString())
+    const max = parseScoreBoundArg(maxTok.toString())
+    const zset = ctx.db.getSortedSet(args.key)
+    if (!zset) return []
+    let matched = getSortedMembers(zset).filter(m =>
+      scoreWithinBounds(m.score, min, max),
+    )
+    if (args.rev) matched = matched.reverse()
+    return applyLexLimit(matched, args.limit)
+  }
+
+  // BYLEX
+  const min = parseLexBoundArg(minTok)
+  const max = parseLexBoundArg(maxTok)
+  const zset = ctx.db.getSortedSet(args.key)
+  if (!zset) return []
+  let matched = getLexSortedMembers(zset).filter(m =>
+    lexMemberWithinBounds(m.member, min, max),
+  )
+  if (args.rev) matched = matched.reverse()
+  return applyLexLimit(matched, args.limit)
+}
+
+function buildStoredMembers(
+  members: RedisSortedSetMember[],
+): Map<string, RedisSortedSetMember> {
+  return new Map(
+    members.map(entry => [
+      entry.member.toString('hex'),
+      { member: Buffer.from(entry.member), score: entry.score },
+    ]),
+  )
 }
 
 function buildRangeOutput(
@@ -141,51 +242,29 @@ export const zrangeCommand = defineCommand({
   flags: ['readonly'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    // With REV the bounds are supplied as `max min`, so swap before parsing.
-    const minTok = args.rev ? args.max : args.min
-    const maxTok = args.rev ? args.min : args.max
-
-    if (args.by === 'index') {
-      // parse index bounds up front so a bad index errors even on a missing key
-      const startIdx = parseLexLimitInt(args.min)
-      const stopIdx = parseLexLimitInt(args.max)
-      const zset = ctx.db.getSortedSet(args.key)
-      if (!zset) return array([])
-      const slice = sliceByIndex(
-        getSortedMembers(zset),
-        startIdx,
-        stopIdx,
-        args.rev,
-      )
-      return array(buildRangeOutput(slice, args.withScores))
-    }
-
-    if (args.by === 'score') {
-      const min = parseScoreBoundArg(minTok.toString())
-      const max = parseScoreBoundArg(maxTok.toString())
-      const zset = ctx.db.getSortedSet(args.key)
-      if (!zset) return array([])
-      let matched = getSortedMembers(zset).filter(m =>
-        scoreWithinBounds(m.score, min, max),
-      )
-      if (args.rev) matched = matched.reverse()
-      return array(
-        buildRangeOutput(applyLexLimit(matched, args.limit), args.withScores),
-      )
-    }
-
-    // BYLEX
-    const min = parseLexBoundArg(minTok)
-    const max = parseLexBoundArg(maxTok)
-    const zset = ctx.db.getSortedSet(args.key)
-    if (!zset) return array([])
-    let matched = getLexSortedMembers(zset).filter(m =>
-      lexMemberWithinBounds(m.member, min, max),
-    )
-    if (args.rev) matched = matched.reverse()
     return array(
-      buildRangeOutput(applyLexLimit(matched, args.limit), args.withScores),
+      buildRangeOutput(selectZrangeMembers(args, ctx), args.withScores),
     )
+  },
+})
+
+export const zrangestoreCommand = defineCommand({
+  name: 'zrangestore',
+  schema: createZrangestoreSchema(),
+  flags: ['write'],
+  keys: args => [args.destination, args.key],
+  execute: (args, ctx) => {
+    const members = buildStoredMembers(selectZrangeMembers(args, ctx))
+    if (members.size === 0) {
+      ctx.db.delete(args.destination)
+      return integer(0)
+    }
+
+    ctx.db.delete(args.destination)
+    ctx.db.updateSortedSet(args.destination, zset => {
+      zset.replaceMembers(members, { forceDirty: true })
+    })
+    return integer(members.size)
   },
 })
 

--- a/tests-integration/ioredis/zset-modern-range-integration.test.ts
+++ b/tests-integration/ioredis/zset-modern-range-integration.test.ts
@@ -2,7 +2,7 @@ import { test, describe, before, after } from 'node:test'
 import assert from 'node:assert'
 import { Cluster } from 'ioredis'
 import { TestRunner } from '../test-config'
-import { errorWithMessage, randomKey } from '../utils'
+import { connectToSlotOwner, errorWithMessage, randomKey } from '../utils'
 
 const testRunner = new TestRunner()
 
@@ -382,6 +382,289 @@ describe(`Sorted Set Modern Range / ZMSCORE / ZRANDMEMBER (${testRunner.getBacke
       await redisClient?.zrange(key, '-', '+', 'BYLEX'),
       [],
     )
+  })
+
+  // ---------- ZRANGESTORE ----------
+
+  test('ZRANGESTORE stores an index range and overwrites destination', async () => {
+    const tag = `{zrangestore:${randomKey()}}`
+    const source = `${tag}:source`
+    const destination = `${tag}:destination`
+
+    try {
+      await redisClient?.zadd(source, 1, 'a', 2, 'b', 3, 'c', 4, 'd')
+      await redisClient?.set(destination, 'old-value')
+
+      assert.strictEqual(
+        await redisClient?.call('zrangestore', destination, source, '1', '2'),
+        2,
+      )
+      assert.deepStrictEqual(
+        await redisClient?.zrange(destination, 0, -1, 'WITHSCORES'),
+        ['b', '2', 'c', '3'],
+      )
+      assert.deepStrictEqual(await redisClient?.zrange(source, 0, -1), [
+        'a',
+        'b',
+        'c',
+        'd',
+      ])
+    } finally {
+      await redisClient?.del(source)
+      await redisClient?.del(destination)
+    }
+  })
+
+  test('ZRANGESTORE supports BYSCORE and BYLEX ranges', async () => {
+    const tag = `{zrangestore-ranges:${randomKey()}}`
+    const scoreSource = `${tag}:score-source`
+    const scoreDestination = `${tag}:score-destination`
+    const lexSource = `${tag}:lex-source`
+    const lexDestination = `${tag}:lex-destination`
+
+    try {
+      await redisClient?.zadd(
+        scoreSource,
+        1,
+        'a',
+        2,
+        'b',
+        3,
+        'c',
+        4,
+        'd',
+        5,
+        'e',
+      )
+      assert.strictEqual(
+        await redisClient?.call(
+          'zrangestore',
+          scoreDestination,
+          scoreSource,
+          '5',
+          '2',
+          'BYSCORE',
+          'REV',
+          'LIMIT',
+          '1',
+          '2',
+        ),
+        2,
+      )
+      assert.deepStrictEqual(
+        await redisClient?.zrange(scoreDestination, 0, -1, 'WITHSCORES'),
+        ['c', '3', 'd', '4'],
+      )
+
+      await redisClient?.zadd(lexSource, 0, 'a', 0, 'b', 0, 'c', 0, 'd')
+      assert.strictEqual(
+        await redisClient?.call(
+          'zrangestore',
+          lexDestination,
+          lexSource,
+          '[d',
+          '[b',
+          'BYLEX',
+          'REV',
+          'LIMIT',
+          '0',
+          '2',
+        ),
+        2,
+      )
+      assert.deepStrictEqual(await redisClient?.zrange(lexDestination, 0, -1), [
+        'c',
+        'd',
+      ])
+    } finally {
+      await redisClient?.del(
+        scoreSource,
+        scoreDestination,
+        lexSource,
+        lexDestination,
+      )
+    }
+  })
+
+  test('ZRANGESTORE deletes destination when source is missing or range is empty', async () => {
+    const tag = `{zrangestore-empty:${randomKey()}}`
+    const source = `${tag}:source`
+    const missingSource = `${tag}:missing`
+    const destination = `${tag}:destination`
+
+    try {
+      await redisClient?.zadd(source, 1, 'a')
+      await redisClient?.zadd(destination, 9, 'old')
+      assert.strictEqual(
+        await redisClient?.call(
+          'zrangestore',
+          destination,
+          source,
+          '2',
+          '3',
+          'BYSCORE',
+        ),
+        0,
+      )
+      assert.strictEqual(await redisClient?.exists(destination), 0)
+
+      await redisClient?.zadd(destination, 9, 'old')
+      assert.strictEqual(
+        await redisClient?.call(
+          'zrangestore',
+          destination,
+          missingSource,
+          '0',
+          '-1',
+        ),
+        0,
+      )
+      assert.strictEqual(await redisClient?.exists(destination), 0)
+    } finally {
+      await redisClient?.del(source, missingSource, destination)
+    }
+  })
+
+  test('ZRANGESTORE rejects invalid syntax and wrong-type sources', async () => {
+    const tag = `{zrangestore-errors:${randomKey()}}`
+    const source = `${tag}:source`
+    const destination = `${tag}:destination`
+    const stringSource = `${tag}:string-source`
+
+    try {
+      await redisClient?.zadd(source, 1, 'a', 2, 'b')
+      await redisClient?.set(stringSource, 'not-a-zset')
+
+      await assert.rejects(
+        () =>
+          redisClient?.call(
+            'zrangestore',
+            destination,
+            source,
+            '0',
+            '-1',
+            'LIMIT',
+            '0',
+            '1',
+          ),
+        errorWithMessage(
+          'ERR syntax error, LIMIT is only supported in combination with either BYSCORE or BYLEX',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.call(
+            'zrangestore',
+            destination,
+            source,
+            '0',
+            '-1',
+            'WITHSCORES',
+          ),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.call(
+            'zrangestore',
+            destination,
+            source,
+            '-',
+            '+',
+            'BYSCORE',
+            'BYLEX',
+          ),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => redisClient?.call('zrangestore', destination, source, '(1', '4'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.call(
+            'zrangestore',
+            destination,
+            source,
+            'x',
+            '5',
+            'BYSCORE',
+          ),
+        errorWithMessage('ERR min or max is not a float'),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.call(
+            'zrangestore',
+            destination,
+            source,
+            'a',
+            'c',
+            'BYLEX',
+          ),
+        errorWithMessage('ERR min or max not valid string range item'),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.call(
+            'zrangestore',
+            destination,
+            source,
+            '-inf',
+            '+inf',
+            'BYSCORE',
+            'LIMIT',
+            'a',
+            'b',
+          ),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () => redisClient?.call('zrangestore', destination, source, '0'),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'zrangestore' command",
+        ),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.call(
+            'zrangestore',
+            destination,
+            stringSource,
+            '0',
+            '-1',
+          ),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+    } finally {
+      await redisClient?.del(source, destination, stringSource)
+    }
+  })
+
+  test('ZRANGESTORE rejects destination and source keys from different slots', async () => {
+    const source = `{zrangestore-cross:${randomKey()}}:source`
+    const destination = `zrangestore-cross-destination:${randomKey()}`
+
+    try {
+      await redisClient?.zadd(source, 1, 'a')
+      const directClient = await connectToSlotOwner(redisClient!, source)
+      try {
+        await assert.rejects(
+          () =>
+            directClient.call('zrangestore', destination, source, '0', '-1'),
+          errorWithMessage(
+            "CROSSSLOT Keys in request don't hash to the same slot",
+          ),
+        )
+      } finally {
+        directClient.disconnect()
+      }
+    } finally {
+      await redisClient?.del(source)
+      await redisClient?.del(destination)
+    }
   })
 
   // ---------- modern ZRANGE: error paths ----------


### PR DESCRIPTION
## Summary
- add `ZRANGESTORE destination source min max [BYSCORE | BYLEX] [REV] [LIMIT offset count]`
- reuse the modern `ZRANGE` parser/range selection for index, score, and lex ranges
- overwrite destination keys, delete empty results, and expose destination/source keys for cluster routing
- update sorted-set command documentation

## Root Cause
`ZRANGESTORE` was still unregistered, so Redis-compatible clients received `ERR unknown command` even though the underlying `ZRANGE` range-selection behavior was already implemented.

## Validation
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/zset-modern-range-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/zset-modern-range-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`

Fixes #211