### PR TITLE
refactor: drive ClusterPolicy off capabilities not command names (#128)

### DIFF
--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -419,6 +419,7 @@ export const selectCommand = defineCommand({
     database: t.integer({ min: 0 }),
   }),
   flags: ['fast'],
+  capabilities: { clusterMode: 'singleDb' },
   keys: () => [],
   execute: (args, ctx) => {
     ctx.session.selectDatabase(args.database)

--- a/src/commands/keys.ts
+++ b/src/commands/keys.ts
@@ -440,6 +440,7 @@ export const moveCommand = defineCommand({
   name: 'move',
   schema: t.object({ key: t.key(), database: t.integer() }),
   flags: ['write'],
+  capabilities: { clusterMode: 'forbidden' },
   keys: args => [args.key],
   execute: (args, ctx) => {
     const targetDb = ctx.server.databases[args.database]

--- a/src/commands/transactions.ts
+++ b/src/commands/transactions.ts
@@ -14,6 +14,7 @@ export const multiCommand = defineCommand({
   name: 'multi',
   schema: t.object({}),
   flags: ['readonly', 'fast', 'transaction', 'noscript'],
+  capabilities: { transactionBoundary: 'begin' },
   keys: () => [],
   execute: (_args, ctx) => {
     ctx.session.beginTransaction()
@@ -28,6 +29,7 @@ export const execCommand = defineCommand({
   // only marks it as transaction-control so policies do not treat it as a
   // normal write/read command.
   flags: ['transaction', 'noscript'],
+  capabilities: { transactionBoundary: 'end' },
   keys: () => [],
   execute: async (_args, ctx) => {
     if (ctx.session.mode !== 'transaction') {
@@ -56,6 +58,7 @@ export const discardCommand = defineCommand({
   name: 'discard',
   schema: t.object({}),
   flags: ['readonly', 'fast', 'transaction', 'noscript'],
+  capabilities: { transactionBoundary: 'end' },
   keys: () => [],
   execute: (_args, ctx) => {
     if (ctx.session.mode !== 'transaction') {

--- a/src/core/command-definition.ts
+++ b/src/core/command-definition.ts
@@ -22,6 +22,18 @@ export type CommandCapabilities = {
   pushOnly?: boolean
   movableKeys?: boolean
   scriptKeys?: boolean
+  /**
+   * How the command behaves under cluster mode. `'forbidden'` is always
+   * rejected; `'singleDb'` is rejected only when it targets a non-zero
+   * database. Consumed by `ClusterPolicy` instead of matching command names.
+   */
+  clusterMode?: 'forbidden' | 'singleDb'
+  /**
+   * Marks the command as a transaction boundary. `'begin'` opens a transaction
+   * (MULTI); `'end'` closes one (EXEC/DISCARD). `ClusterPolicy` uses this to
+   * reset the per-session pinned slot instead of matching command names.
+   */
+  transactionBoundary?: 'begin' | 'end'
 }
 
 export type CommandMonitorMetadata = {

--- a/src/core/execution-policies/cluster-policy.ts
+++ b/src/core/execution-policies/cluster-policy.ts
@@ -33,29 +33,38 @@ export function createClusterPolicy(
         localNodeChecked = true
       }
 
-      if (plan.definition.name === 'select') {
-        // Cluster mode has a single logical database (0). SELECT 0 is a no-op
-        // and accepted; any non-zero index is rejected like real Redis.
+      const capabilities = plan.definition.capabilities
+
+      if (capabilities?.clusterMode === 'forbidden') {
+        throw new RedisCommandError(
+          `${plan.definition.name.toUpperCase()} is not allowed in cluster mode`,
+        )
+      }
+
+      if (capabilities?.clusterMode === 'singleDb') {
+        // Cluster mode has a single logical database (0). DB 0 is a no-op and
+        // accepted; any non-zero index is rejected like real Redis.
         const index = (plan.args as { database: number }).database
         if (index !== 0) {
-          throw new RedisCommandError('SELECT is not allowed in cluster mode')
+          throw new RedisCommandError(
+            `${plan.definition.name.toUpperCase()} is not allowed in cluster mode`,
+          )
         }
       }
 
-      if (plan.definition.name === 'move') {
-        throw new RedisCommandError('MOVE is not allowed in cluster mode')
-      }
-
+      // A transaction boundary resets the per-session pinned slot: 'begin'
+      // (MULTI) starts fresh, 'end' (EXEC/DISCARD) releases the pin once the
+      // current transaction is over.
       if (
-        plan.definition.name === 'multi' &&
+        capabilities?.transactionBoundary === 'begin' &&
         ctx.session.mode !== 'transaction'
       ) {
         transactionSlots.delete(ctx.session)
       }
 
       if (
-        ctx.session.mode === 'transaction' &&
-        (plan.definition.name === 'exec' || plan.definition.name === 'discard')
+        capabilities?.transactionBoundary === 'end' &&
+        ctx.session.mode === 'transaction'
       ) {
         transactionSlots.delete(ctx.session)
       }

--- a/tests/core-cluster-policy.test.ts
+++ b/tests/core-cluster-policy.test.ts
@@ -152,6 +152,15 @@ describe('new cluster execution policy', () => {
     )
   })
 
+  test('accepts SELECT 0 in cluster mode', async () => {
+    const { session } = createClusterHarness()
+
+    assert.deepStrictEqual(
+      await session.execute('select', [Buffer.from('0')]),
+      RedisResult.ok(),
+    )
+  })
+
   test('rejects MOVE in cluster mode like Redis Cluster', async () => {
     const { session, topology } = createClusterHarness()
     const key = findKeyOwnedBy(topology, 'local')
@@ -159,6 +168,37 @@ describe('new cluster execution policy', () => {
     assert.deepStrictEqual(
       await session.execute('move', [key, Buffer.from('1')]),
       RedisResult.error('MOVE is not allowed in cluster mode', 'ERR'),
+    )
+  })
+
+  test('DISCARD clears the pinned transaction slot', async () => {
+    const { session, server, topology } = createClusterHarness()
+    const [first, second] = findDifferentSlotKeysOwnedBy(topology, 'local')
+
+    // Pin the slot to `first`, then abandon the transaction.
+    assert.deepStrictEqual(await session.execute('multi', []), RedisResult.ok())
+    assert.deepStrictEqual(
+      await session.execute('set', [first, Buffer.from('one')]),
+      RedisResult.create(RedisValue.simpleString('QUEUED')),
+    )
+    assert.deepStrictEqual(
+      await session.execute('discard', []),
+      RedisResult.ok(),
+    )
+
+    // A fresh transaction must be able to pin a different slot.
+    assert.deepStrictEqual(await session.execute('multi', []), RedisResult.ok())
+    assert.deepStrictEqual(
+      await session.execute('set', [second, Buffer.from('two')]),
+      RedisResult.create(RedisValue.simpleString('QUEUED')),
+    )
+    assert.deepStrictEqual(
+      await session.execute('exec', []),
+      RedisResult.create(RedisValue.array([RedisValue.simpleString('OK')])),
+    )
+    assert.deepStrictEqual(
+      server.getDatabase(0).getString(second),
+      Buffer.from('two'),
     )
   })
 })


### PR DESCRIPTION
## Summary
- `ClusterPolicy` special-cased SELECT/MOVE/MULTI/EXEC/DISCARD via `plan.definition.name` string equality to reject cluster-forbidden commands and reset transaction slot pinning — brittle name-literal matching in policy code.
- Replaced with declarative `CommandDefinition` capabilities:
  - `clusterMode: 'forbidden'` (MOVE) | `'singleDb'` (SELECT, rejects only non-zero DB)
  - `transactionBoundary: 'begin'` (MULTI) | `'end'` (EXEC/DISCARD)
- The policy now branches on these capabilities; no command-name string comparison remains. Pure internal refactor — no client-visible behavior change.

Closes #128

## Test plan
- [x] Existing cluster-policy unit tests stay green (SELECT/MOVE rejection, transaction slot pinning + clearing)
- [x] Added regression tests: `SELECT 0` accepted, `DISCARD` clears the pinned slot
- [x] `npm run build` + `npm run lint` clean
- [x] `npm run test:all` passes (196 unit, 523 mock, 523 real)