### PR TITLE
Add XSETID stream command

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -344,15 +344,12 @@ with `GT` or `LT`.
 - [x] `XINFO STREAM key [FULL [COUNT count]]` - Inspect stream metadata, entries, groups, and PEL details
 - [x] `XINFO GROUPS key` - List stream consumer groups
 - [x] `XINFO CONSUMERS key group` - List consumers in a group
+- [x] `XSETID key last-id [ENTRIESADDED entries-added]` - Set the last-generated stream ID and optionally the entries-added counter
 
 #### Notes / gaps vs. real Redis
 
 - Approximate (`~`) `XADD`/`XTRIM` trim specs use a simplified mock heuristic that may leave one extra eligible entry; `LIMIT count` is accepted for Redis-compatible parsing and treated as a trimming hint.
 - [ ] Stream radix-tree statistics in `XINFO STREAM` are approximated for mock compatibility rather than mirroring Redis internals
-
-#### Not implemented
-
-- [ ] `XSETID key last-id [ENTRIESADDED entries-added]` - Set the last-delivered ID and optionally the entries-added counter for a stream
 
 ## 10. Scan Family
 

--- a/src/commands/streams/index.ts
+++ b/src/commands/streams/index.ts
@@ -10,6 +10,7 @@ import { xpendingCommand } from './xpending'
 import { xrangeCommand, xrevrangeCommand } from './xrange'
 import { xreadCommand } from './xread'
 import { xreadgroupCommand } from './xreadgroup'
+import { xsetidCommand } from './xsetid'
 import { xtrimCommand } from './xtrim'
 
 export const streamsCommands = [
@@ -27,6 +28,7 @@ export const streamsCommands = [
   xclaimCommand,
   xautoclaimCommand,
   xinfoCommand,
+  xsetidCommand,
 ]
 
 export {
@@ -43,5 +45,6 @@ export {
   xreadCommand,
   xreadgroupCommand,
   xrevrangeCommand,
+  xsetidCommand,
   xtrimCommand,
 }

--- a/src/commands/streams/xsetid.ts
+++ b/src/commands/streams/xsetid.ts
@@ -1,0 +1,91 @@
+import { defineCommand } from '../../core/command-definition'
+import { t, type ParseContext } from '../../core/command-schema'
+import {
+  NoSuchKeyError,
+  RedisCommandError,
+  RedisSyntaxError,
+  WrongNumberOfArgumentsError,
+} from '../../core/redis-error'
+import type { StreamId } from '../../state/data-types'
+import { ok } from '../helpers'
+import {
+  cloneStreamId,
+  compareStreamId,
+  parseExactId,
+  parseNonNegativeInteger,
+} from './ids'
+
+class XsetidSmallerThanTopError extends RedisCommandError {
+  constructor() {
+    super(
+      'The ID specified in XSETID is smaller than the target stream top item',
+    )
+  }
+}
+
+type XsetidArgs = {
+  key: Buffer
+  id: StreamId
+  entriesAdded: number | null
+}
+
+function createXsetidSchema() {
+  return t.custom<XsetidArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const key = input[index]
+      const rawId = input[index + 1]
+      if (!key || !rawId) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      let cursor = index + 2
+      let entriesAdded: number | null = null
+      while (cursor < input.length) {
+        const option = input[cursor].toString().toUpperCase()
+        if (option === 'ENTRIESADDED') {
+          const rawEntriesAdded = input[cursor + 1]
+          if (!rawEntriesAdded) throw new RedisSyntaxError()
+          entriesAdded = parseNonNegativeInteger(rawEntriesAdded)
+          cursor += 2
+          continue
+        }
+
+        throw new RedisSyntaxError()
+      }
+
+      return {
+        value: {
+          key,
+          id: parseExactId(rawId.toString()),
+          entriesAdded,
+        },
+        nextIndex: input.length,
+      }
+    },
+  )
+}
+
+export const xsetidCommand = defineCommand({
+  name: 'xsetid',
+  schema: t.object({ args: createXsetidSchema() }),
+  flags: ['write', 'fast'],
+  keys: args => [args.args.key],
+  execute: (args, ctx) => {
+    const command = args.args
+    const stream = ctx.db.getStream(command.key)
+    if (!stream) throw new NoSuchKeyError()
+    if (compareStreamId(command.id, stream.lastId) < 0) {
+      throw new XsetidSmallerThanTopError()
+    }
+
+    ctx.db.updateStream(command.key, writable => {
+      writable.value.lastId = cloneStreamId(command.id)
+      if (command.entriesAdded !== null) {
+        writable.value.entriesAdded = command.entriesAdded
+      }
+      writable.forceWrite()
+    })
+
+    return ok()
+  },
+})

