### PR TITLE
fix: support ZRANK WITHSCORE

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -289,8 +289,8 @@ with `GT` or `LT`.
 - [x] `ZCARD key` - Get the number of members
 - [x] `ZSCORE key member` - Get the score of a member
 - [x] `ZINCRBY key increment member` - Increment the score of a member (`inf`, `+inf`, and `-inf` increments supported; NaN results rejected)
-- [x] `ZRANK key member` - Get the index of a member, lowest score first
-- [x] `ZREVRANK key member` - Get the index of a member, highest score first
+- [x] `ZRANK key member [WITHSCORE]` - Get the index of a member, lowest score first; optionally return `[rank, score]`
+- [x] `ZREVRANK key member [WITHSCORE]` - Get the index of a member, highest score first; optionally return `[rank, score]`
 - [x] `ZRANGE key min max [BYSCORE | BYLEX] [REV] [LIMIT offset count] [WITHSCORES]` - Return a range of members by index, score, or lexicographic range, optionally reversed
 - [x] `ZRANGESTORE destination source min max [BYSCORE | BYLEX] [REV] [LIMIT offset count]` - Store a `ZRANGE`-style result in destination; empty result deletes destination
 - [x] `ZREVRANGE key start stop [WITHSCORES]` - Return a range of members by index, high to low
@@ -322,9 +322,8 @@ with `GT` or `LT`.
 
 #### Notes / gaps vs. real Redis
 
-- Score replies from `ZSCORE`, `ZINCRBY`, `ZRANGE WITHSCORES`, `ZREVRANGE WITHSCORES`, `ZRANGEBYSCORE WITHSCORES`, `ZREVRANGEBYSCORE WITHSCORES`, `ZPOPMIN`, `ZPOPMAX`, `ZMPOP`, `BZMPOP`, `BZPOPMIN`, `BZPOPMAX`, and `ZSCAN` serialize infinite scores as `inf` / `-inf`.
+- Score replies from `ZSCORE`, `ZINCRBY`, `ZRANK WITHSCORE`, `ZREVRANK WITHSCORE`, `ZRANGE WITHSCORES`, `ZREVRANGE WITHSCORES`, `ZRANGEBYSCORE WITHSCORES`, `ZREVRANGEBYSCORE WITHSCORES`, `ZPOPMIN`, `ZPOPMAX`, `ZMPOP`, `BZMPOP`, `BZPOPMIN`, `BZPOPMAX`, and `ZSCAN` serialize infinite scores as `inf` / `-inf`.
 - [ ] `ZREVRANGE` does not support the Redis 6.2+ unified syntax (`BYSCORE`, `BYLEX`, `REV`, `LIMIT offset count`) - `start`/`stop` are always treated as indexes; use `ZRANGE ... REV` instead
-- [ ] `ZRANK`/`ZREVRANK` do not support the Redis 7.2 `WITHSCORE` option
 
 ## 9. Stream Commands
 

--- a/src/commands/zsets/zrank.ts
+++ b/src/commands/zsets/zrank.ts
@@ -1,40 +1,87 @@
 import { defineCommand } from '../../core/command-definition'
 import { t } from '../../core/command-schema'
+import {
+  RedisSyntaxError,
+  WrongNumberOfArgumentsError,
+} from '../../core/redis-error'
 import { RedisResult } from '../../core/redis-result'
-import { integer } from '../helpers'
+import { RedisValue } from '../../core/redis-value'
+import { array, integer, scoreBuffer } from '../helpers'
 import { getSortedMembers } from './helpers'
+
+type ZRankArgs = {
+  key: Buffer
+  member: Buffer
+  withScore: boolean
+}
+
+const zrankSchema = t.custom<ZRankArgs>((input, index, ctx) => {
+  const remaining = input.length - index
+  if (remaining < 2 || remaining > 3) {
+    throw new WrongNumberOfArgumentsError(ctx.commandName)
+  }
+
+  const key = input[index]
+  const member = input[index + 1]
+  if (!key || !member) {
+    throw new WrongNumberOfArgumentsError(ctx.commandName)
+  }
+
+  const option = input[index + 2]
+  if (option && option.toString().toUpperCase() !== 'WITHSCORE') {
+    throw new RedisSyntaxError()
+  }
+
+  return {
+    value: { key, member, withScore: option !== undefined },
+    nextIndex: input.length,
+  }
+})
+
+function rankResponse(rank: number, score: number, withScore: boolean) {
+  if (!withScore) {
+    return integer(rank)
+  }
+
+  return array([
+    RedisValue.integer(rank),
+    RedisValue.bulkString(scoreBuffer(score)),
+  ])
+}
 
 export const zrankCommand = defineCommand({
   name: 'zrank',
-  schema: t.object({ key: t.key(), member: t.key() }),
+  schema: zrankSchema,
   flags: ['readonly', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
     const zset = ctx.db.getSortedSet(args.key)
     if (!zset) return RedisResult.nil()
     const hex = args.member.toString('hex')
-    if (!zset.members.has(hex)) return RedisResult.nil()
+    const entry = zset.members.get(hex)
+    if (!entry) return RedisResult.nil()
     const sorted = getSortedMembers(zset)
     const rank = sorted.findIndex(m => m.member.toString('hex') === hex)
-    return integer(rank)
+    return rankResponse(rank, entry.score, args.withScore)
   },
 })
 
 export const zrevrankCommand = defineCommand({
   name: 'zrevrank',
-  schema: t.object({ key: t.key(), member: t.key() }),
+  schema: zrankSchema,
   flags: ['readonly', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
     const zset = ctx.db.getSortedSet(args.key)
     if (!zset) return RedisResult.nil()
     const hex = args.member.toString('hex')
-    if (!zset.members.has(hex)) return RedisResult.nil()
+    const entry = zset.members.get(hex)
+    if (!entry) return RedisResult.nil()
     const sorted = getSortedMembers(zset)
     const rank = sorted
       .slice()
       .reverse()
       .findIndex(m => m.member.toString('hex') === hex)
-    return integer(rank)
+    return rankResponse(rank, entry.score, args.withScore)
   },
 })

