### PR TITLE
Add HGETDEL command

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,20 +1,41 @@
 services:
-  # Redis Cluster using grokzen/redis-cluster
+  # Redis 8.0 cluster. grokzen/redis-cluster never published an 8.x tag, so we
+  # run our own 6-node cluster from the official image. All six redis-server
+  # processes live in ONE container so they reach each other over 127.0.0.1 and
+  # the host port map is 1:1 — each node announces 127.0.0.1:<port>, which makes
+  # MOVED/ASK redirects resolvable from a Mac host (the same property that made
+  # grokzen "just work"). Bus ports default to client-port + 10000 (40000-4000x)
+  # and stay container-internal — host clients only ever touch the client ports.
   redis-cluster:
-    image: grokzen/redis-cluster:7.2.5
+    image: redis:8.0
     platform: linux/amd64
     ports:
       - '30000-30005:30000-30005'
-    environment:
-      # Configure cluster to start at port 8000 instead of default 7000
-      INITIAL_PORT: 30000
-      # 3 masters with 1 slave each (default, but explicit)
-      MASTERS: 3
-      SLAVES_PER_MASTER: 1
-      # For Mac compatibility
-      IP: 0.0.0.0
-      LANG: C
-      LC_ALL: C
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        for port in 30000 30001 30002 30003 30004 30005; do
+          redis-server \
+            --port $$port \
+            --cluster-enabled yes \
+            --cluster-config-file nodes-$$port.conf \
+            --cluster-node-timeout 5000 \
+            --cluster-announce-ip 127.0.0.1 \
+            --cluster-announce-port $$port \
+            --appendonly no \
+            --save "" \
+            --daemonize yes
+        done
+        until redis-cli -p 30000 ping >/dev/null 2>&1; do sleep 0.2; done
+        echo "yes" | redis-cli --cluster create \
+          127.0.0.1:30000 127.0.0.1:30001 127.0.0.1:30002 \
+          127.0.0.1:30003 127.0.0.1:30004 127.0.0.1:30005 \
+          --cluster-replicas 1
+        # Keep the container alive in the foreground; the redis-servers run
+        # daemonized in the background.
+        exec tail -f /dev/null
     healthcheck:
       # Only healthy once every slot is assigned and the cluster reports OK.
       # `get a` answers before the cluster has finished forming, which lets
@@ -34,7 +55,7 @@ services:
   # or SELECT (e.g. SELECT inside MULTI/EXEC) connect here instead. The harness
   # uses it when REDIS_STANDALONE_PORT is set; see tests-integration/test-config.ts.
   redis-standalone:
-    image: redis:7.2.5
+    image: redis:8.0
     ports:
       - '6399:6379'
     healthcheck:
@@ -49,7 +70,7 @@ services:
   # connect here. The harness uses it when REDIS_STANDALONE_AUTH_PORT is set;
   # see tests-integration/test-config.ts (STANDALONE_AUTH_PASSWORD).
   redis-standalone-auth:
-    image: redis:7.2.5
+    image: redis:8.0
     command:
       [
         'redis-server',

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -228,6 +228,7 @@ with `GT` or `LT`.
 - [x] `HMGET key field [field ...]` - Get the values of multiple hash fields
 - [x] `HGETALL key` - Get all fields and values in a hash (RESP3 map / RESP2 flat array)
 - [x] `HDEL key field [field ...]` - Delete one or more hash fields
+- [x] `HGETDEL key FIELDS numfields field [field ...]` - Get and delete one or more hash fields
 - [x] `HEXISTS key field` - Determine if a hash field exists
 - [x] `HKEYS key` - Get all fields in a hash
 - [x] `HVALS key` - Get all values in a hash
@@ -240,7 +241,7 @@ with `GT` or `LT`.
 
 #### Not implemented
 
-- [ ] `HEXPIRE` / `HPEXPIRE` / `HEXPIREAT` / `HPEXPIREAT` / `HPERSIST` / `HTTL` / `HPTTL` / `HGETDEL` / `HGETEX` (Redis 7.4 hash-field-TTL family)
+- [ ] `HEXPIRE` / `HPEXPIRE` / `HEXPIREAT` / `HPEXPIREAT` / `HPERSIST` / `HTTL` / `HPTTL` / `HGETEX` (hash-field-TTL family)
 
 ## 6. List Commands
 

--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -8,6 +8,7 @@ import {
 import {
   HashValueNotFloatError,
   HashValueNotIntegerError,
+  RedisCommandError,
   RedisSyntaxError,
   WrongNumberOfArgumentsError,
 } from '../core/redis-error'
@@ -21,6 +22,12 @@ type HrandfieldArgs = {
   count: number | undefined
   withValues: boolean
 }
+type HgetdelArgs = {
+  key: Buffer
+  fields: Buffer[]
+}
+
+const LONG_MAX = 9223372036854775807n
 
 function createFieldValuePairsSchema() {
   return t.custom<FieldValuePair[]>(
@@ -83,6 +90,51 @@ function createHrandfieldSchema() {
       return { value: { key, count, withValues }, nextIndex: cursor }
     },
   )
+}
+
+function createHgetdelSchema() {
+  return t.custom<HgetdelArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const key = input[index]
+      if (!key || input.length - index < 4) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      const fieldsToken = input[index + 1]
+      if (fieldsToken.toString().toUpperCase() !== 'FIELDS') {
+        throw new RedisCommandError(
+          'Mandatory argument FIELDS is missing or not at the right position',
+        )
+      }
+
+      const fieldCount = parsePositiveFieldCount(input[index + 2])
+      const fields = input.slice(index + 3)
+      if (fieldCount !== BigInt(fields.length)) {
+        throw new RedisCommandError(
+          'The `numfields` parameter must match the number of arguments',
+        )
+      }
+
+      return {
+        value: { key, fields },
+        nextIndex: input.length,
+      }
+    },
+  )
+}
+
+function parsePositiveFieldCount(token: Buffer): bigint {
+  const raw = token.toString()
+  if (!isIntegerToken(raw)) {
+    throw new RedisCommandError('Number of fields must be a positive integer')
+  }
+
+  const value = BigInt(raw)
+  if (value < 1n || value > LONG_MAX) {
+    throw new RedisCommandError('Number of fields must be a positive integer')
+  }
+
+  return value
 }
 
 function randomHashEntries<TValue>(entries: TValue[], count: number): TValue[] {
@@ -187,6 +239,35 @@ export const hdelCommand = defineCommand({
       ctx.db.delete(args.key)
     }
     return integer(deleted)
+  },
+})
+
+export const hgetdelCommand = defineCommand({
+  name: 'hgetdel',
+  schema: createHgetdelSchema(),
+  flags: ['write', 'fast'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    if (!ctx.db.getHash(args.key)) {
+      return array(args.fields.map(() => RedisValue.bulkString(null)))
+    }
+
+    let remaining = 0
+    const values = ctx.db.updateHash(args.key, hash => {
+      const replies: RedisValue[] = []
+      for (const field of args.fields) {
+        const entry = hash.getField(field)
+        replies.push(RedisValue.bulkString(entry?.value ?? null))
+        if (entry) hash.deleteField(field)
+      }
+      remaining = hash.size
+      return replies
+    })
+
+    if (remaining === 0) {
+      ctx.db.delete(args.key)
+    }
+    return array(values)
   },
 })
 
