### PR TITLE
Implement MOVE command

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -418,7 +418,8 @@ genuinely partitioned) but **sharing** the topology object, registered with:
 There is no separate "cluster commander" type — cluster mode is the same
 `Resp2Server` + `CommandExecutor` core, configured with one extra command and
 one extra policy. `SELECT 0` is accepted as a no-op in cluster mode (Redis
-Cluster only exposes database 0); any non-zero index is rejected.
+Cluster only exposes database 0); any non-zero index is rejected. Multi-database
+commands such as `MOVE` are rejected in cluster mode.
 
 ## Lua scripting
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -159,6 +159,7 @@ surface.
 - [x] `RENAME key newkey` - Rename a key
 - [x] `RENAMENX key newkey` - Rename a key only if the new key does not exist
 - [x] `COPY source destination [DB destination-db] [REPLACE]` - Copy a key's value (and TTL) to a destination, optionally into another database; returns `0` if the destination exists without `REPLACE`
+- [x] `MOVE key db` - Move a key to another database, preserving TTL; returns `0` if the source is missing or the destination already exists; rejected in cluster mode
 - [x] `KEYS pattern` - Find all keys matching a glob pattern
 - [x] `SCAN cursor [MATCH pattern] [COUNT count] [TYPE type]` - Incrementally iterate the keyspace (see [Scan Family](#10-scan-family))
 - [x] `SORT key [LIMIT offset count] [ASC | DESC] [ALPHA] [STORE destination]` - Sort a list, set, or zset (zset sorted by member value, not score); numeric by default, `ALPHA` for lexicographic; `STORE` writes the result to a destination list and returns its length
@@ -187,7 +188,6 @@ with `GT` or `LT`.
 #### Not implemented
 
 - [ ] `OBJECT ENCODING|REFCOUNT|IDLETIME|FREQ|HELP`
-- [ ] `MOVE`
 - [ ] `DUMP` / `RESTORE`
 - [ ] `WAIT`
 - [ ] `MIGRATE`

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -124,6 +124,7 @@ export {
   flushallCommand,
   flushdbCommand,
   keysCommands,
+  moveCommand,
   persistCommand,
   pexpireCommand,
   pexpireatCommand,

--- a/src/commands/keys.ts
+++ b/src/commands/keys.ts
@@ -436,6 +436,43 @@ export const renamenxCommand = defineCommand({
   },
 })
 
+export const moveCommand = defineCommand({
+  name: 'move',
+  schema: t.object({ key: t.key(), database: t.integer() }),
+  flags: ['write'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const targetDb = ctx.server.databases[args.database]
+    if (!targetDb) {
+      throw new DbIndexOutOfRangeError()
+    }
+
+    if (targetDb.id === ctx.db.id) {
+      throw new SameObjectError()
+    }
+
+    const value = ctx.db.get(args.key)
+    if (!value) return integer(0)
+
+    if (targetDb.getType(args.key) !== null) {
+      return integer(0)
+    }
+
+    const expiration = ctx.db.getExpiration(args.key)
+    const expiresAt =
+      expiration.kind === 'expires' ? expiration.expiresAt : undefined
+
+    ctx.db.delete(args.key)
+    targetDb.set(
+      args.key,
+      value,
+      expiresAt !== undefined ? { expiresAt } : undefined,
+    )
+
+    return integer(1)
+  },
+})
+
 type CopyOptions = { db?: number; replace: boolean }
 
 /**
@@ -705,6 +742,7 @@ export const keysCommands = [
   pexpireatCommand,
   renameCommand,
   renamenxCommand,
+  moveCommand,
   copyCommand,
   sortCommand,
   sortRoCommand,

--- a/src/core/execution-policies/cluster-policy.ts
+++ b/src/core/execution-policies/cluster-policy.ts
@@ -42,6 +42,10 @@ export function createClusterPolicy(
         }
       }
 
+      if (plan.definition.name === 'move') {
+        throw new RedisCommandError('MOVE is not allowed in cluster mode')
+      }
+
       if (
         plan.definition.name === 'multi' &&
         ctx.session.mode !== 'transaction'

--- a/tests-integration/ioredis/move-integration.test.ts
+++ b/tests-integration/ioredis/move-integration.test.ts
@@ -1,0 +1,160 @@
+import { Redis, type Cluster } from 'ioredis'
+import { after, before, describe, test } from 'node:test'
+import assert from 'node:assert'
+import { TestRunner } from '../test-config'
+import { connectToSlotOwner, randomKey } from '../utils'
+import { errorWithMessage } from '../../tests/shared-test-helpers'
+
+const testRunner = new TestRunner()
+
+describe('MOVE command integration (standalone)', () => {
+  let client: Redis | undefined
+
+  before(async () => {
+    client = await testRunner.setupIoredisStandalone()
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  test('moves a key to another database and removes it from the source', async () => {
+    const key = randomKey()
+
+    await client!.select(0)
+    await client!.set(key, 'value')
+
+    assert.strictEqual(await client!.call('MOVE', key, '1'), 1)
+    assert.strictEqual(await client!.get(key), null)
+
+    await client!.select(1)
+    assert.strictEqual(await client!.get(key), 'value')
+    await client!.select(0)
+  })
+
+  test('returns 0 when the source key is missing', async () => {
+    const key = randomKey()
+
+    await client!.select(0)
+    assert.strictEqual(await client!.call('MOVE', key, '1'), 0)
+
+    await client!.select(1)
+    assert.strictEqual(await client!.exists(key), 0)
+    await client!.select(0)
+  })
+
+  test('returns 0 and leaves both databases unchanged when destination exists', async () => {
+    const key = randomKey()
+
+    await client!.select(0)
+    await client!.set(key, 'source')
+    await client!.select(1)
+    await client!.set(key, 'destination')
+
+    await client!.select(0)
+    assert.strictEqual(await client!.call('MOVE', key, '1'), 0)
+    assert.strictEqual(await client!.get(key), 'source')
+
+    await client!.select(1)
+    assert.strictEqual(await client!.get(key), 'destination')
+    await client!.select(0)
+  })
+
+  test('preserves TTL on the moved key', async () => {
+    const key = randomKey()
+
+    await client!.select(0)
+    await client!.set(key, 'value', 'EX', 1000)
+
+    assert.strictEqual(await client!.call('MOVE', key, '1'), 1)
+
+    await client!.select(1)
+    const ttl = await client!.ttl(key)
+    assert.ok(ttl > 990 && ttl <= 1000, `expected ttl ~1000, got ${ttl}`)
+    await client!.select(0)
+  })
+
+  test('errors when moving to the current database', async () => {
+    const key = randomKey()
+
+    await client!.select(0)
+    await client!.set(key, 'value')
+
+    await assert.rejects(
+      client!.call('MOVE', key, '0'),
+      errorWithMessage('ERR source and destination objects are the same'),
+    )
+  })
+
+  test('errors when the destination DB index is out of range', async () => {
+    const key = randomKey()
+
+    await client!.select(0)
+    await client!.set(key, 'value')
+
+    await assert.rejects(
+      client!.call('MOVE', key, '99'),
+      errorWithMessage('ERR DB index is out of range'),
+    )
+
+    await assert.rejects(
+      client!.call('MOVE', key, '-1'),
+      errorWithMessage('ERR DB index is out of range'),
+    )
+  })
+
+  test('errors when the destination DB index is not an integer', async () => {
+    const key = randomKey()
+
+    await client!.select(0)
+    await client!.set(key, 'value')
+
+    await assert.rejects(
+      client!.call('MOVE', key, 'abc'),
+      errorWithMessage('ERR value is not an integer or out of range'),
+    )
+  })
+
+  test('errors on wrong number of arguments', async () => {
+    await assert.rejects(
+      client!.call('MOVE'),
+      errorWithMessage("ERR wrong number of arguments for 'move' command"),
+    )
+
+    await assert.rejects(
+      client!.call('MOVE', 'only-key'),
+      errorWithMessage("ERR wrong number of arguments for 'move' command"),
+    )
+
+    await assert.rejects(
+      client!.call('MOVE', 'key', '1', 'extra'),
+      errorWithMessage("ERR wrong number of arguments for 'move' command"),
+    )
+  })
+})
+
+describe(`MOVE command cluster rejection (${testRunner.getBackendName()})`, () => {
+  let cluster: Cluster | undefined
+
+  before(async () => {
+    cluster = await testRunner.setupIoredisCluster('move-integration')
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  test('rejects MOVE in cluster mode', async () => {
+    const key = `{move:${randomKey()}}:cluster`
+    const slotOwner = await connectToSlotOwner(cluster!, key)
+
+    try {
+      await assert.rejects(
+        slotOwner.call('MOVE', key, '1'),
+        errorWithMessage('ERR MOVE is not allowed in cluster mode'),
+      )
+    } finally {
+      slotOwner.disconnect()
+    }
+  })
+})

--- a/tests/core-cluster-policy.test.ts
+++ b/tests/core-cluster-policy.test.ts
@@ -151,6 +151,16 @@ describe('new cluster execution policy', () => {
       RedisResult.error('SELECT is not allowed in cluster mode', 'ERR'),
     )
   })
+
+  test('rejects MOVE in cluster mode like Redis Cluster', async () => {
+    const { session, topology } = createClusterHarness()
+    const key = findKeyOwnedBy(topology, 'local')
+
+    assert.deepStrictEqual(
+      await session.execute('move', [key, Buffer.from('1')]),
+      RedisResult.error('MOVE is not allowed in cluster mode', 'ERR'),
+    )
+  })
 })
 
 function createClusterHarness() {


### PR DESCRIPTION
## Summary
- Implement `MOVE key db` for standalone databases with Redis-compatible return values.
- Preserve source TTL when moving and leave the source untouched when the destination already exists.
- Reject `MOVE` in cluster mode with Redis-compatible error text.
- Update command/architecture docs for the new command support.

## Root Cause
`MOVE` was not registered in the key command surface, so clients received `ERR unknown command`. The cluster policy also had no explicit guard for this multi-database command.

## Validation
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/move-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/move-integration.test.ts`
- `node --enable-source-maps --import tsx --no-warnings --test ./tests/core-cluster-policy.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real` (510 passed, 1 skipped, 0 failed)
- `npm run lint`

Fixes #201
