### PR TITLE
Add hash field expiry commands

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -330,9 +330,13 @@ cloned command events without any command writing directly to a transport.
 Each database wraps a [`RedisKeyspace`](../src/state/keyspace.ts#L34): a
 `Map<keyId, KeyspaceEntry>` holding byte-safe `Buffer` keys and typed
 [`RedisDataValue`](../src/state/data-types.ts)s (`string`, `hash`, `list`,
-`set`, `zset`, `stream`). Stream values store ordered entries plus consumer
-groups, per-group pending-entry lists, and consumer idle metadata. Expiration is
-handled by both an active sweep and a lazy fallback. `RedisServerState` runs a
+`set`, `zset`, `stream`). Hash values store byte-safe field entries and can
+attach an `expiresAt` timestamp to individual fields for the hash-field TTL
+commands; tracked hash helpers lazily delete expired fields on hash reads and
+writes, and the keyspace removes the hash key when the last live field
+disappears. Stream values store ordered entries plus consumer groups, per-group
+pending-entry lists, and consumer idle metadata. Key expiration is handled by
+both an active sweep and a lazy fallback. `RedisServerState` runs a
 background active-expiry pass across its databases, under each database's
 `SerialTurnQueue`; cluster replicas disable their own active sweep and rely on
 the master's replicated deletion. `getLiveEntry` still calls

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -229,6 +229,10 @@ with `GT` or `LT`.
 - [x] `HGETALL key` - Get all fields and values in a hash (RESP3 map / RESP2 flat array)
 - [x] `HDEL key field [field ...]` - Delete one or more hash fields
 - [x] `HGETDEL key FIELDS numfields field [field ...]` - Get and delete one or more hash fields
+- [x] `HEXPIRE key seconds [NX|XX|GT|LT] FIELDS numfields field [field ...]` - Set hash-field TTLs in seconds
+- [x] `HPEXPIRE key milliseconds [NX|XX|GT|LT] FIELDS numfields field [field ...]` - Set hash-field TTLs in milliseconds
+- [x] `HEXPIREAT key unix-time-seconds [NX|XX|GT|LT] FIELDS numfields field [field ...]` - Set hash-field expiration timestamps in seconds
+- [x] `HPEXPIREAT key unix-time-milliseconds [NX|XX|GT|LT] FIELDS numfields field [field ...]` - Set hash-field expiration timestamps in milliseconds
 - [x] `HEXISTS key field` - Determine if a hash field exists
 - [x] `HKEYS key` - Get all fields in a hash
 - [x] `HVALS key` - Get all values in a hash
@@ -241,7 +245,7 @@ with `GT` or `LT`.
 
 #### Not implemented
 
-- [ ] `HEXPIRE` / `HPEXPIRE` / `HEXPIREAT` / `HPEXPIREAT` / `HPERSIST` / `HTTL` / `HPTTL` / `HGETEX` (hash-field-TTL family)
+- [ ] `HPERSIST` / `HTTL` / `HPTTL` / `HGETEX` (remaining hash-field-TTL family)
 
 ## 6. List Commands
 

--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -5,7 +5,9 @@ import {
   t,
   type ParseContext,
 } from '../core/command-schema'