@@ -391,6 +472,7 @@ export const hashesCommands = [
   hsetnxCommand,
   hgetCommand,
   hdelCommand,
+  hgetdelCommand,
   hmsetCommand,
   hmgetCommand,
   hgetallCommand,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -186,6 +186,7 @@ export {
   hashesCommands,
   hexistsCommand,
   hgetallCommand,
+  hgetdelCommand,
   hgetCommand,
   hdelCommand,
   hincrbyfloatCommand,

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -243,11 +243,18 @@ function readOptionValue(
 
 function parseCursor(raw: Buffer): bigint {
   const value = raw.toString()
-  if (!/^-?\d+$/.test(value)) {
+  // Redis parses the cursor as an unsigned 64-bit integer (strict_strtoull):
+  // a leading sign or a value past UINT64_MAX is rejected as `invalid cursor`.
+  if (!/^\d+$/.test(value)) {
     throw new RedisCommandError('invalid cursor')
   }
 
-  return BigInt(value)
+  const parsed = BigInt(value)
+  if (parsed > 0xffffffffffffffffn) {
+    throw new RedisCommandError('invalid cursor')
+  }
+
+  return parsed
 }
 
 function parseCount(raw: Buffer): number {

--- a/tests-integration/ioredis/hash-integration.test.ts
+++ b/tests-integration/ioredis/hash-integration.test.ts
@@ -28,6 +28,17 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
     await testRunner.cleanup()
   })
 
+  async function supportsHgetdel(
+    client: Cluster | undefined,
+  ): Promise<boolean> {
+    if (testRunner.backend !== 'real') {
+      return true
+    }
+
+    const info = await client?.call('COMMAND', 'INFO', 'HGETDEL')
+    return Array.isArray(info) && info[0] !== null
+  }
+
   test('HSET and HGET commands', async () => {
     // HSET single field
     const result1 = await redisClient?.hset('hash1', 'field1', 'value1')
@@ -331,6 +342,172 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
     assert.strictEqual(await redisClient?.hdel(key, 'field1'), 0)
     assert.strictEqual(await redisClient?.exists(key), 0)
     assert.strictEqual(await redisClient?.type(key), 'none')
+  })
+
+  test('HGETDEL returns values and deletes fields', async t => {
+    if (!(await supportsHgetdel(redisClient))) {
+      t.skip('configured real Redis does not support HGETDEL')
+      return
+    }
+
+    const key = `{hgetdel:${randomKey()}}:hash`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, key)
+
+      await directClient.hset(
+        key,
+        'field1',
+        'value1',
+        'field2',
+        'value2',
+        'field3',
+        'value3',
+      )
+
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HGETDEL',
+          key,
+          'FIELDS',
+          '3',
+          'field2',
+          'missing',
+          'field1',
+        ),
+        ['value2', null, 'value1'],
+      )
+      assert.deepStrictEqual(
+        await directClient.hmget(key, 'field1', 'field2', 'field3'),
+        [null, null, 'value3'],
+      )
+      assert.strictEqual(await directClient.hlen(key), 1)
+
+      await directClient.hset(key, 'field4', 'value4')
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HGETDEL',
+          key,
+          'FIELDS',
+          '2',
+          'field4',
+          'field4',
+        ),
+        ['value4', null],
+      )
+      assert.strictEqual(await directClient.hexists(key, 'field4'), 0)
+
+      assert.deepStrictEqual(
+        await directClient.call('HGETDEL', key, 'FIELDS', '1', 'field3'),
+        ['value3'],
+      )
+      assert.strictEqual(await directClient.exists(key), 0)
+      assert.strictEqual(await directClient.type(key), 'none')
+
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HGETDEL',
+          key,
+          'FIELDS',
+          '2',
+          'field3',
+          'missing',
+        ),
+        [null, null],
+      )
+      assert.strictEqual(await directClient.exists(key), 0)
+    } finally {
+      await directClient?.del(key)
+      directClient?.disconnect()
+    }
+  })
+
+  test('HGETDEL errors match Redis', async t => {
+    if (!(await supportsHgetdel(redisClient))) {
+      t.skip('configured real Redis does not support HGETDEL')
+      return
+    }
+
+    const tag = `{hgetdel-errors:${randomKey()}}`
+    const hashKey = `${tag}:hash`
+    const stringKey = `${tag}:string`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, hashKey)
+      await directClient.hset(hashKey, 'field', 'value')
+      await directClient.set(stringKey, 'value')
+
+      await assert.rejects(
+        () => directClient?.call('HGETDEL', stringKey, 'FIELDS', '1', 'field'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
+        () => directClient?.call('HGETDEL'),
+        errorWithMessage("ERR wrong number of arguments for 'hgetdel' command"),
+      )
+      await assert.rejects(
+        () => directClient?.call('HGETDEL', hashKey),
+        errorWithMessage("ERR wrong number of arguments for 'hgetdel' command"),
+      )
+      await assert.rejects(
+        () => directClient?.call('HGETDEL', hashKey, 'FIELD', '1', 'field'),
+        errorWithMessage(
+          'ERR Mandatory argument FIELDS is missing or not at the right position',
+        ),
+      )
+      await assert.rejects(
+        () => directClient?.call('HGETDEL', hashKey, 'FIELDS', 'abc', 'field'),
+        errorWithMessage('ERR Number of fields must be a positive integer'),
+      )
+      await assert.rejects(
+        () => directClient?.call('HGETDEL', hashKey, 'FIELDS', '0', 'field'),
+        errorWithMessage('ERR Number of fields must be a positive integer'),
+      )
+      await assert.rejects(
+        () => directClient?.call('HGETDEL', hashKey, 'FIELDS', '-1', 'field'),
+        errorWithMessage('ERR Number of fields must be a positive integer'),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HGETDEL',
+            hashKey,
+            'FIELDS',
+            '9223372036854775808',
+            'field',
+          ),
+        errorWithMessage('ERR Number of fields must be a positive integer'),
+      )
+      await assert.rejects(
+        () => directClient?.call('HGETDEL', hashKey, 'FIELDS', '2', 'field'),
+        errorWithMessage(
+          'ERR The `numfields` parameter must match the number of arguments',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HGETDEL',
+            hashKey,
+            'FIELDS',
+            '1',
+            'field',
+            'extra',
+          ),
+        errorWithMessage(
+          'ERR The `numfields` parameter must match the number of arguments',
+        ),
+      )
+    } finally {
+      await directClient?.del(hashKey, stringKey)
+      directClient?.disconnect()
+    }
   })
 
   test('HINCRBY command', async () => {

--- a/tests-integration/ioredis/hash-integration.test.ts
+++ b/tests-integration/ioredis/hash-integration.test.ts
@@ -28,17 +28,6 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
     await testRunner.cleanup()
   })
 