--- a/tests-integration/ioredis/zset-integration.test.ts
+++ b/tests-integration/ioredis/zset-integration.test.ts
@@ -6,6 +6,24 @@ import { errorWithMessage, randomKey } from '../utils'
 
 const testRunner = new TestRunner()
 
+function redisVersionFromInfo(info: string | undefined): string | null {
+  const match = info?.match(/^redis_version:(\d+\.\d+\.\d+)/m)
+  return match?.[1] ?? null
+}
+
+function redisVersionAtLeast(
+  version: string | null,
+  major: number,
+  minor: number,
+): boolean {
+  if (!version) {
+    return false
+  }
+
+  const [actualMajor = 0, actualMinor = 0] = version.split('.').map(Number)
+  return actualMajor > major || (actualMajor === major && actualMinor >= minor)
+}
+
 describe(`Sorted Set Commands Integration (${testRunner.getBackendName()})`, () => {
   let redisClient: Cluster | undefined
 
@@ -187,6 +205,82 @@ describe(`Sorted Set Commands Integration (${testRunner.getBackendName()})`, () 
 
     const revrank2 = await redisClient?.zrevrank('zset5', 'one')
     assert.strictEqual(revrank2, 2)
+  })
+
+  test('ZRANK and ZREVRANK WITHSCORE option', async t => {
+    if (testRunner.backend === 'real') {
+      const serverInfo = (await redisClient?.call('INFO', 'server')) as
+        | string
+        | undefined
+      const redisVersion = redisVersionFromInfo(serverInfo)
+      if (!redisVersionAtLeast(redisVersion, 7, 2)) {
+        t.skip(
+          `ZRANK WITHSCORE requires Redis 7.2+; real backend is ${redisVersion ?? 'unknown'}`,
+        )
+        return
+      }
+    }
+
+    const keyTag = `zrank-withscore:${randomKey()}`
+    const zsetKey = `{${keyTag}}:zset`
+    const stringKey = `{${keyTag}}:string`
+
+    try {
+      await redisClient?.call('ZADD', zsetKey, 1, 'one', 2, 'two', 3.5, 'three')
+
+      assert.deepStrictEqual(
+        await redisClient?.call('ZRANK', zsetKey, 'one', 'WITHSCORE'),
+        [0, '1'],
+      )
+      assert.deepStrictEqual(
+        await redisClient?.call('ZRANK', zsetKey, 'three', 'withscore'),
+        [2, '3.5'],
+      )
+      assert.deepStrictEqual(
+        await redisClient?.call('ZREVRANK', zsetKey, 'three', 'WITHSCORE'),
+        [0, '3.5'],
+      )
+      assert.deepStrictEqual(
+        await redisClient?.call('ZREVRANK', zsetKey, 'one', 'WITHSCORE'),
+        [2, '1'],
+      )
+
+      assert.strictEqual(
+        await redisClient?.call('ZRANK', zsetKey, 'missing', 'WITHSCORE'),
+        null,
+      )
+      assert.strictEqual(
+        await redisClient?.call('ZREVRANK', zsetKey, 'missing', 'WITHSCORE'),
+        null,
+      )
+
+      await redisClient?.call('SET', stringKey, 'not-a-zset')
+      await assert.rejects(
+        () => redisClient?.call('ZRANK', stringKey, 'one', 'WITHSCORE'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
+        () => redisClient?.call('ZRANK', zsetKey, 'one', 'BADOPTION'),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.call(
+            'ZREVRANK',
+            zsetKey,
+            'one',
+            'WITHSCORE',
+            'WITHSCORE',
+          ),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'zrevrank' command",
+        ),
+      )
+    } finally {
+      await redisClient?.call('DEL', zsetKey, stringKey)
+    }
   })
 
   test('ZINCRBY command', async () => {


### PR DESCRIPTION
## Summary
- Add Redis 7.2 `WITHSCORE` parsing for `ZRANK` and `ZREVRANK`.
- Return `[rank, score]` arrays when requested while preserving nil replies for missing members.
- Document the new sorted-set support and remove the stale gap entry.

## Root cause
`ZRANK` and `ZREVRANK` were still defined with a strict two-argument schema, so the Redis 7.2 optional `WITHSCORE` flag was rejected before command execution.

## Validation
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test --test-name-pattern 'ZRANK and ZREVRANK WITHSCORE option' ./tests-integration/ioredis/zset-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test --test-name-pattern 'ZRANK and ZREVRANK WITHSCORE option' ./tests-integration/ioredis/zset-integration.test.ts` (skipped on local Redis 7.0.14; requires Redis 7.2+)
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/zset-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/zset-integration.test.ts` (1 Redis 7.2+ skip on local Redis 7.0.14)
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real` (501 passed, 1 Redis 7.2+ skip, 0 failed)
- `npm run lint`

Fixes #210