### PR TITLE
[codex] unskip Redis 7.2 integration coverage

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,8 @@
 services:
   # Redis Cluster using grokzen/redis-cluster
   redis-cluster:
-    image: grokzen/redis-cluster:7.0.14
+    image: grokzen/redis-cluster:7.2.5
+    platform: linux/amd64
     ports:
       - '30000-30005:30000-30005'
     environment:
@@ -12,6 +13,8 @@ services:
       SLAVES_PER_MASTER: 1
       # For Mac compatibility
       IP: 0.0.0.0
+      LANG: C
+      LC_ALL: C
     healthcheck:
       # Only healthy once every slot is assigned and the cluster reports OK.
       # `get a` answers before the cluster has finished forming, which lets
@@ -31,7 +34,7 @@ services:
   # or SELECT (e.g. SELECT inside MULTI/EXEC) connect here instead. The harness
   # uses it when REDIS_STANDALONE_PORT is set; see tests-integration/test-config.ts.
   redis-standalone:
-    image: redis:7.2
+    image: redis:7.2.5
     ports:
       - '6399:6379'
     healthcheck:
@@ -46,7 +49,7 @@ services:
   # connect here. The harness uses it when REDIS_STANDALONE_AUTH_PORT is set;
   # see tests-integration/test-config.ts (STANDALONE_AUTH_PASSWORD).
   redis-standalone-auth:
-    image: redis:7.2
+    image: redis:7.2.5
     command:
       [
         'redis-server',

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -195,7 +195,7 @@ with `GT` or `LT`.
 
 ## 4. String Commands
 
-- [x] `GET key` - Get the value of a key
+- [x] `GET key` - Returns the string value of a key.
 - [x] `SET key value [NX | XX] [GET] [KEEPTTL | EX seconds | PX milliseconds | EXAT unix-time-seconds | PXAT unix-time-milliseconds]` - Set the string value of a key
 - [x] `SETNX key value` - Set the value of a key, only if it does not exist
 - [x] `SETEX key seconds value` - Set the value and expiration in seconds
@@ -324,7 +324,7 @@ with `GT` or `LT`.
 #### Notes / gaps vs. real Redis
 
 - Score replies from `ZSCORE`, `ZINCRBY`, `ZRANK WITHSCORE`, `ZREVRANK WITHSCORE`, `ZRANGE WITHSCORES`, `ZREVRANGE WITHSCORES`, `ZRANGEBYSCORE WITHSCORES`, `ZREVRANGEBYSCORE WITHSCORES`, `ZPOPMIN`, `ZPOPMAX`, `ZMPOP`, `BZMPOP`, `BZPOPMIN`, `BZPOPMAX`, and `ZSCAN` serialize infinite scores as `inf` / `-inf`.
-- `ZREVRANGE` is intentionally limited to `key start stop [WITHSCORES]`, matching real Redis: the command was deprecated in 6.2 in favor of `ZRANGE ... REV` and never gained `BYSCORE`/`BYLEX`/`REV`/`LIMIT` itself (verified against live Redis 7.0.14, which also rejects those tokens with `ERR syntax error`). Use `ZRANGE ... REV` for the unified syntax.
+- `ZREVRANGE` is intentionally limited to `key start stop [WITHSCORES]`, matching real Redis: the command was deprecated in 6.2 in favor of `ZRANGE ... REV` and never gained `BYSCORE`/`BYLEX`/`REV`/`LIMIT` itself (verified against live Redis 7.2.5, which also rejects those tokens with `ERR syntax error`). Use `ZRANGE ... REV` for the unified syntax.
 
 ## 9. Stream Commands
 

--- a/src/commands/streams/xadd.ts
+++ b/src/commands/streams/xadd.ts
@@ -2,7 +2,6 @@ import { defineCommand } from '../../core/command-definition'
 import { t, type ParseContext } from '../../core/command-schema'
 import {
   InvalidStreamIdError,
-  StreamElementTooLargeError,
   StreamIdEqualOrSmallerError,
   StreamIdExhaustedError,
   StreamIdNotGreaterThanZeroError,
@@ -59,10 +58,7 @@ function nextSeqForMs(ms: bigint, lastId: StreamId): StreamId {
   if (ms < lastId.ms) {
     return { ms, seq: lastId.seq === MAX_UINT64 ? MAX_UINT64 : lastId.seq + 1n }
   }
-  if (lastId.seq === MAX_UINT64) {
-    if (ms === MAX_UINT64) throw new StreamIdExhaustedError()
-    throw new StreamElementTooLargeError()
-  }
+  if (lastId.seq === MAX_UINT64) return { ms, seq: MAX_UINT64 }
 
   return { ms, seq: lastId.seq + 1n }
 }

--- a/src/commands/strings.ts
+++ b/src/commands/strings.ts
@@ -61,7 +61,7 @@ export const getCommand = defineCommand({
     keyStep: 1,
     categories: ['@read', '@string', '@fast'],
     keySpecs: [commandKeySpec(1, 0, 1, ['RO', 'access'])],
-    docs: commandDocs('Get the value of a key', 'string', [
+    docs: commandDocs('Returns the string value of a key.', 'string', [
       commandKeyArgument('key', 0),
     ]),
   },

--- a/tests-integration/ioredis/command-integration.test.ts
+++ b/tests-integration/ioredis/command-integration.test.ts
@@ -113,7 +113,7 @@ describe(`COMMAND integration (${testRunner.getBackendName()})`, () => {
     assert.strictEqual(docs[0], 'get')
 
     const getDocs = docs[1] as unknown[]
-    assertMapEntry(getDocs, 'summary', 'Get the value of a key')
+    assertMapEntry(getDocs, 'summary', 'Returns the string value of a key.')
     assertMapEntry(getDocs, 'group', 'string')
 
     const unknownDocs = (await redisClient?.call(
@@ -141,7 +141,7 @@ describe(`COMMAND integration (${testRunner.getBackendName()})`, () => {
       assert.ok(getDocs instanceof Map)
       assert.strictEqual(
         respText(respMapGet(getDocs, 'summary')),
-        'Get the value of a key',
+        'Returns the string value of a key.',
       )
       assert.strictEqual(respText(respMapGet(getDocs, 'group')), 'string')
 

--- a/tests-integration/ioredis/stream-integration.test.ts
+++ b/tests-integration/ioredis/stream-integration.test.ts
@@ -77,7 +77,9 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
       )
       await assert.rejects(
         () => node.call('XADD', fixedMsKey, '7-*', 'f', 'v'),
-        errorWithMessage('ERR Elements are too large to be stored'),
+        errorWithMessage(
+          'ERR The ID specified in XADD is equal or smaller than the target stream top item',
+        ),
       )
 
       assert.strictEqual(

--- a/tests-integration/ioredis/zset-integration.test.ts
+++ b/tests-integration/ioredis/zset-integration.test.ts
@@ -6,24 +6,6 @@ import { errorWithMessage, randomKey } from '../utils'
 
 const testRunner = new TestRunner()
 
-function redisVersionFromInfo(info: string | undefined): string | null {
-  const match = info?.match(/^redis_version:(\d+\.\d+\.\d+)/m)
-  return match?.[1] ?? null
-}
-
-function redisVersionAtLeast(
-  version: string | null,
-  major: number,
-  minor: number,
-): boolean {
-  if (!version) {
-    return false
-  }
-
-  const [actualMajor = 0, actualMinor = 0] = version.split('.').map(Number)
-  return actualMajor > major || (actualMajor === major && actualMinor >= minor)
-}
-
 describe(`Sorted Set Commands Integration (${testRunner.getBackendName()})`, () => {
   let redisClient: Cluster | undefined
 
@@ -207,20 +189,7 @@ describe(`Sorted Set Commands Integration (${testRunner.getBackendName()})`, () 
     assert.strictEqual(revrank2, 2)
   })
 
-  test('ZRANK and ZREVRANK WITHSCORE option', async t => {
-    if (testRunner.backend === 'real') {
-      const serverInfo = (await redisClient?.call('INFO', 'server')) as
-        | string
-        | undefined
-      const redisVersion = redisVersionFromInfo(serverInfo)
-      if (!redisVersionAtLeast(redisVersion, 7, 2)) {
-        t.skip(
-          `ZRANK WITHSCORE requires Redis 7.2+; real backend is ${redisVersion ?? 'unknown'}`,
-        )
-        return
-      }
-    }
-
+  test('ZRANK and ZREVRANK WITHSCORE option', async () => {
     const keyTag = `zrank-withscore:${randomKey()}`
     const zsetKey = `{${keyTag}}:zset`
     const stringKey = `{${keyTag}}:string`


### PR DESCRIPTION
## Summary

- upgrade the real Redis test compose stack to Redis 7.2.5 so Redis 7.2-only coverage can run instead of being skipped
- remove the ZRANK/ZREVRANK WITHSCORE runtime skip from the ioredis integration suite
- align mock behavior and docs with Redis 7.2.5 for COMMAND DOCS GET and XADD fixed-millisecond sequence overflow

## Root Cause

The real cluster image was pinned to Redis 7.0.14, so the ZRANK/ZREVRANK WITHSCORE integration coverage had to skip on the real backend. Moving the cluster to grokzen/redis-cluster:7.2.5 exposed two Redis 7.2.5 compatibility differences that the mock needed to match.

## Validation

- npm run build
- npm test
- npm run lint
- npm run test:integration:mock
- npm run test:integration:real
- final test skip scan found no test.skip / t.skip markers
- push hook reran npm test successfully

## Notes

The Grokzen 7.2.5 cluster image is amd64-only and has a broken en_US.UTF-8 locale setup, so docker-compose.test.yml sets platform: linux/amd64 and LANG/LC_ALL=C for reliable startup on arm64 hosts.