-  async function supportsHgetdel(
-    client: Cluster | undefined,
-  ): Promise<boolean> {
-    if (testRunner.backend !== 'real') {
-      return true
-    }
-
-    const info = await client?.call('COMMAND', 'INFO', 'HGETDEL')
-    return Array.isArray(info) && info[0] !== null
-  }
-
   test('HSET and HGET commands', async () => {
     // HSET single field
     const result1 = await redisClient?.hset('hash1', 'field1', 'value1')
@@ -344,12 +333,7 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
     assert.strictEqual(await redisClient?.type(key), 'none')
   })
 
-  test('HGETDEL returns values and deletes fields', async t => {
-    if (!(await supportsHgetdel(redisClient))) {
-      t.skip('configured real Redis does not support HGETDEL')
-      return
-    }
-
+  test('HGETDEL returns values and deletes fields', async () => {
     const key = `{hgetdel:${randomKey()}}:hash`
     let directClient: Redis | undefined
 
@@ -424,12 +408,7 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
     }
   })
 
-  test('HGETDEL errors match Redis', async t => {
-    if (!(await supportsHgetdel(redisClient))) {
-      t.skip('configured real Redis does not support HGETDEL')
-      return
-    }
-
+  test('HGETDEL errors match Redis', async () => {
     const tag = `{hgetdel-errors:${randomKey()}}`
     const hashKey = `${tag}:hash`
     const stringKey = `${tag}:string`

--- a/tests-integration/ioredis/scan-integration.test.ts
+++ b/tests-integration/ioredis/scan-integration.test.ts
@@ -174,14 +174,13 @@ describe(`Scan Commands Integration (${testRunner.getBackendName()})`, () => {
 
       assert.deepStrictEqual(result.values, expected)
 
-      if (testRunner.backend === 'mock') {
-        // Multi-step traversal across COUNT batches. We can't assert an exact
-        // page partition or empty-page positions: top-level SCAN sweeps the
-        // whole node keyspace, so keys from other tests sharing the node (the
-        // suite runs files concurrently) consume COUNT budget and shift which
-        // page each hit lands on. `values` stays exact because MATCH filters.
-        assert.ok(result.iterations > Math.ceil(expected.length / 2))
-      }
+      // Multi-step traversal across COUNT batches. We can't assert an exact
+      // page partition or empty-page positions: top-level SCAN sweeps the
+      // whole node keyspace, so keys from other tests sharing the node (the
+      // suite runs files concurrently) consume COUNT budget and shift which
+      // page each hit lands on. `values` stays exact because MATCH filters.
+      // Lower bound holds on both backends — extra keys only raise iterations.
+      assert.ok(result.iterations > Math.ceil(expected.length / 2))
     } finally {
       await directClient.del(...keys)
       directClient.disconnect()
@@ -490,10 +489,10 @@ describe(`Scan Commands Integration (${testRunner.getBackendName()})`, () => {
       () => redisClient?.scan('abc'),
       errorWithMessage('ERR invalid cursor'),
     )
-    assert.deepStrictEqual(await redisClient?.scan('-1', 'MATCH', 'missing'), [
-      '0',
-      [],
-    ])
+    await assert.rejects(
+      () => redisClient!.scan('-1', 'MATCH', 'missing'),
+      errorWithMessage('ERR invalid cursor'),
+    )
     await assert.rejects(
       () => redisClient?.scan('0', 'COUNT', 'abc'),
       errorWithMessage('ERR value is not an integer or out of range'),


### PR DESCRIPTION
## Summary
- Implement `HGETDEL key FIELDS numfields field [field ...]` for hashes.
- Return field values in request order while deleting existing fields, including duplicate-field requests.
- Remove emptied hash keys and document `HGETDEL` as supported.
- Run the integration suite against a **Redis 8.0** cluster so the real backend exercises HGETDEL (and other 8.0 semantics) instead of skipping.

## Root cause
`HGETDEL` was still missing from the hash command registry, so clients could only get/delete fields through separate operations or receive an unknown-command error.

The integration harness pinned the real backend to `grokzen/redis-cluster:7.2.5` (no 8.x tag exists), and Redis 7.2 has no HGETDEL — so the HGETDEL coverage skipped on real Redis instead of validating it.

## Test infra: Redis 8.0
- Replace the cluster service with a 6-node cluster built from the official `redis:8.0` image. All nodes run in one container and announce `127.0.0.1:<port>`, so `MOVED`/`ASK` redirects resolve from a Mac host (the property that made grokzen "just work"). Standalone services bumped to 8.0 too.
- Drop the `supportsHgetdel` guard and the mock-only branch in the SCAN traversal test — integration now behaves identically on mock and real.

## Redis 8 cursor validation
Redis 8 parses the SCAN/HSCAN/SSCAN/ZSCAN cursor as an unsigned 64-bit integer, rejecting a leading sign or a value past `UINT64_MAX` with `ERR invalid cursor`. `parseCursor` previously accepted negative cursors; it now matches Redis 8, and the scan error test expects the rejection.

## Validation
- `npm run build`
- `npm test` (194 pass)
- `npm run lint`
- `TEST_BACKEND=mock` hash + scan integration — all pass
- `TEST_BACKEND=real` hash + scan integration against the Redis 8.0 cluster — all pass (HGETDEL now runs, no skips)

Parent: #207
Fixes #257