--- a/tests-integration/ioredis/stream-integration.test.ts
+++ b/tests-integration/ioredis/stream-integration.test.ts
@@ -125,6 +125,110 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
     )
   })
 
+  test('XSETID sets last-generated-id and advances generated XADD ids', async () => {
+    const key = `{xsetid:${randomKey()}}`
+    const node = await connectToSlotOwner(redisClient!, key)
+    const futureMs = BigInt(Date.now()) + 60_000n
+
+    try {
+      await node.call('XADD', key, '1-0', 'f', 'v')
+      assert.strictEqual(await node.call('XSETID', key, `${futureMs}-0`), 'OK')
+
+      const streamInfo = (await node.call('XINFO', 'STREAM', key)) as unknown[]
+      assert.strictEqual(kvArrayGet(streamInfo, 'length'), 1)
+      assert.strictEqual(
+        kvArrayGet(streamInfo, 'last-generated-id'),
+        `${futureMs}-0`,
+      )
+      assert.strictEqual(kvArrayGet(streamInfo, 'entries-added'), 1)
+
+      assert.strictEqual(
+        await node.call('XADD', key, '*', 'f', 'v'),
+        `${futureMs}-1`,
+      )
+    } finally {
+      await node.del(key)
+      node.disconnect()
+    }
+  })
+
+  test('XSETID ENTRIESADDED updates XINFO STREAM metadata', async () => {
+    const key = `{xsetid-meta:${randomKey()}}`
+    const node = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      await node.call('XADD', key, '1-0', 'f', 'v')
+      assert.strictEqual(
+        await node.call('XSETID', key, '5-0', 'entriesadded', '42'),
+        'OK',
+      )
+
+      const streamInfo = (await node.call('XINFO', 'STREAM', key)) as unknown[]
+      assert.strictEqual(kvArrayGet(streamInfo, 'last-generated-id'), '5-0')
+      assert.strictEqual(kvArrayGet(streamInfo, 'entries-added'), 42)
+      assert.strictEqual(
+        await node.call('XADD', key, '5-*', 'f', 'next'),
+        '5-1',
+      )
+
+      const updatedInfo = (await node.call('XINFO', 'STREAM', key)) as unknown[]
+      assert.strictEqual(kvArrayGet(updatedInfo, 'entries-added'), 43)
+    } finally {
+      await node.del(key)
+      node.disconnect()
+    }
+  })
+
+  test('XSETID rejects lower ids, invalid options, and wrong types', async () => {
+    const tag = `{xsetid-errors:${randomKey()}}`
+    const key = `${tag}:stream`
+    const stringKey = `${tag}:string`
+    const node = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      await node.call('XADD', key, '5-0', 'f', 'v')
+      await node.set(stringKey, 'not-a-stream')
+
+      await assert.rejects(
+        () => node.call('XSETID', `${tag}:missing`, '1-0'),
+        errorWithMessage('ERR no such key'),
+      )
+      await assert.rejects(
+        () => node.call('XSETID', key, '4-0'),
+        errorWithMessage(
+          'ERR The ID specified in XSETID is smaller than the target stream top item',
+        ),
+      )
+      await assert.rejects(
+        () => node.call('XSETID', key, 'not-an-id'),
+        errorWithMessage(
+          'ERR Invalid stream ID specified as stream command argument',
+        ),
+      )
+      await assert.rejects(
+        () => node.call('XSETID', key, '6-0', 'ENTRIESADDED', 'nope'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () => node.call('XSETID', key, '6-0', 'ENTRIESADDED'),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => node.call('XSETID', key, '6-0', 'BOGUS', '1'),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => node.call('XSETID', stringKey, '6-0'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+    } finally {
+      await node.del(key, stringKey)
+      node.disconnect()
+    }
+  })
+
   test('XRANGE returns entries within an inclusive range', async () => {
     const key = randomKey()
     await redisClient?.xadd(key, '1-1', 'a', '1')


### PR DESCRIPTION
## Summary

- Add `XSETID key last-id [ENTRIESADDED entries-added]` as a stream write command.
- Match real Redis behavior for existing-stream requirement, lower-ID rejection, generated ID advancement, and `entries-added` metadata updates.
- Mark XSETID implemented in `docs/COMMANDS.md`.

## Root Cause

`XSETID` was listed as missing, so callers could not set a stream's `last-generated-id` or replicate the `entries-added` counter through the Redis command surface.

## Validation

- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/stream-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/stream-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`

Fixes #213
