### PR TITLE
fix xsetid maxdeletedid option

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -344,13 +344,12 @@ with `GT` or `LT`.
 - [x] `XINFO STREAM key [FULL [COUNT count]]` - Inspect stream metadata, entries, groups, and PEL details
 - [x] `XINFO GROUPS key` - List stream consumer groups
 - [x] `XINFO CONSUMERS key group` - List consumers in a group
-- [x] `XSETID key last-id [ENTRIESADDED entries-added]` - Set the last-generated stream ID and optionally the entries-added counter
+- [x] `XSETID key last-id [ENTRIESADDED entries-added] [MAXDELETEDID max-deleted-id]` - Set the last-generated stream ID and optionally stream metadata counters
 
 #### Notes / gaps vs. real Redis
 
 - Approximate (`~`) `XADD`/`XTRIM` trim specs use a simplified mock heuristic that may leave one extra eligible entry; `LIMIT count` is accepted for Redis-compatible parsing and treated as a trimming hint.
 - [ ] Stream radix-tree statistics in `XINFO STREAM` are approximated for mock compatibility rather than mirroring Redis internals
-- [ ] `XSETID ... MAXDELETEDID max-deleted-id` is not supported - rejected with a syntax error instead of updating `max-deleted-entry-id` ([#259](https://github.com/fatal10110/js-redis-server/issues/259))
 
 ## 10. Scan Family
 

--- a/src/commands/streams/xsetid.ts
+++ b/src/commands/streams/xsetid.ts
@@ -27,6 +27,7 @@ type XsetidArgs = {
   key: Buffer
   id: StreamId
   entriesAdded: number | null
+  maxDeletedId: StreamId | null
 }
 
 function createXsetidSchema() {
@@ -40,12 +41,21 @@ function createXsetidSchema() {
 
       let cursor = index + 2
       let entriesAdded: number | null = null
+      let maxDeletedId: StreamId | null = null
       while (cursor < input.length) {
         const option = input[cursor].toString().toUpperCase()
         if (option === 'ENTRIESADDED') {
           const rawEntriesAdded = input[cursor + 1]
           if (!rawEntriesAdded) throw new RedisSyntaxError()
           entriesAdded = parseNonNegativeInteger(rawEntriesAdded)
+          cursor += 2
+          continue
+        }
+
+        if (option === 'MAXDELETEDID') {
+          const rawMaxDeletedId = input[cursor + 1]
+          if (!rawMaxDeletedId) throw new RedisSyntaxError()
+          maxDeletedId = parseExactId(rawMaxDeletedId.toString())
           cursor += 2
           continue
         }
@@ -58,6 +68,7 @@ function createXsetidSchema() {
           key,
           id: parseExactId(rawId.toString()),
           entriesAdded,
+          maxDeletedId,
         },
         nextIndex: input.length,
       }
@@ -82,6 +93,9 @@ export const xsetidCommand = defineCommand({
       writable.value.lastId = cloneStreamId(command.id)
       if (command.entriesAdded !== null) {
         writable.value.entriesAdded = command.entriesAdded
+      }
+      if (command.maxDeletedId !== null) {
+        writable.value.maxDeletedEntryId = cloneStreamId(command.maxDeletedId)
       }
       writable.forceWrite()
     })

--- a/tests-integration/ioredis/stream-integration.test.ts
+++ b/tests-integration/ioredis/stream-integration.test.ts
@@ -179,6 +179,64 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
     }
   })
 
+  test('XSETID MAXDELETEDID updates XINFO STREAM metadata', async () => {
+    const key = `{xsetid-maxdeleted:${randomKey()}}`
+    const node = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      await node.call('XADD', key, '1-0', 'f', 'v')
+      assert.strictEqual(
+        await node.call(
+          'XSETID',
+          key,
+          '5-0',
+          'maxdeletedid',
+          '2-0',
+          'ENTRIESADDED',
+          '42',
+        ),
+        'OK',
+      )
+
+      const streamInfo = (await node.call('XINFO', 'STREAM', key)) as unknown[]
+      assert.strictEqual(kvArrayGet(streamInfo, 'last-generated-id'), '5-0')
+      assert.strictEqual(kvArrayGet(streamInfo, 'max-deleted-entry-id'), '2-0')
+      assert.strictEqual(kvArrayGet(streamInfo, 'entries-added'), 42)
+
+      assert.strictEqual(
+        await node.call(
+          'XSETID',
+          key,
+          '6-0',
+          'ENTRIESADDED',
+          '7',
+          'MAXDELETEDID',
+          '3-0',
+          'ENTRIESADDED',
+          '9',
+          'MAXDELETEDID',
+          '4-0',
+        ),
+        'OK',
+      )
+
+      const duplicateInfo = (await node.call(
+        'XINFO',
+        'STREAM',
+        key,
+      )) as unknown[]
+      assert.strictEqual(kvArrayGet(duplicateInfo, 'last-generated-id'), '6-0')
+      assert.strictEqual(
+        kvArrayGet(duplicateInfo, 'max-deleted-entry-id'),
+        '4-0',
+      )
+      assert.strictEqual(kvArrayGet(duplicateInfo, 'entries-added'), 9)
+    } finally {
+      await node.del(key)
+      node.disconnect()
+    }
+  })
+
   test('XSETID rejects lower ids, invalid options, and wrong types', async () => {
     const tag = `{xsetid-errors:${randomKey()}}`
     const key = `${tag}:stream`
@@ -211,6 +269,16 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
       )
       await assert.rejects(
         () => node.call('XSETID', key, '6-0', 'ENTRIESADDED'),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => node.call('XSETID', key, '6-0', 'MAXDELETEDID', 'bad-id'),
+        errorWithMessage(
+          'ERR Invalid stream ID specified as stream command argument',
+        ),
+      )
+      await assert.rejects(
+        () => node.call('XSETID', key, '6-0', 'MAXDELETEDID'),
         errorWithMessage('ERR syntax error'),
       )
       await assert.rejects(


### PR DESCRIPTION
## Summary
- Accept `XSETID ... MAXDELETEDID max-deleted-id` and persist it to stream `max-deleted-entry-id` metadata.
- Cover mixed option ordering, case-insensitivity, duplicate-option last-value-wins behavior, and missing/invalid `MAXDELETEDID` errors against real Redis.
- Update `docs/COMMANDS.md` to remove the fixed gap and document the full syntax.

## Root Cause
`XSETID` used a custom schema that only recognized `ENTRIESADDED`, so `MAXDELETEDID` fell through to `ERR syntax error` instead of parsing a stream ID and updating `stream.maxDeletedEntryId`.

## Validation
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test-name-pattern "XSETID" --test ./tests-integration/ioredis/stream-integration.test.ts` (failed before fix, passed after)
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 60000 --test-name-pattern "XSETID" --test ./tests-integration/ioredis/stream-integration.test.ts`
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/stream-integration.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 60000 --test ./tests-integration/ioredis/stream-integration.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`

Note: `npm run test:integration:real` prints READONLY responses from replica nodes during the cluster cleanup `FLUSHALL`; the command completed successfully with 518 passing, 1 skipped, and 0 failures.

Fixes #259
