### PR TITLE
fix: drop slot number from CLUSTERDOWN error message (#64)

### DIFF
--- a/src/core/execution-policies/cluster-policy.ts
+++ b/src/core/execution-policies/cluster-policy.ts
@@ -124,7 +124,7 @@ function validateClusterSlot(
 
   const owner = topology.getSlotOwner(slot)
   if (!owner) {
-    throw new RedisClusterDownError(slot)
+    throw new RedisClusterDownError()
   }
 
   throw new RedisMovedError(slot, owner.host, owner.port)

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -208,8 +208,8 @@ export class RedisMovedError extends RedisCommandError {
 }
 
 export class RedisClusterDownError extends RedisCommandError {
-  constructor(slot: number) {
-    super(`Hash slot ${slot} is not served`, 'CLUSTERDOWN')
+  constructor() {
+    super('Hash slot not served', 'CLUSTERDOWN')
   }
 }
 

--- a/tests/core-cluster-policy.test.ts
+++ b/tests/core-cluster-policy.test.ts
@@ -171,6 +171,16 @@ describe('new cluster execution policy', () => {
     )
   })
 
+  test('returns CLUSTERDOWN without the slot number for an unassigned slot', async () => {
+    const { session, topology } = createClusterHarnessWithUnassignedSlot()
+    const key = findKeyInUnassignedSlot(topology)
+
+    assert.deepStrictEqual(
+      await session.execute('get', [key]),
+      RedisResult.error('Hash slot not served', 'CLUSTERDOWN'),
+    )
+  })
+
   test('DISCARD clears the pinned transaction slot', async () => {
     const { session, server, topology } = createClusterHarness()
     const [first, second] = findDifferentSlotKeysOwnedBy(topology, 'local')
@@ -228,6 +238,45 @@ function createClusterHarness() {
   const session = new ClientSession({ server, executor })
 
   return { executor, server, session, topology }
+}
+
+function createClusterHarnessWithUnassignedSlot() {
+  // Leave slot 8192 unassigned so a key hashing to it triggers CLUSTERDOWN.
+  const topology = new RedisClusterTopology([
+    {
+      id: 'local',
+      role: 'master',
+      host: '127.0.0.1',
+      port: 7000,
+      slots: [[0, 8191]],
+    },
+    {
+      id: 'remote',
+      role: 'master',
+      host: '127.0.0.1',
+      port: 7001,
+      slots: [[8193, 16383]],
+    },
+  ])
+  const server = new RedisServerState({ clusterTopology: topology })
+  const executor = createRedisCommandExecutor({
+    extraCommands: createClusterCommands('local'),
+    policies: [createClusterPolicy({ localNodeId: 'local' })],
+  })
+  const session = new ClientSession({ server, executor })
+
+  return { executor, server, session, topology }
+}
+
+function findKeyInUnassignedSlot(topology: RedisClusterTopology): Buffer {
+  for (let index = 0; index < 1000000; index++) {
+    const key = Buffer.from(`unassigned-${index}`)
+    if (topology.getSlotOwner(topology.calculateSlot(key)) === undefined) {
+      return key
+    }
+  }
+
+  throw new Error('Could not find key hashing to an unassigned slot')
 }
 
 function findKeyOwnedBy(


### PR DESCRIPTION
## Summary
- For an unassigned cluster slot, real Redis returns `CLUSTERDOWN Hash slot not served` — no slot number.
- `RedisClusterDownError` interpolated the slot (`Hash slot ${slot} is not served`), diverging from the real wire string. Verified against real `redis-server` 7.2 (`cluster-require-full-coverage no`, one unbound slot): the unbound-slot reply is exactly `CLUSTERDOWN Hash slot not served`.
- Dropped the now-unused `slot` constructor arg and updated its single caller in `cluster-policy.ts`.

Closes #64

## Test plan
- [x] New unit test in `tests/core-cluster-policy.test.ts` routes a key in an unassigned slot through the real ClusterPolicy and asserts `CLUSTERDOWN Hash slot not served` (red before fix: got `Hash slot 8192 is not served`).
- [x] Integration can't cover this — a healthy cluster (mock + shared real harness) assigns all 16384 slots; the expected string was instead ground-truthed directly against a local real `redis-server`.
- [x] Fix makes the test pass.
- [x] `npm run build`, `npm run lint`, `npm run test:all` all pass (533 tests, unit + mock + real integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)