### PR TITLE
Fix CONFIG RESETSTAT and REWRITE

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -85,8 +85,8 @@ surface.
 - [x] `CONFIG GET parameter [parameter ...]` - Get configuration parameters (glob-matched against a fixed set of plausible defaults; RESP3 map / RESP2 flat array)
 - [x] `CONFIG SET parameter value [parameter value ...]` - Set configuration parameters (rejects unknown parameter names with the real Redis error, matching CONFIG SET's "all-or-nothing" validation)
 - [x] `CONFIG HELP`
-- [ ] `CONFIG RESETSTAT` - Reset the stats returned by INFO
-- [ ] `CONFIG REWRITE` - Rewrite the configuration file
+- [x] `CONFIG RESETSTAT` - Reset the stats returned by INFO (no-op in the mock)
+- [x] `CONFIG REWRITE` - Rewrite the configuration file (returns Redis' no-config-file error)
 
 > There is no real configuration subsystem behind this - values are an
 > in-memory per-server store seeded with plausible defaults (`maxmemory`,
@@ -96,7 +96,8 @@ surface.
 > `notify-keyspace-events`, which is a real, behavior-driving setting — see
 > [Keyspace notifications](#14-pubsub-commands). Its value is validated and
 > normalized exactly like Redis (e.g. `CONFIG SET ... KEA` reads back as `AKE`;
-> an unknown class character is rejected).
+> an unknown class character is rejected). Since there is no backing config file,
+> `CONFIG REWRITE` reports the same no-config-file error as Redis.
 
 #### DBSIZE
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -143,6 +143,22 @@ function configSet(
   return ok()
 }
 
+function configResetStat(args: readonly Buffer[]): RedisResult {
+  if (args.length !== 0) {
+    throw new WrongNumberOfArgumentsError('config|resetstat')
+  }
+
+  return ok()
+}
+
+function configRewrite(args: readonly Buffer[]): RedisResult {
+  if (args.length !== 0) {
+    throw new WrongNumberOfArgumentsError('config|rewrite')
+  }
+
+  throw new RedisCommandError('The server is running without a config file')
+}
+
 export const configCommand = defineCommand({
   name: 'config',
   schema: t.object({
@@ -165,6 +181,8 @@ export const configCommand = defineCommand({
       commandSubcommandInfo('config|get', -3),
       commandSubcommandInfo('config|set', -4),
       commandSubcommandInfo('config|help', 2),
+      commandSubcommandInfo('config|resetstat', 2),
+      commandSubcommandInfo('config|rewrite', 2),
     ],
   },
   keys: () => [],
@@ -177,6 +195,14 @@ export const configCommand = defineCommand({
 
     if (subcommand === 'set') {
       return configSet(args.args, ctx)
+    }
+
+    if (subcommand === 'resetstat') {
+      return configResetStat(args.args)
+    }
+
+    if (subcommand === 'rewrite') {
+      return configRewrite(args.args)
     }
 
     throw new RedisCommandError(

--- a/tests-integration/ioredis/config-integration.test.ts
+++ b/tests-integration/ioredis/config-integration.test.ts
@@ -2,7 +2,7 @@ import { after, before, describe, test } from 'node:test'
 import assert from 'node:assert'
 import { Cluster, Redis } from 'ioredis'
 import { TestRunner } from '../test-config'
-import { connectToSlotOwner, randomKey } from '../utils'
+import { connectToSlotOwner, errorWithMessage, randomKey } from '../utils'
 
 const testRunner = new TestRunner()
 
@@ -19,6 +19,7 @@ function configArrayToMap(reply: unknown): Map<string, string> {
 describe(`CONFIG GET/SET integration (${testRunner.getBackendName()})`, () => {
   let redisClient: Cluster | undefined
   let directClient: Redis | undefined
+  let standaloneClient: Redis | undefined
 
   before(async () => {
     redisClient = await testRunner.setupIoredisCluster('config-integration')
@@ -26,6 +27,7 @@ describe(`CONFIG GET/SET integration (${testRunner.getBackendName()})`, () => {
       redisClient,
       `{config:${randomKey()}}:probe`,
     )
+    standaloneClient = await testRunner.setupIoredisStandalone()
   })
 
   after(async () => {
@@ -76,6 +78,37 @@ describe(`CONFIG GET/SET integration (${testRunner.getBackendName()})`, () => {
   test('CONFIG SET rejects an unknown parameter', async () => {
     await assert.rejects(async () =>
       directClient?.call('CONFIG', 'SET', 'definitely-not-a-real-param', '1'),
+    )
+  })
+
+  test('CONFIG RESETSTAT returns OK', async () => {
+    const reply = await standaloneClient?.call('CONFIG', 'RESETSTAT')
+
+    assert.strictEqual(reply, 'OK')
+  })
+
+  test('CONFIG RESETSTAT rejects extra arguments', async () => {
+    await assert.rejects(
+      () => standaloneClient!.call('CONFIG', 'RESETSTAT', 'extra'),
+      errorWithMessage(
+        "ERR wrong number of arguments for 'config|resetstat' command",
+      ),
+    )
+  })
+
+  test('CONFIG REWRITE rejects when no config file is loaded', async () => {
+    await assert.rejects(
+      () => standaloneClient!.call('CONFIG', 'REWRITE'),
+      errorWithMessage('ERR The server is running without a config file'),
+    )
+  })
+
+  test('CONFIG REWRITE rejects extra arguments', async () => {
+    await assert.rejects(
+      () => standaloneClient!.call('CONFIG', 'REWRITE', 'extra'),
+      errorWithMessage(
+        "ERR wrong number of arguments for 'config|rewrite' command",
+      ),
     )
   })
 })


### PR DESCRIPTION
Summary
- Add Redis-compatible CONFIG RESETSTAT as a no-op OK reply.
- Add CONFIG REWRITE with Redis' no-config-file error for this mock server.
- Register both subcommands in CONFIG introspection and update the command matrix.

Root cause
- CONFIG only dispatched GET and SET, so RESETSTAT and REWRITE fell through to the generic unknown-subcommand error despite being tracked as missing roadmap work.

Validation
- TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/config-integration.test.ts
- TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/config-integration.test.ts
- npm run build
- npm test
- npm run test:integration:mock
- npm run test:integration:real
- npm run lint

Fixes #199