### PR TITLE
Fix cluster command public export

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -413,14 +413,15 @@ split evenly across masters, with optional replicas), then spins up one
 `Resp2Server` per node — each with its **own** `RedisServerState` (so data is
 genuinely partitioned) but **sharing** the topology object, registered with:
 
-- an extra `CLUSTER` command ([`createClusterCommand`](../src/commands/cluster.ts))
-  scoped to that node's id (`CLUSTER INFO`/`MYID`/`NODES`/`SHARDS`/`SLOTS`), and
+- extra cluster commands ([`createClusterCommands`](../src/commands/cluster.ts)):
+  `CLUSTER`, scoped to that node's id
+  (`CLUSTER INFO`/`MYID`/`NODES`/`SHARDS`/`SLOTS`), plus `READONLY`/`READWRITE`, and
 - a [`ClusterPolicy`](../src/core/execution-policies/cluster-policy.ts) bound to
   that node's id, so each node independently validates ownership and redirects
   with `MOVED`/`CROSSSLOT`/`CLUSTERDOWN` (see [Cluster routing](#cluster-routing)).
 
 There is no separate "cluster commander" type — cluster mode is the same
-`Resp2Server` + `CommandExecutor` core, configured with one extra command and
+`Resp2Server` + `CommandExecutor` core, configured with extra cluster commands and
 one extra policy. `SELECT 0` is accepted as a no-op in cluster mode (Redis
 Cluster only exposes database 0); any non-zero index is rejected. Multi-database
 commands such as `MOVE` are rejected in cluster mode.

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -73,7 +73,6 @@ export {
 } from './connection'
 export { monitorCommand, monitorCommands } from './monitor'
 export {
-  createClusterCommand,
   createClusterCommands,
   readonlyCommand,
   readwriteCommand,

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,6 @@ export {
   createRedisCommandRegistry,
   commandCommand,
   copyCommand,
-  createClusterCommand,
   createClusterCommands,
   dbsizeCommand,
   delCommand,

--- a/tests/cluster-nodes-format.test.ts
+++ b/tests/cluster-nodes-format.test.ts
@@ -4,7 +4,7 @@ import {
   ClientSession,
   RedisClusterTopology,
   RedisServerState,
-  createClusterCommand,
+  createClusterCommands,
   createClusterPolicy,
   createRedisCommandExecutor,
 } from '../src'
@@ -57,7 +57,7 @@ async function clusterNodes(): Promise<string> {
   ])
   const server = new RedisServerState({ clusterTopology: topology })
   const executor = createRedisCommandExecutor({
-    extraCommands: [createClusterCommand('local')],
+    extraCommands: createClusterCommands('local'),
     policies: [createClusterPolicy({ localNodeId: 'local' })],
   })
   const session = new ClientSession({ server, executor })

--- a/tests/core-cluster-policy.test.ts
+++ b/tests/core-cluster-policy.test.ts
@@ -7,7 +7,7 @@ import {
   RedisServerState,
   RedisValue,
   createClusterPolicy,
-  createClusterCommand,
+  createClusterCommands,
   createRedisCommandExecutor,
 } from '../src'
 
@@ -182,7 +182,7 @@ function createClusterHarness() {
   ])
   const server = new RedisServerState({ clusterTopology: topology })
   const executor = createRedisCommandExecutor({
-    extraCommands: [createClusterCommand('local')],
+    extraCommands: createClusterCommands('local'),
     policies: [createClusterPolicy({ localNodeId: 'local' })],
   })
   const session = new ClientSession({ server, executor })

--- a/tests/public-exports.test.ts
+++ b/tests/public-exports.test.ts
@@ -1,0 +1,14 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import * as commandApi from '../src/commands'
+import * as publicApi from '../src'
+
+describe('public exports', () => {
+  test('exports only the plural cluster command factory', () => {
+    assert.strictEqual('createClusterCommands' in publicApi, true)
+    assert.strictEqual('createClusterCommand' in publicApi, false)
+
+    assert.strictEqual('createClusterCommands' in commandApi, true)
+    assert.strictEqual('createClusterCommand' in commandApi, false)
+  })
+})


### PR DESCRIPTION
## Summary
- Remove the stale singular `createClusterCommand` helper from the public root and command barrel exports.
- Update internal cluster test harnesses to use `createClusterCommands`, which registers `CLUSTER`, `READONLY`, and `READWRITE` together.
- Add a public export regression and refresh the architecture note for the cluster command set.

## Root Cause
`createClusterCommand` remained re-exported after `createClusterCommands` was introduced. External callers could continue using the old singular helper and silently build cluster executors without `READONLY`/`READWRITE` registered.

## Validation
- Confirmed new `tests/public-exports.test.ts` fails before the fix.
- `npx tsc --noEmit && node --enable-source-maps --import tsx --no-warnings --test ./tests/public-exports.test.ts ./tests/core-cluster-policy.test.ts ./tests/cluster-nodes-format.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`
- Push hook reran `npm test` successfully.

Fixes #95