### PR TITLE
Add sharded Pub/Sub commands

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -442,9 +442,8 @@ flags are enforced inside `redis.call`/`redis.pcall`.
 - [x] `SUBSCRIBE` / `UNSUBSCRIBE`
 - [x] `PSUBSCRIBE` / `PUNSUBSCRIBE`
 - [x] `PUBSUB CHANNELS|NUMSUB|NUMPAT`
-- [x] `PUBSUB SHARDCHANNELS|SHARDNUMSUB` - Present for Redis 7 command compatibility; returns empty shard pub/sub state because sharded Pub/Sub subscriptions are not implemented yet.
-
-- [ ] `SSUBSCRIBE` / `SUNSUBSCRIBE` / `SPUBLISH`
+- [x] `SSUBSCRIBE` / `SUNSUBSCRIBE` / `SPUBLISH`
+- [x] `PUBSUB SHARDCHANNELS|SHARDNUMSUB`
 
 Subscribed connections enforce Redis' restricted command mode: only subscribe,
 unsubscribe, `PING`, `RESET`, and `QUIT` are accepted until all subscriptions

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -176,7 +176,10 @@ export {
   pubsubCommand,
   pubsubCommands,
   punsubscribeCommand,
+  spublishCommand,
+  ssubscribeCommand,
   subscribeCommand,
+  sunsubscribeCommand,
   unsubscribeCommand,
 } from './pubsub'
 export {

--- a/src/commands/pubsub.ts
+++ b/src/commands/pubsub.ts
@@ -205,13 +205,7 @@ export const pubsubCommand = defineCommand({
       }),
     ],
   },