+import type { RedisExecutionContext } from '../core/redis-context'
 import {
+  ExpectedIntegerError,
   HashValueNotFloatError,
   HashValueNotIntegerError,
   RedisCommandError,
@@ -14,6 +16,7 @@ import {
 } from '../core/redis-error'
 import { RedisResult } from '../core/redis-result'
 import { RedisValue } from '../core/redis-value'
+import type { TrackedHashData } from '../state/tracked-values'
 import { bulk, integer, ok, array, parseIntegerToken } from './helpers'
 
 type FieldValuePair = { field: Buffer; value: Buffer }
@@ -26,8 +29,23 @@ type HgetdelArgs = {
   key: Buffer
   fields: Buffer[]
 }
+type HashExpireOption = 'NX' | 'XX' | 'GT' | 'LT'
+type HashExpireMode =
+  | 'seconds'
+  | 'milliseconds'
+  | 'unix-seconds'
+  | 'unix-milliseconds'
+type HashExpireArgs = {
+  key: Buffer
+  time: bigint
+  option: HashExpireOption | undefined
+  fields: Buffer[]
+}
 
 const LONG_MAX = 9223372036854775807n
+const LONG_MIN = -9223372036854775808n
+const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER)
+const MIN_SAFE_INTEGER_BIGINT = BigInt(Number.MIN_SAFE_INTEGER)
 
 function createFieldValuePairsSchema() {
   return t.custom<FieldValuePair[]>(
@@ -123,6 +141,59 @@ function createHgetdelSchema() {
   )
 }
 
+function createHashExpireSchema() {
+  return t.custom<HashExpireArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const key = input[index]
+      const timeToken = input[index + 1]
+      if (!key || !timeToken) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      const time = parseHashExpireTime(timeToken)
+      let cursor = index + 2
+      if (cursor >= input.length) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      let option: HashExpireOption | undefined
+      const maybeOption = input[cursor].toString().toUpperCase()
+      if (isHashExpireOption(maybeOption)) {
+        option = maybeOption
+        cursor += 1
+      }
+
+      const fieldsToken = input[cursor]
+      if (!fieldsToken) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+      if (fieldsToken.toString().toUpperCase() !== 'FIELDS') {
+        throw new RedisCommandError(
+          'Mandatory argument FIELDS is missing or not at the right position',
+        )
+      }
+
+      const fieldCountToken = input[cursor + 1]
+      if (!fieldCountToken) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      const fieldCount = parseHashExpireFieldCount(fieldCountToken)
+      const fields = input.slice(cursor + 2)
+      if (fieldCount !== BigInt(fields.length)) {
+        throw new RedisCommandError(
+          'The `numfields` parameter must match the number of arguments',
+        )
+      }
+
+      return {
+        value: { key, time, option, fields },
+        nextIndex: input.length,
+      }
+    },
+  )
+}
+
 function parsePositiveFieldCount(token: Buffer): bigint {
   const raw = token.toString()
   if (!isIntegerToken(raw)) {
@@ -135,6 +206,140 @@ function parsePositiveFieldCount(token: Buffer): bigint {
   }
 
   return value
+}
+
+function parseHashExpireTime(token: Buffer): bigint {
+  const raw = token.toString()
+  if (!isIntegerToken(raw)) {
+    throw new ExpectedIntegerError()
+  }
+
+  const value = BigInt(raw)
+  if (value < LONG_MIN || value > LONG_MAX) {
+    throw new ExpectedIntegerError()
+  }
+
+  return value
+}
+
+function parseHashExpireFieldCount(token: Buffer): bigint {
+  const raw = token.toString()
+  if (!isIntegerToken(raw)) {
+    throw new RedisCommandError(
+      'Parameter `numFields` should be greater than 0',
+    )
+  }
+
+  const value = BigInt(raw)
+  if (value < 1n || value > LONG_MAX) {
+    throw new RedisCommandError(
+      'Parameter `numFields` should be greater than 0',
+    )
+  }
+
+  return value
+}
+
+function isHashExpireOption(value: string): value is HashExpireOption {
+  return value === 'NX' || value === 'XX' || value === 'GT' || value === 'LT'
+}
+
+function withExistingHash<TResult>(
+  ctx: RedisExecutionContext,
+  key: Buffer,
+  missing: () => TResult,
+  callback: (hash: TrackedHashData) => TResult,
+): TResult {
+  const hash = ctx.db.getHash(key)
+  if (!hash) return missing()
+
+  return ctx.db.updateHash(key, callback)
+}
+
+function expireHashFields(
+  args: HashExpireArgs,
+  ctx: RedisExecutionContext,
+  mode: HashExpireMode,
+): RedisResult {
+  const expiresAt = hashExpireTimeToTimestamp(args.time, mode)
+  const now = Date.now()
+
+  return withExistingHash(
+    ctx,
+    args.key,
+    () => array(args.fields.map(() => RedisValue.integer(-2))),
+    hash => {
+      return array(
+        args.fields.map(field => {
+          const entry = hash.getField(field)
+          if (!entry) {
+            return RedisValue.integer(-2)
+          }
+
+          if (!shouldApplyHashExpire(entry.expiresAt, expiresAt, args.option)) {
+            return RedisValue.integer(0)
+          }
+
+          if (expiresAt <= now) {
+            hash.deleteField(field)
+            return RedisValue.integer(2)
+          }
+
+          hash.setFieldExpiration(field, expiresAt)
+          return RedisValue.integer(1)
+        }),
+      )
+    },
+  )
+}
+
+function hashExpireTimeToTimestamp(
+  value: bigint,
+  mode: HashExpireMode,
+): number {
+  if (mode === 'seconds') {
+    return Date.now() + bigintToNumberSaturated(value * 1000n)
+  }
+
+  if (mode === 'milliseconds') {
+    return Date.now() + bigintToNumberSaturated(value)
+  }
+
+  if (mode === 'unix-seconds') {
+    return bigintToNumberSaturated(value * 1000n)
+  }
+
+  return bigintToNumberSaturated(value)
+}
+
+function bigintToNumberSaturated(value: bigint): number {
+  if (value > MAX_SAFE_INTEGER_BIGINT) return Number.MAX_SAFE_INTEGER
+  if (value < MIN_SAFE_INTEGER_BIGINT) return Number.MIN_SAFE_INTEGER
+  return Number(value)
+}
+
+function shouldApplyHashExpire(
+  currentExpiresAt: number | undefined,
+  nextExpiresAt: number,
+  option: HashExpireOption | undefined,
+): boolean {
+  if (option === 'NX') {
+    return currentExpiresAt === undefined
+  }
+
+  if (option === 'XX') {
+    return currentExpiresAt !== undefined
+  }
+
+  if (option === 'GT') {
+    return currentExpiresAt !== undefined && nextExpiresAt > currentExpiresAt
+  }
+
+  if (option === 'LT') {
+    return currentExpiresAt === undefined || nextExpiresAt < currentExpiresAt
+  }
+
+  return true
 }
 
 function randomHashEntries<TValue>(entries: TValue[], count: number): TValue[] {
@@ -212,10 +417,12 @@ export const hgetCommand = defineCommand({
   flags: ['readonly', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const hash = ctx.db.getHash(args.key)
-    if (!hash) return bulk(null)
-    const entry = hash.fields.get(args.field.toString('hex'))
-    return bulk(entry?.value ?? null)
+    return withExistingHash(
+      ctx,
+      args.key,
+      () => bulk(null),
+      hash => bulk(hash.getField(args.field)?.value ?? null),
+    )
   },
 })
 
@@ -271,6 +478,38 @@ export const hgetdelCommand = defineCommand({
   },
 })
 
+export const hexpireCommand = defineCommand({
+  name: 'hexpire',
+  schema: createHashExpireSchema(),
+  flags: ['write', 'fast'],
+  keys: args => [args.key],
+  execute: (args, ctx) => expireHashFields(args, ctx, 'seconds'),
+})
+
+export const hpexpireCommand = defineCommand({
+  name: 'hpexpire',
+  schema: createHashExpireSchema(),
+  flags: ['write', 'fast'],
+  keys: args => [args.key],
+  execute: (args, ctx) => expireHashFields(args, ctx, 'milliseconds'),
+})
+
+export const hexpireatCommand = defineCommand({
+  name: 'hexpireat',
+  schema: createHashExpireSchema(),
+  flags: ['write', 'fast'],
+  keys: args => [args.key],
+  execute: (args, ctx) => expireHashFields(args, ctx, 'unix-seconds'),
+})
+
+export const hpexpireatCommand = defineCommand({
+  name: 'hpexpireat',
+  schema: createHashExpireSchema(),
+  flags: ['write', 'fast'],
+  keys: args => [args.key],
+  execute: (args, ctx) => expireHashFields(args, ctx, 'unix-milliseconds'),
+})
+
 export const hmsetCommand = defineCommand({
   name: 'hmset',
   schema: t.object({ key: t.key(), pairs: createFieldValuePairsSchema() }),
@@ -292,12 +531,17 @@ export const hmgetCommand = defineCommand({
   flags: ['readonly', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const hash = ctx.db.getHash(args.key)
-    return array(
-      args.fields.map(field => {
-        const entry = hash?.fields.get(field.toString('hex'))
-        return RedisValue.bulkString(entry?.value ?? null)
-      }),
+    return withExistingHash(
+      ctx,
+      args.key,
+      () => array(args.fields.map(() => RedisValue.bulkString(null))),
+      hash =>
+        array(
+          args.fields.map(field => {
+            const entry = hash.getField(field)
+            return RedisValue.bulkString(entry?.value ?? null)
+          }),
+        ),
     )
   },
 })
@@ -308,12 +552,21 @@ export const hgetallCommand = defineCommand({
   flags: ['readonly', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const hash = ctx.db.getHash(args.key)
-    const entries: [RedisValue, RedisValue][] = []
-    for (const { field, value } of hash?.fields.values() ?? []) {
-      entries.push([RedisValue.bulkString(field), RedisValue.bulkString(value)])
-    }
-    return RedisResult.create(RedisValue.map(entries))
+    return withExistingHash(
+      ctx,
+      args.key,
+      () => RedisResult.create(RedisValue.map([])),
+      hash => {
+        const entries: [RedisValue, RedisValue][] = []
+        for (const { field, value } of hash.entries()) {
+          entries.push([
+            RedisValue.bulkString(field),
+            RedisValue.bulkString(value),
+          ])
+        }
+        return RedisResult.create(RedisValue.map(entries))
+      },
+    )
   },
 })
 
@@ -323,12 +576,16 @@ export const hkeysCommand = defineCommand({
   flags: ['readonly', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const hash = ctx.db.getHash(args.key)
-    if (!hash) return array([])
-    return array(
-      Array.from(hash.fields.values()).map(({ field }) =>
-        RedisValue.bulkString(field),
-      ),
+    return withExistingHash(
+      ctx,
+      args.key,
+      () => array([]),
+      hash =>
+        array(
+          Array.from(hash.entries()).map(({ field }) =>
+            RedisValue.bulkString(field),
+          ),
+        ),
     )
   },
 })
@@ -339,12 +596,16 @@ export const hvalsCommand = defineCommand({
   flags: ['readonly', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const hash = ctx.db.getHash(args.key)
-    if (!hash) return array([])
-    return array(
-      Array.from(hash.fields.values()).map(({ value }) =>
-        RedisValue.bulkString(value),
-      ),
+    return withExistingHash(
+      ctx,
+      args.key,
+      () => array([]),
+      hash =>
+        array(
+          Array.from(hash.entries()).map(({ value }) =>
+            RedisValue.bulkString(value),
+          ),
+        ),
     )
   },
 })
@@ -355,19 +616,28 @@ export const hrandfieldCommand = defineCommand({
   flags: ['readonly', 'random', 'noscript'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const hash = ctx.db.getHash(args.key)
-    if (!hash || hash.fields.size === 0) {
-      return args.count === undefined ? bulk(null) : array([])
-    }
+    return withExistingHash(
+      ctx,
+      args.key,
+      () => (args.count === undefined ? bulk(null) : array([])),
+      hash => {
+        const entries = Array.from(hash.entries())
+        if (entries.length === 0) {
+          return args.count === undefined ? bulk(null) : array([])
+        }
 
-    const entries = Array.from(hash.fields.values())
-    if (args.count === undefined) {
-      const entry = entries[Math.floor(Math.random() * entries.length)]
-      return bulk(entry.field)
-    }
+        if (args.count === undefined) {
+          const entry = entries[Math.floor(Math.random() * entries.length)]
+          return bulk(entry.field)
+        }
 
-    return array(
-      hashEntriesReply(randomHashEntries(entries, args.count), args.withValues),
+        return array(
+          hashEntriesReply(
+            randomHashEntries(entries, args.count),
+            args.withValues,
+          ),
+        )
+      },
     )
   },
 })
@@ -378,8 +648,12 @@ export const hlenCommand = defineCommand({
   flags: ['readonly', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const hash = ctx.db.getHash(args.key)
-    return integer(hash?.fields.size ?? 0)
+    return withExistingHash(
+      ctx,
+      args.key,
+      () => integer(0),
+      hash => integer(hash.size),
+    )
   },
 })
 
@@ -389,9 +663,12 @@ export const hexistsCommand = defineCommand({
   flags: ['readonly', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const hash = ctx.db.getHash(args.key)
-    if (!hash) return integer(0)
-    return integer(hash.fields.has(args.field.toString('hex')) ? 1 : 0)
+    return withExistingHash(
+      ctx,
+      args.key,
+      () => integer(0),
+      hash => integer(hash.hasField(args.field) ? 1 : 0),
+    )
   },
 })
 
@@ -413,7 +690,7 @@ export const hincrbyCommand = defineCommand({
       }
       const next = current + args.increment
       const valueBuf = Buffer.from(String(next))
-      hash.setField(args.field, valueBuf, { forceDirty: true })
+      hash.setField(args.field, valueBuf, { forceDirty: true, keepTtl: true })
       return next
     })
     return integer(result)
@@ -447,7 +724,7 @@ export const hincrbyfloatCommand = defineCommand({
         formatted = next.toFixed(17).replace(/\.?0+$/, '')
       }
       const valueBuf = Buffer.from(formatted)
-      hash.setField(args.field, valueBuf, { forceDirty: true })
+      hash.setField(args.field, valueBuf, { forceDirty: true, keepTtl: true })
       return valueBuf
     })
     return bulk(result)
@@ -460,10 +737,12 @@ export const hstrlenCommand = defineCommand({
   flags: ['readonly', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
-    const hash = ctx.db.getHash(args.key)
-    if (!hash) return integer(0)
-    const entry = hash.fields.get(args.field.toString('hex'))
-    return integer(entry?.value.byteLength ?? 0)
+    return withExistingHash(
+      ctx,
+      args.key,
+      () => integer(0),
+      hash => integer(hash.getField(args.field)?.value.byteLength ?? 0),
+    )
   },
 })
 
@@ -473,6 +752,10 @@ export const hashesCommands = [
   hgetCommand,
   hdelCommand,
   hgetdelCommand,
+  hexpireCommand,
+  hpexpireCommand,
+  hexpireatCommand,
+  hpexpireatCommand,
   hmsetCommand,
   hmgetCommand,
   hgetallCommand,

--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -10,6 +10,7 @@ import {
   ExpectedIntegerError,
   HashValueNotFloatError,
   HashValueNotIntegerError,
+  InvalidExpireTimeError,
   RedisCommandError,
   RedisSyntaxError,
   WrongNumberOfArgumentsError,
@@ -37,6 +38,9 @@ type HashExpireMode =
   | 'unix-milliseconds'
 type HashExpireArgs = {
   key: Buffer
+  rawArgs: Buffer[]
+}
+type ParsedHashExpireArgs = {
   time: bigint
   option: HashExpireOption | undefined
   fields: Buffer[]
@@ -44,8 +48,7 @@ type HashExpireArgs = {
 
 const LONG_MAX = 9223372036854775807n
 const LONG_MIN = -9223372036854775808n
-const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER)
-const MIN_SAFE_INTEGER_BIGINT = BigInt(Number.MIN_SAFE_INTEGER)
+const HASH_FIELD_EXPIRE_MAX_ABS_MS = 0x0000ffffffffffffn >> 2n
 
 function createFieldValuePairsSchema() {
   return t.custom<FieldValuePair[]>(
@@ -145,53 +148,56 @@ function createHashExpireSchema() {
   return t.custom<HashExpireArgs>(
     (input: readonly Buffer[], index: number, ctx: ParseContext) => {
       const key = input[index]
-      const timeToken = input[index + 1]
-      if (!key || !timeToken) {
+      if (!key || input.length - index < 5) {
         throw new WrongNumberOfArgumentsError(ctx.commandName)
-      }
-
-      const time = parseHashExpireTime(timeToken)
-      let cursor = index + 2
-      if (cursor >= input.length) {
-        throw new WrongNumberOfArgumentsError(ctx.commandName)
-      }
-
-      let option: HashExpireOption | undefined
-      const maybeOption = input[cursor].toString().toUpperCase()
-      if (isHashExpireOption(maybeOption)) {
-        option = maybeOption
-        cursor += 1
-      }
-
-      const fieldsToken = input[cursor]
-      if (!fieldsToken) {
-        throw new WrongNumberOfArgumentsError(ctx.commandName)
-      }
-      if (fieldsToken.toString().toUpperCase() !== 'FIELDS') {
-        throw new RedisCommandError(
-          'Mandatory argument FIELDS is missing or not at the right position',
-        )
-      }
-
-      const fieldCountToken = input[cursor + 1]
-      if (!fieldCountToken) {
-        throw new WrongNumberOfArgumentsError(ctx.commandName)
-      }
-
-      const fieldCount = parseHashExpireFieldCount(fieldCountToken)
-      const fields = input.slice(cursor + 2)
-      if (fieldCount !== BigInt(fields.length)) {
-        throw new RedisCommandError(
-          'The `numfields` parameter must match the number of arguments',
-        )
       }
 
       return {
-        value: { key, time, option, fields },
+        value: { key, rawArgs: input.slice(index + 1) },
         nextIndex: input.length,
       }
     },
   )
+}
+
+function parseHashExpireArgs(
+  rawArgs: readonly Buffer[],
+  commandName: string,
+): ParsedHashExpireArgs {
+  const time = parseHashExpireTime(rawArgs[0])
+  let cursor = 1
+
+  let option: HashExpireOption | undefined
+  const maybeOption = rawArgs[cursor].toString().toUpperCase()
+  if (isHashExpireOption(maybeOption)) {
+    option = maybeOption
+    cursor += 1
+  }
+
+  const fieldsToken = rawArgs[cursor]
+  if (!fieldsToken) {
+    throw new WrongNumberOfArgumentsError(commandName)
+  }
+  if (fieldsToken.toString().toUpperCase() !== 'FIELDS') {
+    throw new RedisCommandError(
+      'Mandatory argument FIELDS is missing or not at the right position',
+    )
+  }
+
+  const fieldCountToken = rawArgs[cursor + 1]
+  if (!fieldCountToken) {
+    throw new WrongNumberOfArgumentsError(commandName)
+  }
+
+  const fieldCount = parseHashExpireFieldCount(fieldCountToken)
+  const fields = rawArgs.slice(cursor + 2)
+  if (fieldCount !== BigInt(fields.length)) {
+    throw new RedisCommandError(
+      'The `numfields` parameter must match the number of arguments',
+    )
+  }
+
+  return { time, option, fields }
 }
 
 function parsePositiveFieldCount(token: Buffer): bigint {
@@ -261,61 +267,85 @@ function expireHashFields(
   ctx: RedisExecutionContext,
   mode: HashExpireMode,
 ): RedisResult {
-  const expiresAt = hashExpireTimeToTimestamp(args.time, mode)
+  const commandName = hashExpireCommandName(mode)
+  const existingHash = ctx.db.getHash(args.key)
+  const parsedArgs = parseHashExpireArgs(args.rawArgs, commandName)
+  const expiresAt = hashExpireTimeToTimestamp(
+    parsedArgs.time,
+    mode,
+    commandName,
+  )
   const now = Date.now()
 
-  return withExistingHash(
-    ctx,
-    args.key,
-    () => array(args.fields.map(() => RedisValue.integer(-2))),
-    hash => {
-      return array(
-        args.fields.map(field => {
-          const entry = hash.getField(field)
-          if (!entry) {
-            return RedisValue.integer(-2)
-          }
+  if (!existingHash) {
+    return array(parsedArgs.fields.map(() => RedisValue.integer(-2)))
+  }
 
-          if (!shouldApplyHashExpire(entry.expiresAt, expiresAt, args.option)) {
-            return RedisValue.integer(0)
-          }
+  return ctx.db.updateHash(args.key, hash => {
+    return array(
+      parsedArgs.fields.map(field => {
+        const entry = hash.getField(field)
+        if (!entry) {
+          return RedisValue.integer(-2)
+        }
 
-          if (expiresAt <= now) {
-            hash.deleteField(field)
-            return RedisValue.integer(2)
-          }
+        if (
+          !shouldApplyHashExpire(entry.expiresAt, expiresAt, parsedArgs.option)
+        ) {
+          return RedisValue.integer(0)
+        }
 
-          hash.setFieldExpiration(field, expiresAt)
-          return RedisValue.integer(1)
-        }),
-      )
-    },
-  )
+        if (expiresAt <= now) {
+          hash.deleteField(field)
+          return RedisValue.integer(2)
+        }
+
+        hash.setFieldExpiration(field, expiresAt)
+        return RedisValue.integer(1)
+      }),
+    )
+  })
 }
 
 function hashExpireTimeToTimestamp(
   value: bigint,
   mode: HashExpireMode,
+  commandName: string,
 ): number {
+  if (value < 0n) {
+    throw new RedisCommandError('invalid expire time, must be >= 0')
+  }
+
+  const isSecondsMode = mode === 'seconds' || mode === 'unix-seconds'
+  if (isSecondsMode && value > HASH_FIELD_EXPIRE_MAX_ABS_MS / 1000n) {
+    throw new InvalidExpireTimeError(commandName)
+  }
+
+  const milliseconds = isSecondsMode ? value * 1000n : value
+  const baseTime =
+    mode === 'seconds' || mode === 'milliseconds' ? BigInt(Date.now()) : 0n
+
+  if (milliseconds > HASH_FIELD_EXPIRE_MAX_ABS_MS - baseTime) {
+    throw new InvalidExpireTimeError(commandName)
+  }
+
+  return Number(milliseconds + baseTime)
+}
+
+function hashExpireCommandName(mode: HashExpireMode): string {
   if (mode === 'seconds') {
-    return Date.now() + bigintToNumberSaturated(value * 1000n)
+    return 'hexpire'
   }
 
   if (mode === 'milliseconds') {
-    return Date.now() + bigintToNumberSaturated(value)
+    return 'hpexpire'
   }
 
   if (mode === 'unix-seconds') {
-    return bigintToNumberSaturated(value * 1000n)
+    return 'hexpireat'
   }
 
-  return bigintToNumberSaturated(value)
-}
-
-function bigintToNumberSaturated(value: bigint): number {
-  if (value > MAX_SAFE_INTEGER_BIGINT) return Number.MAX_SAFE_INTEGER
-  if (value < MIN_SAFE_INTEGER_BIGINT) return Number.MIN_SAFE_INTEGER
-  return Number(value)
+  return 'hpexpireat'
 }
 
 function shouldApplyHashExpire(

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -81,13 +81,13 @@ export const hscanCommand = defineCommand({
       return scanResult([], args)
     }
 
-    const items: ScanItem[] = []
-    for (const { field, value } of hash.fields.values()) {
-      items.push({
-        matchValue: field,
-        values: [RedisValue.bulkString(field), RedisValue.bulkString(value)],
-      })
-    }
+    const entries = ctx.db.updateHash(args.key, hash =>
+      Array.from(hash.entries()),
+    )
+    const items: ScanItem[] = entries.map(({ field, value }) => ({
+      matchValue: field,
+      values: [RedisValue.bulkString(field), RedisValue.bulkString(value)],
+    }))
 
     return scanResult(items, args)
   },

--- a/src/state/data-types.ts
+++ b/src/state/data-types.ts
@@ -19,6 +19,7 @@ export type RedisHashData = {
 export type RedisHashField = {
   field: Buffer
   value: Buffer
+  expiresAt?: number
 }
 
 export type RedisListData = {
@@ -105,6 +106,7 @@ export function cloneRedisDataValue(value: RedisDataValue): RedisDataValue {
             {
               field: Buffer.from(field.field),
               value: Buffer.from(field.value),
+              expiresAt: field.expiresAt,
             },
           ]),
         ),

--- a/src/state/tracked-values.ts
+++ b/src/state/tracked-values.ts
@@ -26,27 +26,43 @@ export class TrackedHashData {
   ) {}
 
   get size(): number {
+    this.deleteExpiredFields()
     return this.hash.fields.size
   }
 
   getField(field: Buffer): RedisHashField | undefined {
-    return this.hash.fields.get(field.toString('hex'))
+    const id = field.toString('hex')
+    const entry = this.hash.fields.get(id)
+    if (!entry) {
+      return undefined
+    }
+
+    if (isHashFieldExpired(entry)) {
+      this.hash.fields.delete(id)
+      this.tracker.markChanged()
+      return undefined
+    }
+
+    return entry
   }
 
   hasField(field: Buffer): boolean {
-    return this.hash.fields.has(field.toString('hex'))
+    return this.getField(field) !== undefined
   }
 
   setField(
     field: Buffer,
     value: Buffer,
-    options: { forceDirty?: boolean } = {},
+    options: { forceDirty?: boolean; keepTtl?: boolean } = {},
   ): { added: boolean; valueChanged: boolean } {
     const hex = field.toString('hex')
-    const existing = this.hash.fields.get(hex)
+    const existing = this.getField(field)
     const valueChanged = !existing || !existing.value.equals(value)
-    this.hash.fields.set(hex, { field, value })
-    if (options.forceDirty || valueChanged) {
+    const expiresAt = options.keepTtl ? existing?.expiresAt : undefined
+    const ttlChanged = existing?.expiresAt !== expiresAt
+
+    this.hash.fields.set(hex, { field, value, expiresAt })
+    if (options.forceDirty || valueChanged || ttlChanged) {
       this.tracker.markChanged()
     }
     return { added: existing === undefined, valueChanged }
@@ -62,6 +78,11 @@ export class TrackedHashData {
   }
 
   deleteField(field: Buffer): boolean {
+    const existing = this.getField(field)
+    if (!existing) {
+      return false
+    }
+
     const deleted = this.hash.fields.delete(field.toString('hex'))
     if (deleted) {
       this.tracker.markChanged()
@@ -69,9 +90,43 @@ export class TrackedHashData {
     return deleted
   }
 
+  setFieldExpiration(field: Buffer, expiresAt: number): boolean {
+    const entry = this.getField(field)
+    if (!entry) {
+      return false
+    }
+
+    if (entry.expiresAt !== expiresAt) {
+      entry.expiresAt = expiresAt
+      this.tracker.markChanged()
+    }
+    return true
+  }
+
   entries(): IterableIterator<RedisHashField> {
+    this.deleteExpiredFields()
     return this.hash.fields.values()
   }
+
+  private deleteExpiredFields(): void {
+    const now = Date.now()
+    let deleted = false
+
+    for (const [id, entry] of this.hash.fields) {
+      if (isHashFieldExpired(entry, now)) {
+        this.hash.fields.delete(id)
+        deleted = true
+      }
+    }
+
+    if (deleted) {
+      this.tracker.markChanged()
+    }
+  }
+}
+
+function isHashFieldExpired(field: RedisHashField, now = Date.now()): boolean {
+  return field.expiresAt !== undefined && field.expiresAt <= now
 }
 
 export class TrackedListData {

--- a/tests-integration/ioredis/hash-integration.test.ts
+++ b/tests-integration/ioredis/hash-integration.test.ts
@@ -579,6 +579,67 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
     }
   })
 
+  test('HSCAN omits expired hash fields', async () => {
+    const key = `{hexpire-hscan:${randomKey()}}:hash`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, key)
+      await directClient.hset(key, 'keep', 'value1', 'gone', 'value2')
+
+      assert.deepStrictEqual(
+        await directClient.call('HPEXPIRE', key, '5', 'FIELDS', '1', 'gone'),
+        [1],
+      )
+
+      await delay(40)
+
+      const [, scanEntries] = (await directClient.call('HSCAN', key, '0')) as [
+        string,
+        string[],
+      ]
+      const scanned = new Map<string, string>()
+      for (let i = 0; i < scanEntries.length; i += 2) {
+        scanned.set(scanEntries[i], scanEntries[i + 1])
+      }
+
+      assert.deepStrictEqual(Object.fromEntries(scanned), { keep: 'value1' })
+    } finally {
+      await directClient?.del(key)
+      directClient?.disconnect()
+    }
+  })
+
+  test('HEXPIRE deletes the key when every field expires', async () => {
+    const key = `{hexpire-empty:${randomKey()}}:hash`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, key)
+      await directClient.hset(key, 'field1', 'value1', 'field2', 'value2')
+
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HPEXPIRE',
+          key,
+          '0',
+          'FIELDS',
+          '2',
+          'field1',
+          'field2',
+        ),
+        [2, 2],
+      )
+      assert.strictEqual(await directClient.exists(key), 0)
+      assert.strictEqual(await directClient.type(key), 'none')
+    } finally {
+      await directClient?.del(key)
+      directClient?.disconnect()
+    }
+  })
+
   test('HEXPIRE condition flags match Redis', async () => {
     const key = `{hexpire-options:${randomKey()}}:hash`
     let directClient: Redis | undefined
@@ -786,6 +847,48 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
         ),
       )
       await assert.rejects(
+        () =>
+          directClient?.call(
+            'HEXPIRE',
+            stringKey,
+            'abc',
+            'FIELDS',
+            '1',
+            'field',
+          ),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HEXPIRE',
+            stringKey,
+            '100',
+            'FIELDS',
+            '5',
+            'field',
+          ),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HEXPIRE',
+            stringKey,
+            '100',
+            'FIELDS',
+            '0',
+            'field',
+          ),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
         () => directClient?.call('HEXPIRE'),
         errorWithMessage("ERR wrong number of arguments for 'hexpire' command"),
       )
@@ -800,7 +903,60 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
       )
       await assert.rejects(
         () =>
+          directClient?.call('HEXPIRE', hashKey, '-1', 'FIELDS', '1', 'field'),
+        errorWithMessage('ERR invalid expire time, must be >= 0'),
+      )
+      assert.strictEqual(await directClient.hget(hashKey, 'field'), 'value')
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HEXPIRE',
+            hashKey,
+            '99999999999',
+            'FIELDS',
+            '1',
+            'field',
+          ),
+        errorWithMessage("ERR invalid expire time in 'hexpire' command"),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HEXPIREAT',
+            hashKey,
+            '9999999999999999',
+            'FIELDS',
+            '1',
+            'field',
+          ),
+        errorWithMessage("ERR invalid expire time in 'hexpireat' command"),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HEXPIRE',
+            hashKey,
+            '9223372036854775807',
+            'FIELDS',
+            '1',
+            'field',
+          ),
+        errorWithMessage("ERR invalid expire time in 'hexpire' command"),
+      )
+      await assert.rejects(
+        () => directClient?.call('HEXPIRE', hashKey, '100', '1', 'field'),
+        errorWithMessage("ERR wrong number of arguments for 'hexpire' command"),
+      )
+      await assert.rejects(
+        () =>
           directClient?.call('HEXPIRE', hashKey, '10', 'FIELD', '1', 'field'),
+        errorWithMessage(
+          'ERR Mandatory argument FIELDS is missing or not at the right position',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call('HEXPIRE', hashKey, '100', '1', 'FIELDS', 'field'),
         errorWithMessage(
           'ERR Mandatory argument FIELDS is missing or not at the right position',
         ),

--- a/tests-integration/ioredis/hash-integration.test.ts
+++ b/tests-integration/ioredis/hash-integration.test.ts
@@ -1038,6 +1038,45 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
     }
   })
 
