### PR TITLE
Fix active expiry sweep

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -332,10 +332,13 @@ Each database wraps a [`RedisKeyspace`](../src/state/keyspace.ts#L34): a
 [`RedisDataValue`](../src/state/data-types.ts)s (`string`, `hash`, `list`,
 `set`, `zset`, `stream`). Stream values store ordered entries plus consumer
 groups, per-group pending-entry lists, and consumer idle metadata. Expiration is
-**lazy** — `getLiveEntry` calls
-[`evictIfExpired`](../src/state/keyspace.ts#L207) on read, deleting and
-emitting an `evict` mutation event so `WATCH` observes expiry exactly like a
-real delete. Every mutation (`write`/`delete`/`expire`/`persist`/`evict`/`flush`)
+handled by both an active sweep and a lazy fallback. `RedisServerState` runs a
+background active-expiry pass across its databases, under each database's
+`SerialTurnQueue`, and `getLiveEntry` still calls
+[`evictIfExpired`](../src/state/keyspace.ts#L240) on reads that encounter an
+expired key before the next sweep. Either path deletes the entry and emits an
+`evict` mutation event so `WATCH` observes expiry exactly like a real delete.
+Every mutation (`write`/`delete`/`expire`/`persist`/`evict`/`flush`)
 flows through [`RedisMutationBus.emit`](../src/state/mutation-events.ts#L68),
 which clones values before fan-out so subscribers can never mutate shared state.
 The [`KeyspaceNotifier`](../src/state/keyspace-notifier.ts) subscribes to this

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -334,7 +334,8 @@ Each database wraps a [`RedisKeyspace`](../src/state/keyspace.ts#L34): a
 groups, per-group pending-entry lists, and consumer idle metadata. Expiration is
 handled by both an active sweep and a lazy fallback. `RedisServerState` runs a
 background active-expiry pass across its databases, under each database's
-`SerialTurnQueue`, and `getLiveEntry` still calls
+`SerialTurnQueue`; cluster replicas disable their own active sweep and rely on
+the master's replicated deletion. `getLiveEntry` still calls
 [`evictIfExpired`](../src/state/keyspace.ts#L240) on reads that encounter an
 expired key before the next sweep. Either path deletes the entry and emits an
 `evict` mutation event so `WATCH` observes expiry exactly like a real delete.

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -233,6 +233,7 @@ function createClusterNodeStates(
       new RedisServerState({
         databaseCount,
         clusterTopology: topology,
+        activeExpiryIntervalMs: node.role === 'replica' ? false : undefined,
       }),
     )
   }

--- a/src/core/transports/resp2/server.ts
+++ b/src/core/transports/resp2/server.ts
@@ -62,6 +62,7 @@ export class Resp2Server {
           reject(err)
           return
         }
+        this.state.close()
         resolve()
       }),
     )

--- a/src/core/transports/resp2/server.ts
+++ b/src/core/transports/resp2/server.ts
@@ -58,11 +58,11 @@ export class Resp2Server {
   close(): Promise<void> {
     return new Promise((resolve, reject) =>
       this.server.close(err => {
+        this.state.close()
         if (err) {
           reject(err)
           return
         }
-        this.state.close()
         resolve()
       }),
     )

--- a/src/state/database.ts
+++ b/src/state/database.ts
@@ -228,6 +228,10 @@ export class RedisDatabase {
     return this.keyspace.entriesSnapshot()
   }
 
+  sweepExpired(now?: number): number {
+    return this.keyspace.sweepExpired(now)
+  }
+
   subscribe(listener: RedisMutationListener): Unsubscribe {
     return this.mutations.subscribe(listener)
   }

--- a/src/state/keyspace.ts
+++ b/src/state/keyspace.ts
@@ -193,25 +193,15 @@ export class RedisKeyspace {
   }
 
   size(): number {
-    let count = 0
-
-    for (const entry of Array.from(this.entries.values())) {
-      if (!this.evictIfExpired(entry)) {
-        count += 1
-      }
-    }
-
-    return count
+    this.sweepExpired()
+    return this.entries.size
   }
 
   entriesSnapshot(): KeyspaceEntry[] {
+    this.sweepExpired()
     const entries: KeyspaceEntry[] = []
 
-    for (const entry of Array.from(this.entries.values())) {
-      if (this.evictIfExpired(entry)) {
-        continue
-      }
-
+    for (const entry of this.entries.values()) {
       entries.push({
         key: Buffer.from(entry.key),
         value: cloneRedisDataValue(entry.value),
@@ -220,6 +210,18 @@ export class RedisKeyspace {
     }
 
     return entries
+  }
+
+  sweepExpired(now = Date.now()): number {
+    let count = 0
+
+    for (const entry of Array.from(this.entries.values())) {
+      if (this.evictIfExpired(entry, now)) {
+        count += 1
+      }
+    }
+
+    return count
   }
 
   private getLiveEntry(key: Buffer): KeyspaceEntry | null {
@@ -235,8 +237,8 @@ export class RedisKeyspace {
     return entry
   }
 
-  private evictIfExpired(entry: KeyspaceEntry): boolean {
-    if (entry.expiresAt === undefined || entry.expiresAt > Date.now()) {
+  private evictIfExpired(entry: KeyspaceEntry, now = Date.now()): boolean {
+    if (entry.expiresAt === undefined || entry.expiresAt > now) {
       return false
     }
 

--- a/src/state/server-state.ts
+++ b/src/state/server-state.ts
@@ -46,8 +46,7 @@ export class RedisServerState {
    */
   notifyKeyspaceEvents = ''
   private readonly clientSessions = new Set<RedisClientSession>()
-  private activeExpiryTimer: ReturnType<typeof setInterval> | null = null
-  private activeExpiryRunning = false
+  private activeExpiryTimer: ReturnType<typeof setTimeout> | null = null
   private closed = false
   private luaRuntimePromise: Promise<RedisLuaRuntime> | null = null
 
@@ -136,7 +135,7 @@ export class RedisServerState {
   close(): void {
     this.closed = true
     if (this.activeExpiryTimer) {
-      clearInterval(this.activeExpiryTimer)
+      clearTimeout(this.activeExpiryTimer)
       this.activeExpiryTimer = null
     }
   }
@@ -151,39 +150,50 @@ export class RedisServerState {
       throw new Error(`Invalid active expiry interval ${resolvedIntervalMs}`)
     }
 
-    const timer = setInterval(() => {
-      void this.runActiveExpiry()
-    }, resolvedIntervalMs)
-    ;(
-      timer as ReturnType<typeof setInterval> & { unref?: () => void }
-    ).unref?.()
+    this.scheduleActiveExpiry(resolvedIntervalMs)
+  }
+
+  private scheduleActiveExpiry(intervalMs: number): void {
+    const timer = setTimeout(() => {
+      this.activeExpiryTimer = null
+      void this.runActiveExpiryTick(intervalMs)
+    }, intervalMs)
+
+    ;(timer as ReturnType<typeof setTimeout> & { unref?: () => void }).unref?.()
     this.activeExpiryTimer = timer
   }
 
+  private async runActiveExpiryTick(intervalMs: number): Promise<void> {
+    try {
+      await this.runActiveExpiry()
+    } catch {
+      // Active expiry is best-effort; command reads still lazily expire keys.
+    } finally {
+      if (!this.closed) {
+        this.scheduleActiveExpiry(intervalMs)
+      }
+    }
+  }
+
   private async runActiveExpiry(): Promise<void> {
-    if (this.closed || this.activeExpiryRunning) {
+    if (this.closed) {
       return
     }
 
-    this.activeExpiryRunning = true
-    try {
-      const now = Date.now()
-      for (const database of this.databases) {
-        if (this.closed) {
-          return
-        }
-
-        const turn = await database.turnQueue.waitTurn()
-        try {
-          if (!this.closed) {
-            database.sweepExpired(now)
-          }
-        } finally {
-          turn.release()
-        }
+    const now = Date.now()
+    for (const database of this.databases) {
+      if (this.closed) {
+        return
       }
-    } finally {
-      this.activeExpiryRunning = false
+
+      const turn = await database.turnQueue.waitTurn()
+      try {
+        if (!this.closed) {
+          database.sweepExpired(now)
+        }
+      } finally {
+        turn.release()
+      }
     }
   }
 }

--- a/src/state/server-state.ts
+++ b/src/state/server-state.ts
@@ -18,12 +18,19 @@ export type RedisServerStateOptions = {
   pubsubBroker?: RedisPubSubBroker
   scriptCache?: RedisScriptCache
   /**
+   * Interval for the background active-expiry sweep. Set to `false` to disable
+   * the timer for tests that need full manual control of expiration.
+   */
+  activeExpiryIntervalMs?: number | false
+  /**
    * Optional server password (Redis `requirepass`). When set, connections start
    * unauthenticated and must `AUTH` before running most commands. When unset,
    * the default user is `nopass` and no authentication is enforced.
    */
   requirepass?: string
 }
+
+const DEFAULT_ACTIVE_EXPIRY_INTERVAL_MS = 100
 
 export class RedisServerState {
   readonly databases: RedisDatabase[]
@@ -39,6 +46,9 @@ export class RedisServerState {
    */
   notifyKeyspaceEvents = ''
   private readonly clientSessions = new Set<RedisClientSession>()
+  private activeExpiryTimer: ReturnType<typeof setInterval> | null = null
+  private activeExpiryRunning = false
+  private closed = false
   private luaRuntimePromise: Promise<RedisLuaRuntime> | null = null
 
   constructor(options?: RedisServerStateOptions) {
@@ -71,6 +81,8 @@ export class RedisServerState {
         ),
       )
     }
+
+    this.startActiveExpiry(options?.activeExpiryIntervalMs)
   }
 
   /**
@@ -110,6 +122,68 @@ export class RedisServerState {
   flushAllDatabases(): void {
     for (const database of this.databases) {
       database.flush()
+    }
+  }
+
+  sweepExpired(now = Date.now()): number {
+    let count = 0
+    for (const database of this.databases) {
+      count += database.sweepExpired(now)
+    }
+    return count
+  }
+
+  close(): void {
+    this.closed = true
+    if (this.activeExpiryTimer) {
+      clearInterval(this.activeExpiryTimer)
+      this.activeExpiryTimer = null
+    }
+  }
+
+  private startActiveExpiry(intervalMs: number | false | undefined): void {
+    if (intervalMs === false) {
+      return
+    }
+
+    const resolvedIntervalMs = intervalMs ?? DEFAULT_ACTIVE_EXPIRY_INTERVAL_MS
+    if (!Number.isInteger(resolvedIntervalMs) || resolvedIntervalMs < 1) {
+      throw new Error(`Invalid active expiry interval ${resolvedIntervalMs}`)
+    }
+
+    const timer = setInterval(() => {
+      void this.runActiveExpiry()
+    }, resolvedIntervalMs)
+    ;(
+      timer as ReturnType<typeof setInterval> & { unref?: () => void }
+    ).unref?.()
+    this.activeExpiryTimer = timer
+  }
+
+  private async runActiveExpiry(): Promise<void> {
+    if (this.closed || this.activeExpiryRunning) {
+      return
+    }
+
+    this.activeExpiryRunning = true
+    try {
+      const now = Date.now()
+      for (const database of this.databases) {
+        if (this.closed) {
+          return
+        }
+
+        const turn = await database.turnQueue.waitTurn()
+        try {
+          if (!this.closed) {
+            database.sweepExpired(now)
+          }
+        } finally {
+          turn.release()
+        }
+      }
+    } finally {
+      this.activeExpiryRunning = false
     }
   }
 }

--- a/tests-integration/ioredis/keyspace-notifications-integration.test.ts
+++ b/tests-integration/ioredis/keyspace-notifications-integration.test.ts
@@ -120,6 +120,26 @@ describe(`Keyspace notifications (${testRunner.getBackendName()})`, () => {
     assert.strictEqual(await expired, true)
   })
 
+  test('publishes expired event from active expiry without a forcing read', async () => {
+    const actor = await connect()
+    const subscriber = await connect()
+    await actor.config('SET', 'notify-keyspace-events', 'KEA')
+    const key = randomKey()
+
+    await subscriber.psubscribe(`__keyevent@0__:*`)
+    await settle()
+
+    const expired = waitForEvent(
+      subscriber,
+      `__keyevent@0__:expired`,
+      key,
+      3000,
+    )
+    await actor.set(key, 'v', 'PX', 50)
+
+    assert.strictEqual(await expired, true)
+  })
+
   test('translates RENAME into rename_from and rename_to', async () => {
     const actor = await connect()
     const subscriber = await connect()

--- a/tests/cluster-network.test.ts
+++ b/tests/cluster-network.test.ts
@@ -46,13 +46,56 @@ describe('ClusterNetwork slot distribution', () => {
     const key = Buffer.from('delayed-replica-key')
     master.server.getDatabase(0).setString(key, Buffer.from('value'))
 
-    assert.strictEqual(replica.server.getDatabase(0).getString(key), null)
+    try {
+      assert.strictEqual(replica.server.getDatabase(0).getString(key), null)
 
-    await sleep(40)
+      await sleep(40)
 
-    assert.deepStrictEqual(
-      replica.server.getDatabase(0).getString(key),
-      Buffer.from('value'),
-    )
+      assert.deepStrictEqual(
+        replica.server.getDatabase(0).getString(key),
+        Buffer.from('value'),
+      )
+    } finally {
+      await closeUnstartedCluster(cluster)
+    }
+  })
+
+  test('replica states do not actively expire replicated keys on their own clock', async () => {
+    const cluster = buildRedisCluster({
+      masters: 1,
+      replicasPerMaster: 1,
+      basePort: 0,
+    })
+    const replica = cluster.nodes.find(node => node.role === 'replica')
+    assert.ok(replica)
+
+    const key = Buffer.from('replica-active-expiry-key')
+    const events: string[] = []
+    const replicaDb = replica.server.getDatabase(0)
+    replicaDb.subscribeKey(key, event => events.push(event.type))
+
+    try {
+      replicaDb.setString(key, Buffer.from('value'), {
+        expiresAt: Date.now() + 10,
+      })
+
+      await sleep(150)
+
+      assert.deepStrictEqual(events, ['write'])
+    } finally {
+      await closeUnstartedCluster(cluster)
+    }
   })
 })
+
+async function closeUnstartedCluster(
+  cluster: ReturnType<typeof buildRedisCluster>,
+): Promise<void> {
+  try {
+    await cluster.close()
+  } catch (err) {
+    if ((err as { code?: string }).code !== 'ERR_SERVER_NOT_RUNNING') {
+      throw err
+    }
+  }
+}

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -83,6 +83,25 @@ describe('new Redis state core', () => {
     db.expire(key, Date.now() - 1)
     assert.strictEqual(db.get(key), null)
     assert.strictEqual(events.at(-1)?.type, 'evict')
+    server.close()
+  })
+
+  test('actively sweeps expired entries without a read', async () => {
+    const server = new RedisServerState({ activeExpiryIntervalMs: 5 })
+    const db = server.getDatabase(0)
+    const key = Buffer.from('active-expiring')
+    const events: RedisMutationEvent[] = []
+    db.subscribeKey(key, event => events.push(event))
+
+    try {
+      db.setString(key, Buffer.from('value'), { expiresAt: Date.now() + 10 })
+
+      await waitUntil(() => events.some(event => event.type === 'evict'))
+
+      assert.strictEqual(db.size(), 0)
+    } finally {
+      server.close()
+    }
   })
 
   test('returns defensive clones from reads and mutation events', () => {
@@ -239,4 +258,19 @@ function assertHashValue(value: RedisDataValue | null, expected: string) {
 
 function fieldKey(field: string): string {
   return Buffer.from(field).toString('hex')
+}
+
+async function waitUntil(
+  predicate: () => boolean,
+  timeoutMs = 500,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return
+    }
+    await new Promise(resolve => setTimeout(resolve, 5))
+  }
+
+  assert.fail('Timed out waiting for condition')
 }

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -1,6 +1,12 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert'
-import { RedisServerState, WrongTypeRedisError, createStringData } from '../src'
+import {
+  Resp2Server,
+  RedisServerState,
+  WrongTypeRedisError,
+  createRedisCommandExecutor,
+  createStringData,
+} from '../src'
 import type {
   RedisDataValue,
   RedisMonitorCommandEvent,
@@ -102,6 +108,61 @@ describe('new Redis state core', () => {
     } finally {
       server.close()
     }
+  })
+
+  test('active expiry swallows listener failures without an unhandled rejection', async () => {
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown) => unhandled.push(reason)
+    process.on('unhandledRejection', onUnhandled)
+
+    const server = new RedisServerState({ activeExpiryIntervalMs: 5 })
+    const db = server.getDatabase(0)
+    const key = Buffer.from('active-expiry-listener-error')
+    db.subscribe(event => {
+      if (event.type === 'evict') {
+        throw new Error('listener boom')
+      }
+    })
+
+    try {
+      db.setString(key, Buffer.from('value'), { expiresAt: Date.now() + 10 })
+
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      assert.strictEqual(
+        unhandled.length,
+        0,
+        'active expiry must catch sweep failures',
+      )
+    } finally {
+      server.close()
+      process.off('unhandledRejection', onUnhandled)
+    }
+  })
+
+  test('Resp2Server.close closes state even when the TCP server never listened', async () => {
+    const state = new RedisServerState({ activeExpiryIntervalMs: 5 })
+    const server = new Resp2Server({
+      server: state,
+      executor: createRedisCommandExecutor(),
+    })
+    const db = state.getDatabase(0)
+    const key = Buffer.from('close-before-listen')
+    const events: RedisMutationEvent[] = []
+    db.subscribeKey(key, event => events.push(event))
+
+    db.setString(key, Buffer.from('value'), { expiresAt: Date.now() + 10 })
+
+    await assert.rejects(() => server.close(), {
+      code: 'ERR_SERVER_NOT_RUNNING',
+    })
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    assert.deepStrictEqual(
+      events.map(event => event.type),
+      ['write'],
+      'state timer must be closed even when server.close rejects',
+    )
   })
 
   test('returns defensive clones from reads and mutation events', () => {


### PR DESCRIPTION
## Summary
- Add a RedisServerState active-expiry sweep that removes expired entries without waiting for a later read.
- Run sweep work under each database SerialTurnQueue and clean up the timer through RedisServerState.close()/Resp2Server.close().
- Keep lazy eviction as a fallback and document the updated expiration lifecycle.

## Root cause
Expired entries were only evicted by read/snapshot paths. Keys that expired and were never touched again stayed allocated, and active expiry notifications were never emitted.

## Validation
- Red check: mock active-expiry notification test timed out before the fix.
- Focused unit active-expiry state test.
- Focused mock and real keyspace-notification active-expiry tests.
- npm run build
- npm test
- npm run test:integration:mock
- npm run test:integration:real (518 passed, 1 skipped, 0 failed)
- npm run lint
- git diff --check
- Pre-push hook: npm test

Fixes #86