-  keys: args => {
-    if (args.subcommand.toLowerCase() === 'shardnumsub') {
-      return args.args
-    }
-
-    return []
-  },
+  keys: () => [],
   execute: (args, ctx) => {
     const subcommand = args.subcommand.toLowerCase()
 

--- a/src/commands/pubsub.ts
+++ b/src/commands/pubsub.ts
@@ -54,6 +54,44 @@ export const unsubscribeCommand = defineCommand({
     framesResult(ctx.session.unsubscribePubSubChannels(args.channels)),
 })
 
+export const ssubscribeCommand = defineCommand({
+  name: 'ssubscribe',
+  schema: t.object({
+    channels: t.variadic(t.key(), { min: 1 }),
+  }),
+  flags: ['pubsub', 'noscript', 'subscribed'],
+  introspection: {
+    arity: -2,
+    flags: ['pubsub', 'noscript', 'loading', 'stale'],
+    firstKey: 1,
+    lastKey: -1,
+    keyStep: 1,
+    categories: ['@pubsub', '@slow'],
+  },
+  keys: args => args.channels,
+  execute: (args, ctx) =>
+    framesResult(ctx.session.subscribePubSubShardChannels(args.channels)),
+})
+
+export const sunsubscribeCommand = defineCommand({
+  name: 'sunsubscribe',
+  schema: t.object({
+    channels: t.variadic(t.key()),
+  }),
+  flags: ['pubsub', 'noscript', 'subscribed'],
+  introspection: {
+    arity: -1,
+    flags: ['pubsub', 'noscript', 'loading', 'stale'],
+    firstKey: 1,
+    lastKey: -1,
+    keyStep: 1,
+    categories: ['@pubsub', '@slow'],
+  },
+  keys: args => args.channels,
+  execute: (args, ctx) =>
+    framesResult(ctx.session.unsubscribePubSubShardChannels(args.channels)),
+})
+
 export const psubscribeCommand = defineCommand({
   name: 'psubscribe',
   schema: t.object({
@@ -112,6 +150,26 @@ export const publishCommand = defineCommand({
     integer(ctx.server.pubsubBroker.publish(args.channel, args.message)),
 })
 
+export const spublishCommand = defineCommand({
+  name: 'spublish',
+  schema: t.object({
+    channel: t.key(),
+    message: t.bulk(),
+  }),
+  flags: ['pubsub', 'fast'],
+  introspection: {
+    arity: 3,
+    flags: ['pubsub', 'loading', 'stale', 'fast'],
+    firstKey: 1,
+    lastKey: 1,
+    keyStep: 1,
+    categories: ['@pubsub', '@fast'],
+  },
+  keys: args => [args.channel],
+  execute: (args, ctx) =>
+    integer(ctx.server.pubsubBroker.spublish(args.channel, args.message)),
+})
+
 export const pubsubCommand = defineCommand({
   name: 'pubsub',
   schema: t.object({
@@ -147,7 +205,13 @@ export const pubsubCommand = defineCommand({
       }),
     ],
   },
-  keys: () => [],
+  keys: args => {
+    if (args.subcommand.toLowerCase() === 'shardnumsub') {
+      return args.args
+    }
+
+    return []
+  },
   execute: (args, ctx) => {
     const subcommand = args.subcommand.toLowerCase()
 
@@ -166,7 +230,10 @@ export const pubsubCommand = defineCommand({
 
     if (subcommand === 'shardchannels') {
       expectPubSubSubcommandMaxArgCount(args.subcommand, args.args, 1)
-      return array([])
+      const channels = ctx.server.pubsubBroker.shardChannelsMatching(
+        args.args[0],
+      )
+      return array(channels.map(channel => RedisValue.bulkString(channel)))
     }
 
     if (subcommand === 'shardnumsub') {
@@ -174,7 +241,9 @@ export const pubsubCommand = defineCommand({
         RedisValue.array(
           args.args.flatMap(channel => [
             RedisValue.bulkString(Buffer.from(channel)),
-            RedisValue.integer(0),
+            RedisValue.integer(
+              ctx.server.pubsubBroker.shardSubscriberCount(channel),
+            ),
           ]),
         ),
       )
@@ -194,9 +263,12 @@ export const pubsubCommand = defineCommand({
 export const pubsubCommands = [
   subscribeCommand,
   unsubscribeCommand,
+  ssubscribeCommand,
+  sunsubscribeCommand,
   psubscribeCommand,
   punsubscribeCommand,
   publishCommand,
+  spublishCommand,
   pubsubCommand,
 ]
 

--- a/src/core/client-session.ts
+++ b/src/core/client-session.ts
@@ -172,12 +172,12 @@ export class ClientSession implements RedisClientSession {
     return this.pubsubPatterns.size
   }
 
+  get pubsubRegularSubscriptionCount(): number {
+    return this.pubsubChannelCount + this.pubsubPatternCount
+  }
+
   get pubsubSubscriptionCount(): number {
-    return (
-      this.pubsubChannelCount +
-      this.pubsubShardChannelCount +
-      this.pubsubPatternCount
-    )
+    return this.pubsubRegularSubscriptionCount + this.pubsubShardChannelCount
   }
 
   setAuthenticated(value: boolean): void {
@@ -432,7 +432,7 @@ export class ClientSession implements RedisClientSession {
       frames.push(
         pubsubFrame('subscribe', [
           RedisValue.bulkString(Buffer.from(channel)),
-          RedisValue.integer(this.pubsubSubscriptionCount),
+          RedisValue.integer(this.pubsubRegularSubscriptionCount),
         ]),
       )
     }
@@ -454,7 +454,7 @@ export class ClientSession implements RedisClientSession {
       return [
         pubsubFrame('unsubscribe', [
           RedisValue.bulkString(null),
-          RedisValue.integer(this.pubsubSubscriptionCount),
+          RedisValue.integer(this.pubsubRegularSubscriptionCount),
         ]),
       ]
     }
@@ -472,7 +472,7 @@ export class ClientSession implements RedisClientSession {
       frames.push(
         pubsubFrame('unsubscribe', [
           RedisValue.bulkString(Buffer.from(channel)),
-          RedisValue.integer(this.pubsubSubscriptionCount),
+          RedisValue.integer(this.pubsubRegularSubscriptionCount),
         ]),
       )
     }
@@ -509,7 +509,7 @@ export class ClientSession implements RedisClientSession {
       frames.push(
         pubsubFrame('ssubscribe', [
           RedisValue.bulkString(Buffer.from(channel)),
-          RedisValue.integer(this.pubsubSubscriptionCount),
+          RedisValue.integer(this.pubsubShardChannelCount),
         ]),
       )
     }
@@ -531,7 +531,7 @@ export class ClientSession implements RedisClientSession {
       return [
         pubsubFrame('sunsubscribe', [
           RedisValue.bulkString(null),
-          RedisValue.integer(this.pubsubSubscriptionCount),
+          RedisValue.integer(this.pubsubShardChannelCount),
         ]),
       ]
     }
@@ -549,7 +549,7 @@ export class ClientSession implements RedisClientSession {
       frames.push(
         pubsubFrame('sunsubscribe', [
           RedisValue.bulkString(Buffer.from(channel)),
-          RedisValue.integer(this.pubsubSubscriptionCount),
+          RedisValue.integer(this.pubsubShardChannelCount),
         ]),
       )
     }
@@ -587,7 +587,7 @@ export class ClientSession implements RedisClientSession {
       frames.push(
         pubsubFrame('psubscribe', [
           RedisValue.bulkString(Buffer.from(pattern)),
-          RedisValue.integer(this.pubsubSubscriptionCount),
+          RedisValue.integer(this.pubsubRegularSubscriptionCount),
         ]),
       )
     }
@@ -609,7 +609,7 @@ export class ClientSession implements RedisClientSession {
       return [
         pubsubFrame('punsubscribe', [
           RedisValue.bulkString(null),
-          RedisValue.integer(this.pubsubSubscriptionCount),
+          RedisValue.integer(this.pubsubRegularSubscriptionCount),
         ]),
       ]
     }
@@ -627,7 +627,7 @@ export class ClientSession implements RedisClientSession {
       frames.push(
         pubsubFrame('punsubscribe', [
           RedisValue.bulkString(Buffer.from(pattern)),
-          RedisValue.integer(this.pubsubSubscriptionCount),
+          RedisValue.integer(this.pubsubRegularSubscriptionCount),
         ]),
       )
     }

--- a/src/core/client-session.ts
+++ b/src/core/client-session.ts
@@ -107,6 +107,7 @@ export class ClientSession implements RedisClientSession {
   /** Subset of watched keys mutated since WATCH — non-empty fails the next EXEC. */
   private readonly dirtyWatches = new Set<string>()
   private readonly pubsubChannels = new Map<string, PubSubRegistration>()
+  private readonly pubsubShardChannels = new Map<string, PubSubRegistration>()
   private readonly pubsubPatterns = new Map<string, PubSubRegistration>()
   private readonly pushQueue: RedisResult[] = []
   private readonly pushWaiters = new Set<() => void>()
@@ -163,12 +164,20 @@ export class ClientSession implements RedisClientSession {
     return this.pubsubChannels.size
   }
 
+  get pubsubShardChannelCount(): number {
+    return this.pubsubShardChannels.size
+  }
+
   get pubsubPatternCount(): number {
     return this.pubsubPatterns.size
   }
 
   get pubsubSubscriptionCount(): number {
-    return this.pubsubChannelCount + this.pubsubPatternCount
+    return (
+      this.pubsubChannelCount +
+      this.pubsubShardChannelCount +
+      this.pubsubPatternCount
+    )
   }
 
   setAuthenticated(value: boolean): void {
@@ -471,6 +480,83 @@ export class ClientSession implements RedisClientSession {
     return frames
   }
 
+  subscribePubSubShardChannels(channels: readonly Buffer[]): RedisResult[] {
+    const frames: RedisResult[] = []
+
+    for (const channel of channels) {
+      const key = pubsubId(channel)
+      if (!this.pubsubShardChannels.has(key)) {
+        const subscribedChannel = Buffer.from(channel)
+        const unsubscribe = this.server.pubsubBroker.ssubscribe(
+          subscribedChannel,
+          message => {
+            this.enqueuePush(
+              pubsubFrame('smessage', [
+                RedisValue.bulkString(Buffer.from(message.channel)),
+                RedisValue.bulkString(Buffer.from(message.message)),
+              ]),
+            )
+          },
+        )
+
+        this.pubsubShardChannels.set(key, {
+          value: subscribedChannel,
+          unsubscribe,
+        })
+      }
+
+      this.refreshPubSubMode()
+      frames.push(
+        pubsubFrame('ssubscribe', [
+          RedisValue.bulkString(Buffer.from(channel)),
+          RedisValue.integer(this.pubsubSubscriptionCount),
+        ]),
+      )
+    }
+
+    return frames
+  }
+
+  unsubscribePubSubShardChannels(channels: readonly Buffer[]): RedisResult[] {
+    const targets =
+      channels.length > 0
+        ? channels
+        : Array.from(
+            this.pubsubShardChannels.values(),
+            entry => entry.value,
+          ).reverse()
+
+    if (targets.length === 0) {
+      this.refreshPubSubMode()
+      return [
+        pubsubFrame('sunsubscribe', [
+          RedisValue.bulkString(null),
+          RedisValue.integer(this.pubsubSubscriptionCount),
+        ]),
+      ]
+    }
+
+    const frames: RedisResult[] = []
+    for (const channel of targets) {
+      const key = pubsubId(channel)
+      const existing = this.pubsubShardChannels.get(key)
+      if (existing) {
+        existing.unsubscribe()
+        this.pubsubShardChannels.delete(key)
+      }
+
+      this.refreshPubSubMode()
+      frames.push(
+        pubsubFrame('sunsubscribe', [
+          RedisValue.bulkString(Buffer.from(channel)),
+          RedisValue.integer(this.pubsubSubscriptionCount),
+        ]),
+      )
+    }
+
+    return frames
+  }
+
   subscribePubSubPatterns(patterns: readonly Buffer[]): RedisResult[] {
     const frames: RedisResult[] = []
 
@@ -553,11 +639,15 @@ export class ClientSession implements RedisClientSession {
     for (const subscription of this.pubsubChannels.values()) {
       subscription.unsubscribe()
     }
+    for (const subscription of this.pubsubShardChannels.values()) {
+      subscription.unsubscribe()
+    }
     for (const subscription of this.pubsubPatterns.values()) {
       subscription.unsubscribe()
     }
 
     this.pubsubChannels.clear()
+    this.pubsubShardChannels.clear()
     this.pubsubPatterns.clear()
     this.refreshPubSubMode()
   }

--- a/src/core/redis-context.ts
+++ b/src/core/redis-context.ts
@@ -52,10 +52,13 @@ export interface RedisClientSession {
   unwatch(): void
   isWatchDirty(): boolean
   readonly pubsubChannelCount: number
+  readonly pubsubShardChannelCount: number
   readonly pubsubPatternCount: number
   readonly pubsubSubscriptionCount: number
   subscribePubSubChannels(channels: readonly Buffer[]): RedisResult[]
   unsubscribePubSubChannels(channels: readonly Buffer[]): RedisResult[]
+  subscribePubSubShardChannels(channels: readonly Buffer[]): RedisResult[]
+  unsubscribePubSubShardChannels(channels: readonly Buffer[]): RedisResult[]
   subscribePubSubPatterns(patterns: readonly Buffer[]): RedisResult[]
   unsubscribePubSubPatterns(patterns: readonly Buffer[]): RedisResult[]
   resetPubSub(): void

--- a/src/state/pubsub-broker.ts
+++ b/src/state/pubsub-broker.ts
@@ -28,6 +28,10 @@ type PatternSubscriber = {
 
 export class RedisPubSubBroker {
   private readonly channels = new Map<string, Map<symbol, ChannelSubscriber>>()
+  private readonly shardChannels = new Map<
+    string,
+    Map<symbol, ChannelSubscriber>
+  >()
   private readonly patterns = new Map<string, Map<symbol, PatternSubscriber>>()
 
   subscribe(
@@ -72,6 +76,27 @@ export class RedisPubSubBroker {
     }
   }
 
+  ssubscribe(
+    channel: Buffer,
+    listener: RedisPubSubMessageListener,
+  ): Unsubscribe {
+    const id = Symbol('shard-channel-subscriber')
+    const key = pubsubKey(channel)
+    let subscribers = this.shardChannels.get(key)
+    if (!subscribers) {
+      subscribers = new Map()
+      this.shardChannels.set(key, subscribers)
+    }
+
+    subscribers.set(id, { channel: Buffer.from(channel), listener })
+    return () => {
+      subscribers?.delete(id)
+      if (subscribers?.size === 0) {
+        this.shardChannels.delete(key)
+      }
+    }
+  }
+
   publish(channel: Buffer, message: Buffer): number {
     let delivered = 0
     const channelSubscribers = this.channels.get(pubsubKey(channel))
@@ -104,6 +129,25 @@ export class RedisPubSubBroker {
     return delivered
   }
 
+  spublish(channel: Buffer, message: Buffer): number {
+    let delivered = 0
+    const channelSubscribers = this.shardChannels.get(pubsubKey(channel))
+
+    if (!channelSubscribers) {
+      return delivered
+    }
+
+    for (const subscriber of Array.from(channelSubscribers.values())) {
+      subscriber.listener({
+        channel: Buffer.from(channel),
+        message: Buffer.from(message),
+      })
+      delivered++
+    }
+
+    return delivered
+  }
+
   channelsMatching(pattern?: Buffer): Buffer[] {
     const channels: Buffer[] = []
 
@@ -123,8 +167,31 @@ export class RedisPubSubBroker {
     return channels
   }
 
+  shardChannelsMatching(pattern?: Buffer): Buffer[] {
+    const channels: Buffer[] = []
+
+    for (const subscribers of this.shardChannels.values()) {
+      const first = subscribers.values().next().value
+      if (!first) {
+        continue
+      }
+
+      if (pattern && !redisGlobMatch(pattern, first.channel)) {
+        continue
+      }
+
+      channels.push(Buffer.from(first.channel))
+    }
+
+    return channels
+  }
+
   subscriberCount(channel: Buffer): number {
     return this.channels.get(pubsubKey(channel))?.size ?? 0
+  }
+
+  shardSubscriberCount(channel: Buffer): number {
+    return this.shardChannels.get(pubsubKey(channel))?.size ?? 0
   }
 
   patternSubscriptionCount(): number {

--- a/tests-integration/ioredis/sharded-pubsub-cluster.test.ts
+++ b/tests-integration/ioredis/sharded-pubsub-cluster.test.ts
@@ -99,6 +99,20 @@ describe(`Sharded Pub/Sub cluster integration (${testRunner.getBackendName()})`,
           "CROSSSLOT Keys in request don't hash to the same slot",
         ),
       )
+
+      assert.deepStrictEqual(
+        await directClient.call('PUBSUB', 'SHARDNUMSUB', remoteChannel),
+        [remoteChannel, 0],
+      )
+      assert.deepStrictEqual(
+        await directClient.call(
+          'PUBSUB',
+          'SHARDNUMSUB',
+          localChannel,
+          remoteChannel,
+        ),
+        [localChannel, 0, remoteChannel, 0],
+      )
     } finally {
       directClient.disconnect()
     }

--- a/tests-integration/ioredis/sharded-pubsub-cluster.test.ts
+++ b/tests-integration/ioredis/sharded-pubsub-cluster.test.ts
@@ -1,0 +1,133 @@
+import { after, before, describe, test } from 'node:test'
+import assert from 'node:assert'
+import { Cluster } from 'ioredis'
+import { TestRunner } from '../test-config'
+import {
+  commandFrame,
+  connectToSlotOwner,
+  errorWithMessage,
+  findSlotOwner,
+  randomKey,
+} from '../utils'
+import {
+  RawRedisConnection,
+  type RespWireValue,
+} from '../raw-tcp/raw-connection'
+
+const testRunner = new TestRunner()
+
+describe(`Sharded Pub/Sub cluster integration (${testRunner.getBackendName()})`, () => {
+  let publisher: Cluster
+  const rawConnections: RawRedisConnection[] = []
+
+  before(async () => {
+    publisher = await testRunner.setupIoredisCluster()
+  })
+
+  after(async () => {
+    for (const connection of rawConnections) {
+      connection.close()
+    }
+    rawConnections.length = 0
+    await testRunner.cleanup()
+  })
+
+  test('routes shard subscriptions and publishes by channel slot', async () => {
+    const channel = `sharded-pubsub:{${randomKey()}}`
+    const [host, port] = await findSlotOwner(publisher, channel)
+    const owner = await connectToSlotOwner(publisher, channel)
+    const subscriber = await RawRedisConnection.connect(host, port)
+    rawConnections.push(subscriber)
+
+    try {
+      subscriber.write(commandFrame('SSUBSCRIBE', channel))
+      assert.deepStrictEqual(normalizeFrame(await subscriber.readFrame()), [
+        'ssubscribe',
+        channel,
+        1,
+      ])
+      assert.deepStrictEqual(
+        await owner.call('PUBSUB', 'SHARDNUMSUB', channel),
+        [channel, 1],
+      )
+
+      const message = subscriber.readFrame()
+      assert.strictEqual(
+        await owner.call('SPUBLISH', channel, 'hello-shard'),
+        1,
+      )
+      assert.deepStrictEqual(normalizeFrame(await message), [
+        'smessage',
+        channel,
+        'hello-shard',
+      ])
+
+      subscriber.write(commandFrame('SUNSUBSCRIBE', channel))
+      assert.deepStrictEqual(normalizeFrame(await subscriber.readFrame()), [
+        'sunsubscribe',
+        channel,
+        0,
+      ])
+      assert.deepStrictEqual(
+        await owner.call('PUBSUB', 'SHARDNUMSUB', channel),
+        [channel, 0],
+      )
+    } finally {
+      owner.disconnect()
+    }
+  })
+
+  test('rejects sharded Pub/Sub commands routed to the wrong slot', async () => {
+    const localChannel = `sharded-pubsub:{${randomKey()}}:local`
+    const [, localPort] = await findSlotOwner(publisher, localChannel)
+    const remoteChannel = await findChannelNotOwnedByPort(publisher, localPort)
+    const directClient = await connectToSlotOwner(publisher, localChannel)
+
+    try {
+      await assert.rejects(
+        directClient.spublish(remoteChannel, 'wrong-node'),
+        error => {
+          assert.ok(error instanceof Error)
+          assert.match(error.message, /^MOVED /)
+          return true
+        },
+      )
+
+      await assert.rejects(
+        directClient.call('SSUBSCRIBE', localChannel, remoteChannel),
+        errorWithMessage(
+          "CROSSSLOT Keys in request don't hash to the same slot",
+        ),
+      )
+    } finally {
+      directClient.disconnect()
+    }
+  })
+})
+
+async function findChannelNotOwnedByPort(
+  cluster: Cluster,
+  port: number,
+): Promise<string> {
+  for (let attempt = 0; attempt < 1000; attempt++) {
+    const channel = `sharded-pubsub:{${randomKey()}}:remote`
+    const [, candidatePort] = await findSlotOwner(cluster, channel)
+    if (candidatePort !== port) {
+      return channel
+    }
+  }
+
+  throw new Error(`Could not find a shard channel not owned by port ${port}`)
+}
+
+function normalizeFrame(value: RespWireValue): RespWireValue {
+  if (Buffer.isBuffer(value)) {
+    return value.toString()
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeFrame)
+  }
+
+  return value
+}

--- a/tests-integration/raw-tcp/pubsub-protocol.test.ts
+++ b/tests-integration/raw-tcp/pubsub-protocol.test.ts
@@ -68,6 +68,71 @@ describe(`Raw TCP Pub/Sub protocol (${testRunner.getBackendName()})`, () => {
     assert.deepStrictEqual(await conn.readFrame(), 'OK')
   })
 
+  test('allows sharded subscribed-mode commands and receives shard messages', async () => {
+    const subscriber = await connect()
+    const publisher = await connect()
+    const channel = `raw-shard-pubsub:${randomKey()}`
+    const missingChannel = `${channel}:missing`
+
+    subscriber.write(commandFrame('SSUBSCRIBE', channel))
+    assert.deepStrictEqual(normalizeFrame(await subscriber.readFrame()), [
+      'ssubscribe',
+      channel,
+      1,
+    ])
+
+    publisher.write(
+      commandFrame('PUBSUB', 'SHARDNUMSUB', channel, missingChannel),
+    )
+    assert.deepStrictEqual(normalizeFrame(await publisher.readFrame()), [
+      channel,
+      1,
+      missingChannel,
+      0,
+    ])
+
+    publisher.write(commandFrame('PUBSUB', 'SHARDCHANNELS', channel))
+    assert.deepStrictEqual(normalizeFrame(await publisher.readFrame()), [
+      channel,
+    ])
+
+    subscriber.write(commandFrame('PING', 'hello'))
+    assert.deepStrictEqual(normalizeFrame(await subscriber.readFrame()), [
+      'pong',
+      'hello',
+    ])
+
+    subscriber.write(commandFrame('GET', 'blocked'))
+    assert.match(
+      respText(await subscriber.readFrame()),
+      /^ERR Can't execute 'get': only .* allowed in this context$/,
+    )
+
+    publisher.write(commandFrame('SPUBLISH', channel, 'hello-shard'))
+    assert.deepStrictEqual(await publisher.readFrame(), 1)
+    assert.deepStrictEqual(normalizeFrame(await subscriber.readFrame()), [
+      'smessage',
+      channel,
+      'hello-shard',
+    ])
+
+    subscriber.write(commandFrame('SUNSUBSCRIBE', channel))
+    assert.deepStrictEqual(normalizeFrame(await subscriber.readFrame()), [
+      'sunsubscribe',
+      channel,
+      0,
+    ])
+
+    subscriber.write(commandFrame('SET', 'after-shard-unsubscribe', 'ok'))
+    assert.deepStrictEqual(await subscriber.readFrame(), 'OK')
+
+    publisher.write(commandFrame('SPUBLISH', channel, 'after'))
+    assert.deepStrictEqual(await publisher.readFrame(), 0)
+
+    publisher.write(commandFrame('PUBSUB', 'SHARDCHANNELS'))
+    assert.deepStrictEqual(await publisher.readFrame(), [])
+  })
+
   test('RESP3 subscribed clients can run commands and use normal PING replies', async () => {
     const conn = await connect()
     const channel = `raw-resp3-pubsub:${randomKey()}`
@@ -207,6 +272,18 @@ describe(`Raw TCP Pub/Sub protocol (${testRunner.getBackendName()})`, () => {
       "ERR wrong number of arguments for 'publish' command",
     )
 
+    conn.write(commandFrame('SSUBSCRIBE'))
+    assert.strictEqual(
+      respText(await conn.readFrame()),
+      "ERR wrong number of arguments for 'ssubscribe' command",
+    )
+
+    conn.write(commandFrame('SPUBLISH', 'channel-only'))
+    assert.strictEqual(
+      respText(await conn.readFrame()),
+      "ERR wrong number of arguments for 'spublish' command",
+    )
+
     conn.write(commandFrame('PUBSUB', 'NUMPAT', 'extra'))
     assert.strictEqual(
       respText(await conn.readFrame()),
@@ -251,6 +328,13 @@ describe(`Raw TCP Pub/Sub protocol (${testRunner.getBackendName()})`, () => {
     conn.write(commandFrame('PUNSUBSCRIBE'))
     assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
       'punsubscribe',
+      null,
+      0,
+    ])
+
+    conn.write(commandFrame('SUNSUBSCRIBE'))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'sunsubscribe',
       null,
       0,
     ])

--- a/tests-integration/raw-tcp/pubsub-protocol.test.ts
+++ b/tests-integration/raw-tcp/pubsub-protocol.test.ts
@@ -133,6 +133,86 @@ describe(`Raw TCP Pub/Sub protocol (${testRunner.getBackendName()})`, () => {
     assert.deepStrictEqual(await publisher.readFrame(), [])
   })
 
+  test('keeps regular and shard subscription reply counts independent', async () => {
+    const conn = await connect()
+    const prefix = `raw-mixed-pubsub:${randomKey()}`
+    const firstChannel = `${prefix}:channel:1`
+    const secondChannel = `${prefix}:channel:2`
+    const firstShardChannel = `${prefix}:shard:1`
+    const secondShardChannel = `${prefix}:shard:2`
+    const pattern = `${prefix}:pattern:*`
+
+    conn.write(commandFrame('SUBSCRIBE', firstChannel))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'subscribe',
+      firstChannel,
+      1,
+    ])
+
+    conn.write(commandFrame('SSUBSCRIBE', firstShardChannel))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'ssubscribe',
+      firstShardChannel,
+      1,
+    ])
+
+    conn.write(commandFrame('SUBSCRIBE', secondChannel))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'subscribe',
+      secondChannel,
+      2,
+    ])
+
+    conn.write(commandFrame('PSUBSCRIBE', pattern))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'psubscribe',
+      pattern,
+      3,
+    ])
+
+    conn.write(commandFrame('SSUBSCRIBE', secondShardChannel))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'ssubscribe',
+      secondShardChannel,
+      2,
+    ])
+
+    conn.write(commandFrame('SUNSUBSCRIBE', firstShardChannel))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'sunsubscribe',
+      firstShardChannel,
+      1,
+    ])
+
+    conn.write(commandFrame('UNSUBSCRIBE', firstChannel))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'unsubscribe',
+      firstChannel,
+      2,
+    ])
+
+    conn.write(commandFrame('PUNSUBSCRIBE', pattern))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'punsubscribe',
+      pattern,
+      1,
+    ])
+
+    conn.write(commandFrame('SUNSUBSCRIBE'))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'sunsubscribe',
+      secondShardChannel,
+      0,
+    ])
+
+    conn.write(commandFrame('UNSUBSCRIBE'))
+    assert.deepStrictEqual(normalizeFrame(await conn.readFrame()), [
+      'unsubscribe',
+      secondChannel,
+      0,
+    ])
+  })
+
   test('RESP3 subscribed clients can run commands and use normal PING replies', async () => {
     const conn = await connect()
     const channel = `raw-resp3-pubsub:${randomKey()}`


### PR DESCRIPTION
## Summary

- implement Redis 7 sharded Pub/Sub commands: `SSUBSCRIBE`, `SUNSUBSCRIBE`, and `SPUBLISH`
- track shard-channel subscriptions separately from regular channels/patterns while sharing subscribed-mode counts and push delivery
- wire `PUBSUB SHARDCHANNELS` and `PUBSUB SHARDNUMSUB` to real shard subscription state
- route sharded Pub/Sub commands by shard channel slot in cluster mode

## Root Cause

`PUBSUB SHARDCHANNELS` and `PUBSUB SHARDNUMSUB` were registered as compatibility stubs, but there was no shard-channel broker/session state and no command definitions for `SSUBSCRIBE`, `SUNSUBSCRIBE`, or `SPUBLISH`.

## Validation

- `npm run build`
- focused mock + real raw Pub/Sub protocol tests
- focused mock + real sharded Pub/Sub cluster tests
- focused mock + real ioredis Pub/Sub tests
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`

Fixes #215
