### PR TITLE
fix: HINCRBY uses Redis 64-bit signed integer range (#29)

### DIFF
--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -10,6 +10,7 @@ import {
   ExpectedIntegerError,
   HashValueNotFloatError,
   HashValueNotIntegerError,
+  IncrDecrOverflowError,
   InvalidExpireTimeError,
   RedisCommandError,
   RedisSyntaxError,
@@ -796,22 +797,34 @@ export const hexistsCommand = defineCommand({
 
 export const hincrbyCommand = defineCommand({
   name: 'hincrby',
-  schema: t.object({ key: t.key(), field: t.key(), increment: t.integer() }),
+  schema: t.object({
+    key: t.key(),
+    field: t.key(),
+    increment: t.bigInteger({ min: LONG_MIN, max: LONG_MAX }),
+  }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
   execute: (args, ctx) => {
     const result = ctx.db.updateHash(args.key, hash => {
       const entry = hash.getField(args.field)
-      let current = 0
+      let current = 0n
       if (entry) {
         const raw = entry.value.toString()
-        if (!isIntegerToken(raw) || !Number.isSafeInteger(Number(raw))) {
+        // Redis parses the stored value as a 64-bit signed integer; a value
+        // outside that range is "hash value is not an integer", not overflow.
+        if (!isIntegerToken(raw)) {
           throw new HashValueNotIntegerError()
         }
-        current = Number(raw)
+        current = BigInt(raw)
+        if (current < LONG_MIN || current > LONG_MAX) {
+          throw new HashValueNotIntegerError()
+        }
       }
       const next = current + args.increment
-      const valueBuf = Buffer.from(String(next))
+      if (next < LONG_MIN || next > LONG_MAX) {
+        throw new IncrDecrOverflowError()
+      }
+      const valueBuf = Buffer.from(next.toString())
       hash.setField(args.field, valueBuf, { forceDirty: true, keepTtl: true })
       return next
     })

--- a/tests-integration/ioredis/hash-integration.test.ts
+++ b/tests-integration/ioredis/hash-integration.test.ts
@@ -1324,6 +1324,67 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
     assert.strictEqual(incr3, 6)
   })
 
+  test('HINCRBY respects Redis 64-bit signed integer range', async () => {
+    const key = `{hincrby64:${randomKey()}}`
+    try {
+      // Values in the gap between 2^53 and 2^63 must keep full precision
+      // (JS Number.isSafeInteger() would wrongly reject these).
+      await redisClient?.hset(key, 'gap', '9007199254740992') // 2^53
+      await redisClient?.call('HINCRBY', key, 'gap', '1')
+      assert.strictEqual(
+        await redisClient?.hget(key, 'gap'),
+        '9007199254740993',
+      )
+
+      // Large value still inside int64 — no overflow (issue #29 wrongly
+      // claimed this overflows; real Redis returns 9000000000000000001).
+      await redisClient?.hset(key, 'big', '9000000000000000000')
+      await redisClient?.call('HINCRBY', key, 'big', '1')
+      assert.strictEqual(
+        await redisClient?.hget(key, 'big'),
+        '9000000000000000001',
+      )
+
+      // Positive overflow past INT64_MAX (2^63-1) is rejected, value untouched.
+      await redisClient?.hset(key, 'max', '9223372036854775807')
+      await assert.rejects(
+        () => redisClient?.call('HINCRBY', key, 'max', '1'),
+        errorWithMessage('ERR increment or decrement would overflow'),
+      )
+      assert.strictEqual(
+        await redisClient?.hget(key, 'max'),
+        '9223372036854775807',
+      )
+
+      // Negative overflow past INT64_MIN (-2^63) is rejected, value untouched.
+      await redisClient?.hset(key, 'min', '-9223372036854775808')
+      await assert.rejects(
+        () => redisClient?.call('HINCRBY', key, 'min', '-1'),
+        errorWithMessage('ERR increment or decrement would overflow'),
+      )
+      assert.strictEqual(
+        await redisClient?.hget(key, 'min'),
+        '-9223372036854775808',
+      )
+
+      // Increment argument outside int64 range is a value error.
+      await assert.rejects(
+        () =>
+          redisClient?.call('HINCRBY', key, 'gap', '99999999999999999999999'),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+
+      // Stored field value outside int64 range is "hash value is not an integer".
+      await redisClient?.hset(key, 'huge', '99999999999999999999999')
+      await assert.rejects(
+        () => redisClient?.call('HINCRBY', key, 'huge', '1'),
+        errorWithMessage('ERR hash value is not an integer'),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
   test('HINCRBYFLOAT command', async () => {
     // HINCRBYFLOAT on non-existent field
     const incr1 = await redisClient?.hincrbyfloat('hash9', 'float', 1.5)


### PR DESCRIPTION
## Summary
- `hincrbyCommand` validated stored values with `Number.isSafeInteger()` and ran the arithmetic with JS `Number`, capping at ±(2^53-1). Real Redis uses 64-bit signed integers (±(2^63-1)).
- Consequences: values in the 2^53–2^63 gap were wrongly rejected as `hash value is not an integer` or stored with floating-point imprecision, and overflow was flagged ~1024x too early.
- Fix: parse stored value + increment as `BigInt`, bound-check against INT64 min/max, serialize back via `.toString()`. A stored value outside int64 range stays `hash value is not an integer`; a result past the boundary is `increment or decrement would overflow`. The increment argument now parses via `t.bigInteger` with int64 bounds, mirroring `INCRBY`.
- Note: issue #29's second repro was inaccurate — `9000000000000000000 + 1` does **not** overflow (it's within int64); verified against real Redis, so the test asserts `9000000000000000001` there and reserves the overflow assertion for the actual INT64 boundary.

Closes #29

## Test plan
- [x] New test in `tests-integration/ioredis/hash-integration.test.ts` ("HINCRBY respects Redis 64-bit signed integer range") reproduces the bug (red on mock before fix)
- [x] Test passes against real Redis (mock-only bug confirmed)
- [x] Fix makes the test pass on mock too
- [x] `npm run build` + `npm run lint` clean; `npm run test:all` passes (the one real-backend SCAN flake is pre-existing and unrelated — passes on re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)