### PR TITLE
fix: preserve EXEC element protocol encoding

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,9 +57,11 @@ to the connection's [`ClientSession`](../src/core/client-session.ts). The
 session asks the [`CommandExecutor`](../src/core/command-executor.ts) to look
 up and run it; the executor returns a `RedisResult` (or a `ResponseStream` for
 streaming replies), which the session adapter encodes back to wire bytes using
-the protocol version (`RESP2`/`RESP3`) negotiated for that connection. While
-executing a valid command plan, the `CommandExecutor` publishes a cloned command
-event to the server-level monitor feed when `MONITOR` clients are listening.
+the protocol version (`RESP2`/`RESP3`) negotiated for that connection. A
+`RedisResult` can also carry pre-encoded bytes for protocol-sensitive composite
+replies such as `EXEC` crossing an in-transaction `HELLO`. While executing a
+valid command plan, the `CommandExecutor` publishes a cloned command event to the
+server-level monitor feed when `MONITOR` clients are listening.
 Unknown commands and arity/syntax failures are skipped; execution errors from
 successfully planned commands are still published, matching Redis. Cluster
 redirects and pre-execution cluster errors are skipped because the command is not
@@ -176,7 +178,7 @@ sequenceDiagram
     end
     CE-->>CS: RedisResult or ResponseStream
     CS-->>SA: result