+  test('HEXPIRE arg-content errors stay inline inside MULTI/EXEC', async () => {
+    const key = `{hexpire-multi-errors:${randomKey()}}:hash`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, key)
+
+      assert.strictEqual(await directClient.call('MULTI'), 'OK')
+      assert.strictEqual(
+        await directClient.call('HSET', key, 'field', 'value'),
+        'QUEUED',
+      )
+      assert.strictEqual(
+        await directClient.call('HEXPIRE', key, 'abc', 'FIELDS', '1', 'field'),
+        'QUEUED',
+      )
+      assert.strictEqual(
+        await directClient.call('HGET', key, 'field'),
+        'QUEUED',
+      )
+
+      const result = await directClient.call('EXEC')
+
+      assert.ok(Array.isArray(result))
+      assert.strictEqual(result.length, 3)
+      assert.strictEqual(result[0], 1)
+      assert.ok(result[1] instanceof Error)
+      assert.strictEqual(
+        result[1].message,
+        'ERR value is not an integer or out of range',
+      )
+      assert.strictEqual(result[2], 'value')
+    } finally {
+      await directClient?.del(key)
+      directClient?.disconnect()
+    }
+  })
+
   test('HINCRBY command', async () => {
     // HINCRBY on non-existent field
     const incr1 = await redisClient?.hincrby('hash8', 'counter', 5)

--- a/tests-integration/ioredis/hash-integration.test.ts
+++ b/tests-integration/ioredis/hash-integration.test.ts
@@ -17,6 +17,10 @@ import {
 
 const testRunner = new TestRunner()
 
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
 describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
   let redisClient: Cluster | undefined
 
@@ -481,6 +485,395 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
           ),
         errorWithMessage(
           'ERR The `numfields` parameter must match the number of arguments',
+        ),
+      )
+    } finally {
+      await directClient?.del(hashKey, stringKey)
+      directClient?.disconnect()
+    }
+  })
+
+  test('HEXPIRE family sets and lazily expires hash fields', async () => {
+    const tag = `{hexpire:${randomKey()}}`
+    const key = `${tag}:hash`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, key)
+      await directClient.hset(
+        key,
+        'keep',
+        'value1',
+        'soon',
+        'value2',
+        'zero',
+        'value3',
+        'past',
+        'value4',
+        'pxat',
+        'value5',
+      )
+
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HEXPIRE',
+          key,
+          '10',
+          'FIELDS',
+          '2',
+          'keep',
+          'missing',
+        ),
+        [1, -2],
+      )
+      assert.deepStrictEqual(
+        await directClient.call('HPEXPIRE', key, '0', 'FIELDS', '1', 'zero'),
+        [2],
+      )
+      assert.deepStrictEqual(
+        await directClient.call('HEXPIREAT', key, '1', 'FIELDS', '1', 'past'),
+        [2],
+      )
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HPEXPIREAT',
+          key,
+          String(Date.now() + 10_000),
+          'FIELDS',
+          '1',
+          'pxat',
+        ),
+        [1],
+      )
+      assert.deepStrictEqual(
+        await directClient.call('HPEXPIRE', key, '5', 'FIELDS', '1', 'soon'),
+        [1],
+      )
+
+      await delay(40)
+
+      assert.strictEqual(await directClient.hget(key, 'soon'), null)
+      assert.deepStrictEqual(
+        await directClient.hmget(key, 'keep', 'soon', 'zero', 'past', 'pxat'),
+        ['value1', null, null, null, 'value5'],
+      )
+      assert.strictEqual(await directClient.hexists(key, 'soon'), 0)
+      assert.strictEqual(await directClient.hstrlen(key, 'soon'), 0)
+      assert.strictEqual(await directClient.hlen(key), 2)
+      assert.deepStrictEqual((await directClient.hkeys(key)).sort(), [
+        'keep',
+        'pxat',
+      ])
+      assert.deepStrictEqual((await directClient.hvals(key)).sort(), [
+        'value1',
+        'value5',
+      ])
+      assert.deepStrictEqual(await directClient.hgetall(key), {
+        keep: 'value1',
+        pxat: 'value5',
+      })
+    } finally {
+      await directClient?.del(key)
+      directClient?.disconnect()
+    }
+  })
+
+  test('HEXPIRE condition flags match Redis', async () => {
+    const key = `{hexpire-options:${randomKey()}}:hash`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, key)
+      await directClient.hset(
+        key,
+        'volatile',
+        'value1',
+        'nx',
+        'value2',
+        'xx',
+        'value3',
+        'lt',
+        'value4',
+      )
+
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HEXPIRE',
+          key,
+          '20',
+          'FIELDS',
+          '1',
+          'volatile',
+        ),
+        [1],
+      )
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HEXPIRE',
+          key,
+          '30',
+          'NX',
+          'FIELDS',
+          '1',
+          'volatile',
+        ),
+        [0],
+      )
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HEXPIRE',
+          key,
+          '30',
+          'NX',
+          'FIELDS',
+          '1',
+          'nx',
+        ),
+        [1],
+      )
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HEXPIRE',
+          key,
+          '30',
+          'XX',
+          'FIELDS',
+          '1',
+          'xx',
+        ),
+        [0],
+      )
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HEXPIRE',
+          key,
+          '30',
+          'XX',
+          'FIELDS',
+          '1',
+          'volatile',
+        ),
+        [1],
+      )
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HEXPIRE',
+          key,
+          '10',
+          'GT',
+          'FIELDS',
+          '1',
+          'nx',
+        ),
+        [0],
+      )
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HEXPIRE',
+          key,
+          '40',
+          'GT',
+          'FIELDS',
+          '1',
+          'nx',
+        ),
+        [1],
+      )
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HEXPIRE',
+          key,
+          '10',
+          'LT',
+          'FIELDS',
+          '1',
+          'lt',
+        ),
+        [1],
+      )
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HEXPIRE',
+          key,
+          '40',
+          'LT',
+          'FIELDS',
+          '1',
+          'lt',
+        ),
+        [0],
+      )
+    } finally {
+      await directClient?.del(key)
+      directClient?.disconnect()
+    }
+  })
+
+  test('hash writes clear or preserve field TTLs like Redis', async () => {
+    const key = `{hash-field-ttl-writes:${randomKey()}}:hash`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, key)
+      await directClient.hset(
+        key,
+        'replace',
+        'old',
+        'counter',
+        '1',
+        'float',
+        '1.5',
+      )
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HPEXPIRE',
+          key,
+          '20',
+          'FIELDS',
+          '3',
+          'replace',
+          'counter',
+          'float',
+        ),
+        [1, 1, 1],
+      )
+
+      assert.strictEqual(await directClient.hset(key, 'replace', 'new'), 0)
+      assert.strictEqual(await directClient.hincrby(key, 'counter', 1), 2)
+      assert.strictEqual(
+        await directClient.hincrbyfloat(key, 'float', 1),
+        '2.5',
+      )
+
+      await delay(50)
+
+      assert.strictEqual(await directClient.hget(key, 'replace'), 'new')
+      assert.strictEqual(await directClient.hget(key, 'counter'), null)
+      assert.strictEqual(await directClient.hget(key, 'float'), null)
+    } finally {
+      await directClient?.del(key)
+      directClient?.disconnect()
+    }
+  })
+
+  test('HEXPIRE errors match Redis', async () => {
+    const tag = `{hexpire-errors:${randomKey()}}`
+    const hashKey = `${tag}:hash`
+    const stringKey = `${tag}:string`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, hashKey)
+      await directClient.hset(hashKey, 'field', 'value')
+      await directClient.set(stringKey, 'value')
+
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HEXPIRE',
+            stringKey,
+            '10',
+            'FIELDS',
+            '1',
+            'field',
+          ),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
+        () => directClient?.call('HEXPIRE'),
+        errorWithMessage("ERR wrong number of arguments for 'hexpire' command"),
+      )
+      await assert.rejects(
+        () => directClient?.call('HEXPIRE', hashKey, '10'),
+        errorWithMessage("ERR wrong number of arguments for 'hexpire' command"),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call('HEXPIRE', hashKey, 'abc', 'FIELDS', '1', 'field'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call('HEXPIRE', hashKey, '10', 'FIELD', '1', 'field'),
+        errorWithMessage(
+          'ERR Mandatory argument FIELDS is missing or not at the right position',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HEXPIRE',
+            hashKey,
+            '10',
+            'FIELDS',
+            'abc',
+            'field',
+          ),
+        errorWithMessage('ERR Parameter `numFields` should be greater than 0'),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call('HEXPIRE', hashKey, '10', 'FIELDS', '0', 'field'),
+        errorWithMessage('ERR Parameter `numFields` should be greater than 0'),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call('HEXPIRE', hashKey, '10', 'FIELDS', '2', 'field'),
+        errorWithMessage(
+          'ERR The `numfields` parameter must match the number of arguments',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HEXPIRE',
+            hashKey,
+            '10',
+            'NX',
+            'XX',
+            'FIELDS',
+            '1',
+            'field',
+          ),
+        errorWithMessage(
+          'ERR Mandatory argument FIELDS is missing or not at the right position',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HEXPIRE',
+            hashKey,
+            '10',
+            'GT',
+            'LT',
+            'FIELDS',
+            '1',
+            'field',
+          ),
+        errorWithMessage(
+          'ERR Mandatory argument FIELDS is missing or not at the right position',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HEXPIRE',
+            hashKey,
+            '10',
+            'BOGUS',
+            'FIELDS',
+            '1',
+            'field',
+          ),
+        errorWithMessage(
+          'ERR Mandatory argument FIELDS is missing or not at the right position',
         ),
       )
     } finally {


### PR DESCRIPTION
## Summary
- Add per-field hash expiry metadata and lazy tracked hash cleanup.
- Implement HEXPIRE, HPEXPIRE, HEXPIREAT, and HPEXPIREAT with NX/XX/GT/LT conditions and Redis return codes.
- Cover mock and real Redis behavior for success paths, parser errors, lazy expiry visibility, and TTL clear/preserve semantics; update command/state docs.

## Root cause
Hash fields only stored field/value pairs, so Redis 7.4 hash-field TTL commands had no state model for per-field expiration and were absent from the command registry.

## Validation
- npm run build
- npm test
- TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/hash-integration.test.ts
- npm run clean:redis && TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/hash-integration.test.ts
- npm run test:integration:mock
- npm run clean:redis && npm run test:integration:real
- npm run lint
- git push pre-push hook: npm test

Fixes #254

Part of #207. Leaves #255 (HPERSIST/HTTL/HPTTL) and #256 (HGETEX) open for follow-up work.