-    SA->>SA: encode via session.protocolVersion (RESP2/RESP3)
+    SA->>SA: write pre-encoded result, or encode via session.protocolVersion
     SA-->>Cl: encoded reply
 ```
 
@@ -255,7 +257,10 @@ already-parsed `CommandPlan` on the session, and replies `+QUEUED` — so parsin
 and key-extraction (and therefore early `CROSSSLOT`/`MOVED` errors) happen at
 queue time, not at `EXEC` time. `EXEC` drains the queue and replays each plan
 through [`ClientSession.executeTransaction`](../src/core/client-session.ts#L156),
-which reuses the normal `executePlan` path per command.
+which reuses the normal `executePlan` path per command. When a queued `HELLO`
+changes the session RESP version, `executeTransaction` captures each element's
+wire bytes with the protocol version active after that element runs, then returns
+a pre-encoded outer array so earlier replies are not retroactively re-encoded.
 
 `WATCH` subscribes to per-key mutation events on the database
 ([`ClientSession.watch`](../src/core/client-session.ts#L185)); any write,
@@ -385,13 +390,14 @@ On the reply side, [`encodeRedisValue`](../src/core/resp-encoder.ts#L17)
 serializes the protocol-agnostic [`RedisValue`](../src/core/redis-value.ts)
 union (`simple-string`, `bulk-string`, `integer`, `double`, `boolean`,
 `big-number`, `verbatim`, `array`, `set`, `map`, `map-pairs`, `push`, `null`, `error`, ...)
-to either RESP2 or RESP3 wire bytes. Each connection starts on RESP2; sending
-`HELLO 3` switches that single session to RESP3 — `RedisValue.map`/`mapPairs`/
-`set`/`double`/`boolean`/`bigNumber`/`push` then encode as their native RESP3
-types (`%`, `%`, `~`, `,`, `#`, `(`, `>`) instead of being downgraded to
-arrays/bulk-strings. `map` downgrades to a flat RESP2 key/value array, while
-`mapPairs` downgrades to a RESP2 array of `[key, value]` pairs for commands like
-`XREAD`. See the
+to either RESP2 or RESP3 wire bytes. [`encodeRedisResult`](../src/core/resp-encoder.ts#L10)
+writes a `RedisResult`'s pre-encoded buffer verbatim when one is present. Each
+connection starts on RESP2; sending `HELLO 3` switches that single session to
+RESP3 — `RedisValue.map`/`mapPairs`/`set`/`double`/`boolean`/`bigNumber`/`push`
+then encode as their native RESP3 types (`%`, `%`, `~`, `,`, `#`, `(`, `>`)
+instead of being downgraded to arrays/bulk-strings. `map` downgrades to a flat
+RESP2 key/value array, while `mapPairs` downgrades to a RESP2 array of
+`[key, value]` pairs for commands like `XREAD`. See the
 [README's protocol-version section](../README.md#protocol-version-resp2--resp3)
 for the client-facing view of this negotiation.
 

--- a/src/core/client-session.ts
+++ b/src/core/client-session.ts
@@ -13,7 +13,7 @@ import {
 import { RedisCommandError } from './redis-error'
 import { RedisResult } from './redis-result'
 import { RedisValue } from './redis-value'
-import type { RespVersion } from './resp-encoder'
+import { encodeRedisValue, type RespVersion } from './resp-encoder'
 import { type RedisTurnHandle, type RedisTurnQueue } from './turn-queue'
 import type {
   RedisClusterNodeRole,
@@ -270,6 +270,8 @@ export class ClientSession implements RedisClientSession {
     plans: readonly CommandPlan[],
   ): Promise<RedisResult> {
     const values: RedisValue[] = []
+    const encodedValues: Buffer[] = []
+    let sawProtocolSwitch = false
 
     // Blocking commands must not park while the EXEC turn is held — that would
     // deadlock because no other session could produce the wakeup write. Override
@@ -304,28 +306,62 @@ export class ClientSession implements RedisClientSession {
       // array. Real Redis always replies with an N-element EXEC array, so trap
       // the failure into this command's slot and keep running the rest (#83).
       let result: Awaited<ReturnType<typeof this.executor.executePlan>>
+      const versionBefore = this.protocolVersion
       try {
         result = await this.executor.executePlan(plan, noBlockCtx)
       } catch (err) {
         if (this.signal.aborted) {
           throw err
         }
-        values.push(RedisValue.error((err as Error).message))
+        this.appendTransactionValue(
+          RedisValue.error((err as Error).message),
+          values,
+          encodedValues,
+        )
+        sawProtocolSwitch ||= this.protocolVersion !== versionBefore
         continue
       }
 
       if (result instanceof RedisResult) {
-        values.push(result.value)
+        this.appendTransactionValue(
+          result.value,
+          values,
+          encodedValues,
+          result.encoded,
+        )
+        sawProtocolSwitch ||= this.protocolVersion !== versionBefore
         continue
       }
 
       result.close('streaming command is not allowed in transaction')
-      values.push(
+      this.appendTransactionValue(
         RedisValue.error('Streaming command is not allowed in transaction'),
+        values,
+        encodedValues,
       )
+      sawProtocolSwitch ||= this.protocolVersion !== versionBefore
     }
 
-    return RedisResult.create(RedisValue.array(values))
+    const value = RedisValue.array(values)
+    if (!sawProtocolSwitch) {
+      return RedisResult.create(value)
+    }
+
+    return RedisResult.preEncoded(value, encodeTransactionArray(encodedValues))
+  }
+
+  private appendTransactionValue(
+    value: RedisValue,
+    values: RedisValue[],
+    encodedValues: Buffer[],
+    encoded?: Buffer,
+  ): void {
+    values.push(value)
+    encodedValues.push(
+      encoded
+        ? Buffer.from(encoded)
+        : encodeRedisValue(value, { version: this.protocolVersion }),
+    )
   }
 
   /**
@@ -779,6 +815,13 @@ function pubsubId(value: Buffer): string {
 
 function pubsubFrame(name: string, items: RedisValue[]): RedisResult {
   return RedisResult.create(RedisValue.push(name, items))
+}
+
+function encodeTransactionArray(encodedValues: readonly Buffer[]): Buffer {
+  return Buffer.concat([
+    Buffer.from(`*${encodedValues.length}\r\n`),
+    ...encodedValues,
+  ])
 }
 
 function createAbortError(): Error {

--- a/src/core/redis-result.ts
+++ b/src/core/redis-result.ts
@@ -9,10 +9,19 @@ export class RedisResult {
   constructor(
     public readonly value: RedisValue,
     public readonly options?: RedisResultOptions,
+    public readonly encoded?: Buffer,
   ) {}
 
   static create(value: RedisValue, options?: RedisResultOptions): RedisResult {
     return new RedisResult(value, options)
+  }
+
+  static preEncoded(
+    value: RedisValue,
+    encoded: Buffer,
+    options?: RedisResultOptions,
+  ): RedisResult {
+    return new RedisResult(value, options, Buffer.from(encoded))
   }
 
   static nil(): RedisResult {

--- a/src/core/resp-encoder.ts
+++ b/src/core/resp-encoder.ts
@@ -11,6 +11,10 @@ export function encodeRedisResult(
   result: RedisResult,
   options?: RespEncodeOptions,
 ): Buffer {
+  if (result.encoded) {
+    return Buffer.from(result.encoded)
+  }
+
   return encodeRedisValue(result.value, options)
 }
 

--- a/tests-integration/raw-tcp/protocol.test.ts
+++ b/tests-integration/raw-tcp/protocol.test.ts
@@ -133,6 +133,49 @@ describe(`Raw TCP protocol integration (${testRunner.getBackendName()})`, () => 
     assert.deepStrictEqual(await conn.readRawFrame(), Buffer.from('$-1\r\n'))
   })
 
+  test('encodes EXEC elements with the protocol active when each command ran', async () => {
+    const conn = await connect()
+    const missing = `${randomKey()}:absent`
+
+    conn.write(
+      Buffer.concat([
+        commandFrame('MULTI'),
+        commandFrame('GET', missing),
+        commandFrame('HELLO', '3'),
+        commandFrame('GET', missing),
+        commandFrame('EXEC'),
+      ]),
+    )
+
+    assert.deepStrictEqual(await conn.readRawFrame(), Buffer.from('+OK\r\n'))
+    assert.deepStrictEqual(
+      await conn.readRawFrame(),
+      Buffer.from('+QUEUED\r\n'),
+    )
+    assert.deepStrictEqual(
+      await conn.readRawFrame(),
+      Buffer.from('+QUEUED\r\n'),
+    )
+    assert.deepStrictEqual(
+      await conn.readRawFrame(),
+      Buffer.from('+QUEUED\r\n'),
+    )
+
+    const rawExec = await conn.readRawFrame()
+    assert.ok(
+      rawExec.subarray(0, 9).equals(Buffer.from('*3\r\n$-1\r\n')),
+      `expected pre-HELLO GET to stay RESP2 null, got ${rawExec.toString()}`,
+    )
+    assert.ok(
+      rawExec.includes(Buffer.from('%7\r\n')),
+      `expected HELLO 3 to be encoded as a RESP3 map, got ${rawExec.toString()}`,
+    )
+    assert.ok(
+      rawExec.subarray(-3).equals(Buffer.from('_\r\n')),
+      `expected post-HELLO GET to use RESP3 null, got ${rawExec.toString()}`,
+    )
+  })
+
   // #80: RESET must execute immediately inside MULTI (like EXEC/DISCARD/WATCH),
   // aborting the transaction — it must not be queued.
   test('RESET inside MULTI executes immediately and aborts the transaction', async () => {

--- a/tests/core-resp-encoder.test.ts
+++ b/tests/core-resp-encoder.test.ts
@@ -131,6 +131,20 @@ describe('RESP encoder core', () => {
     )
   })
 
+  test('writes pre-encoded RedisResult bytes verbatim', () => {
+    const encoded = Buffer.from('*1\r\n_\r\n')
+    const result = RedisResult.preEncoded(
+      RedisValue.array([RedisValue.null()]),
+      encoded,
+    )
+    encoded.write('$', 4)
+
+    assert.deepStrictEqual(
+      encodeRedisResult(result, { version: 2 }),
+      Buffer.from('*1\r\n_\r\n'),
+    )
+  })
+
   test('encodes RESP3 verbatim strings with a 3-byte format prefix', () => {
     assert.deepStrictEqual(
       encodeRedisValue(RedisValue.verbatim('txt', Buffer.from('Some string')), {


### PR DESCRIPTION
## Summary
- add a pre-encoded `RedisResult` path for protocol-sensitive composite replies
- encode each `EXEC` element with the RESP version active after that queued command runs when an in-transaction `HELLO` switches protocol
- cover the mixed RESP2/RESP3 `MULTI; GET; HELLO 3; GET; EXEC` wire behavior against mock and real Redis

## Root Cause
`ClientSession.executeTransaction` collected raw `RedisValue` elements and returned a single array. The session adapter later encoded that whole array with the final session protocol version, so replies that ran before a queued `HELLO 3` were retroactively encoded as RESP3.

## Validation
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/raw-tcp/protocol.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/raw-tcp/protocol.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`

Fixes #143