### PR TITLE
feat: add HGETEX hash command (#256)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -229,6 +229,7 @@ with `GT` or `LT`.
 - [x] `HGETALL key` - Get all fields and values in a hash (RESP3 map / RESP2 flat array)
 - [x] `HDEL key field [field ...]` - Delete one or more hash fields
 - [x] `HGETDEL key FIELDS numfields field [field ...]` - Get and delete one or more hash fields
+- [x] `HGETEX key [EX seconds|PX ms|EXAT unix-s|PXAT unix-ms|PERSIST] FIELDS numfields field [field ...]` - Get one or more hash fields and optionally update their TTLs
 - [x] `HEXPIRE key seconds [NX|XX|GT|LT] FIELDS numfields field [field ...]` - Set hash-field TTLs in seconds
 - [x] `HPEXPIRE key milliseconds [NX|XX|GT|LT] FIELDS numfields field [field ...]` - Set hash-field TTLs in milliseconds
 - [x] `HEXPIREAT key unix-time-seconds [NX|XX|GT|LT] FIELDS numfields field [field ...]` - Set hash-field expiration timestamps in seconds
@@ -245,10 +246,6 @@ with `GT` or `LT`.
 - [x] `HINCRBYFLOAT key field increment` - Increment the float value of a hash field
 - [x] `HRANDFIELD key [count [WITHVALUES]]` - Return one or more random hash fields, optionally with values
 - [x] `HSCAN key cursor [MATCH pattern] [COUNT count]` - Incrementally iterate hash fields and values (see [Scan Family](#10-scan-family))
-
-#### Not implemented
-
-- [ ] `HGETEX key [EX seconds|PX ms|EXAT unix-s|PXAT unix-ms|PERSIST|KEEPTTL] FIELDS numfields field [field ...]`
 
 ## 6. List Commands
 

--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -54,6 +54,19 @@ type ParsedHashExpireArgs = {
   option: HashExpireOption | undefined
   fields: Buffer[]
 }
+type HgetexExpiration =
+  | { kind: 'keep' }
+  | { kind: 'persist' }
+  | { kind: 'set'; mode: HashExpireMode; time: bigint }
+type HgetexPlan =
+  | { kind: 'keep' }
+  | { kind: 'persist' }
+  | { kind: 'expireAt'; at: number }
+type HgetexArgs = {
+  key: Buffer
+  expiration: HgetexExpiration
+  fields: Buffer[]
+}
 
 const LONG_MAX = 9223372036854775807n
 const LONG_MIN = -9223372036854775808n
@@ -151,6 +164,79 @@ function createHashFieldsSchema() {
       }
     },
   )
+}
+
+function createHgetexSchema() {
+  return t.custom<HgetexArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const key = input[index]
+      if (!key || input.length - index < 4) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      const { expiration, nextIndex } = parseHgetexExpiration(
+        input,
+        index + 1,
+        ctx.commandName,
+      )
+
+      const fieldsToken = input[nextIndex]
+      if (!fieldsToken || fieldsToken.toString().toUpperCase() !== 'FIELDS') {
+        throw new RedisCommandError(
+          'Mandatory argument FIELDS is missing or not at the right position',
+        )
+      }
+
+      const fieldCountToken = input[nextIndex + 1]
+      if (!fieldCountToken) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      const fieldCount = parsePositiveFieldCount(fieldCountToken)
+      const fields = input.slice(nextIndex + 2)
+      if (fieldCount !== BigInt(fields.length)) {
+        throw new RedisCommandError(
+          'The `numfields` parameter must match the number of arguments',
+        )
+      }
+
+      return { value: { key, expiration, fields }, nextIndex: input.length }
+    },
+  )
+}
+
+function parseHgetexExpiration(
+  input: readonly Buffer[],
+  index: number,
+  commandName: string,
+): { expiration: HgetexExpiration; nextIndex: number } {
+  const token = input[index]?.toString().toUpperCase()
+  if (token === 'PERSIST') {
+    return { expiration: { kind: 'persist' }, nextIndex: index + 1 }
+  }
+
+  const mode = hgetexExpireMode(token)
+  if (!mode) {
+    return { expiration: { kind: 'keep' }, nextIndex: index }
+  }
+
+  const timeToken = input[index + 1]
+  if (!timeToken) {
+    throw new WrongNumberOfArgumentsError(commandName)
+  }
+
+  const time = parseHashExpireTime(timeToken)
+  return { expiration: { kind: 'set', mode, time }, nextIndex: index + 2 }
+}
+
+function hgetexExpireMode(
+  token: string | undefined,
+): HashExpireMode | undefined {
+  if (token === 'EX') return 'seconds'
+  if (token === 'PX') return 'milliseconds'
+  if (token === 'EXAT') return 'unix-seconds'
+  if (token === 'PXAT') return 'unix-milliseconds'
+  return undefined
 }
 
 function persistHashFields(
@@ -376,6 +462,61 @@ function expireHashFields(
   })
 }
 
+function resolveHgetexPlan(expiration: HgetexExpiration): HgetexPlan {
+  if (expiration.kind === 'set') {
+    return {
+      kind: 'expireAt',
+      at: hashExpireTimeToTimestamp(expiration.time, expiration.mode, 'hgetex'),
+    }
+  }
+  return expiration
+}
+
+function getexHashFields(
+  args: HgetexArgs,
+  ctx: RedisExecutionContext,
+): RedisResult {
+  // Resolve the target timestamp up front so an invalid expire time is
+  // reported even when the key is missing, matching the HEXPIRE ordering.
+  const plan = resolveHgetexPlan(args.expiration)
+
+  const existingHash = ctx.db.getHash(args.key)
+  if (!existingHash) {
+    return array(args.fields.map(() => RedisValue.bulkString(null)))
+  }
+
+  const now = Date.now()
+  let remaining = 0
+  const values = ctx.db.updateHash(args.key, hash => {
+    const replies: RedisValue[] = []
+    for (const field of args.fields) {
+      const entry = hash.getField(field)
+      replies.push(RedisValue.bulkString(entry?.value ?? null))
+      if (!entry) continue
+
+      if (plan.kind === 'persist') {
+        hash.clearFieldExpiration(field)
+        continue
+      }
+
+      if (plan.kind === 'expireAt') {
+        if (plan.at <= now) {
+          hash.deleteField(field)
+        } else {
+          hash.setFieldExpiration(field, plan.at)
+        }
+      }
+    }
+    remaining = hash.size
+    return replies
+  })
+
+  if (remaining === 0) {
+    ctx.db.delete(args.key)
+  }
+  return array(values)
+}
+
 function hashExpireTimeToTimestamp(
   value: bigint,
   mode: HashExpireMode,
@@ -575,6 +716,14 @@ export const hgetdelCommand = defineCommand({
     }
     return array(values)
   },
+})
+
+export const hgetexCommand = defineCommand({
+  name: 'hgetex',
+  schema: createHgetexSchema(),
+  flags: ['write', 'fast'],
+  keys: args => [args.key],
+  execute: getexHashFields,
 })
 
 export const hpersistCommand = defineCommand({
@@ -887,6 +1036,7 @@ export const hashesCommands = [
   hgetCommand,
   hdelCommand,
   hgetdelCommand,
+  hgetexCommand,
   hpersistCommand,
   hexpireCommand,
   hpexpireCommand,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -187,6 +187,7 @@ export {
   hexistsCommand,
   hgetallCommand,
   hgetdelCommand,
+  hgetexCommand,
   hgetCommand,
   hdelCommand,
   hincrbyfloatCommand,

--- a/tests-integration/ioredis/hash-integration.test.ts
+++ b/tests-integration/ioredis/hash-integration.test.ts
@@ -493,6 +493,281 @@ describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
     }
   })
 
+  test('HGETEX returns values and updates field TTLs like Redis', async () => {
+    const tag = `{hgetex:${randomKey()}}`
+    const key = `${tag}:hash`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, key)
+      await directClient.hset(
+        key,
+        'f1',
+        'v1',
+        'f2',
+        'v2',
+        'f3',
+        'v3',
+        'f4',
+        'v4',
+      )
+
+      // Plain read behaves like HMGET, including nil for missing fields.
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HGETEX',
+          key,
+          'FIELDS',
+          '3',
+          'f1',
+          'missing',
+          'f2',
+        ),
+        ['v1', null, 'v2'],
+      )
+      // Missing key yields all-nil without creating the hash.
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HGETEX',
+          `${tag}:nokey`,
+          'FIELDS',
+          '2',
+          'a',
+          'b',
+        ),
+        [null, null],
+      )
+      assert.strictEqual(await directClient.exists(`${tag}:nokey`), 0)
+
+      // EX sets a relative TTL and returns the value.
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HGETEX',
+          key,
+          'EX',
+          '100',
+          'FIELDS',
+          '1',
+          'f1',
+        ),
+        ['v1'],
+      )
+      const ttlSet = (await directClient.call(
+        'HTTL',
+        key,
+        'FIELDS',
+        '1',
+        'f1',
+      )) as number[]
+      assert.ok(ttlSet[0] > 90 && ttlSet[0] <= 100, `ttl ${ttlSet[0]}`)
+
+      // No expiration clause leaves the existing TTL untouched.
+      assert.deepStrictEqual(
+        await directClient.call('HGETEX', key, 'FIELDS', '1', 'f1'),
+        ['v1'],
+      )
+      const ttlKeep = (await directClient.call(
+        'HTTL',
+        key,
+        'FIELDS',
+        '1',
+        'f1',
+      )) as number[]
+      assert.ok(ttlKeep[0] > 90 && ttlKeep[0] <= 100, `ttl ${ttlKeep[0]}`)
+
+      // PERSIST clears the TTL.
+      assert.deepStrictEqual(
+        await directClient.call('HGETEX', key, 'PERSIST', 'FIELDS', '1', 'f1'),
+        ['v1'],
+      )
+      assert.deepStrictEqual(
+        await directClient.call('HTTL', key, 'FIELDS', '1', 'f1'),
+        [-1],
+      )
+
+      // PX sets a millisecond TTL.
+      await directClient.call('HGETEX', key, 'PX', '50000', 'FIELDS', '1', 'f2')
+      const pttlSet = (await directClient.call(
+        'HPTTL',
+        key,
+        'FIELDS',
+        '1',
+        'f2',
+      )) as number[]
+      assert.ok(pttlSet[0] > 40000 && pttlSet[0] <= 50000, `pttl ${pttlSet[0]}`)
+
+      // EXAT in the past returns the value but deletes the field.
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HGETEX',
+          key,
+          'EXAT',
+          '1',
+          'FIELDS',
+          '1',
+          'f3',
+        ),
+        ['v3'],
+      )
+      assert.strictEqual(await directClient.hexists(key, 'f3'), 0)
+
+      // EX 0 expires immediately: value is returned, field removed.
+      assert.deepStrictEqual(
+        await directClient.call('HGETEX', key, 'EX', '0', 'FIELDS', '1', 'f4'),
+        ['v4'],
+      )
+      assert.strictEqual(await directClient.hexists(key, 'f4'), 0)
+
+      // Expiring the last field removes the key entirely.
+      const lone = `${tag}:lone`
+      await directClient.hset(lone, 'only', 'v')
+      assert.deepStrictEqual(
+        await directClient.call(
+          'HGETEX',
+          lone,
+          'EXAT',
+          '1',
+          'FIELDS',
+          '1',
+          'only',
+        ),
+        ['v'],
+      )
+      assert.strictEqual(await directClient.exists(lone), 0)
+    } finally {
+      await directClient?.del(key)
+      directClient?.disconnect()
+    }
+  })
+
+  test('HGETEX errors match Redis', async () => {
+    const tag = `{hgetex-errors:${randomKey()}}`
+    const hashKey = `${tag}:hash`
+    const stringKey = `${tag}:string`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, hashKey)
+      await directClient.hset(hashKey, 'field', 'value')
+      await directClient.set(stringKey, 'value')
+
+      await assert.rejects(
+        () => directClient?.call('HGETEX', stringKey, 'FIELDS', '1', 'field'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
+        () => directClient?.call('HGETEX'),
+        errorWithMessage("ERR wrong number of arguments for 'hgetex' command"),
+      )
+      await assert.rejects(
+        () => directClient?.call('HGETEX', hashKey),
+        errorWithMessage("ERR wrong number of arguments for 'hgetex' command"),
+      )
+      await assert.rejects(
+        () => directClient?.call('HGETEX', hashKey, 'FIELDS', '1'),
+        errorWithMessage("ERR wrong number of arguments for 'hgetex' command"),
+      )
+      await assert.rejects(
+        () => directClient?.call('HGETEX', hashKey, 'FIELD', '1', 'field'),
+        errorWithMessage(
+          'ERR Mandatory argument FIELDS is missing or not at the right position',
+        ),
+      )
+      // KEEPTTL is not a valid HGETEX option.
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HGETEX',
+            hashKey,
+            'KEEPTTL',
+            'FIELDS',
+            '1',
+            'field',
+          ),
+        errorWithMessage(
+          'ERR Mandatory argument FIELDS is missing or not at the right position',
+        ),
+      )
+      // Only one expiration clause is allowed.
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HGETEX',
+            hashKey,
+            'EX',
+            '100',
+            'PERSIST',
+            'FIELDS',
+            '1',
+            'field',
+          ),
+        errorWithMessage(
+          'ERR Mandatory argument FIELDS is missing or not at the right position',
+        ),
+      )
+      await assert.rejects(
+        () => directClient?.call('HGETEX', hashKey, 'FIELDS', 'abc', 'field'),
+        errorWithMessage('ERR Number of fields must be a positive integer'),
+      )
+      await assert.rejects(
+        () => directClient?.call('HGETEX', hashKey, 'FIELDS', '0', 'field'),
+        errorWithMessage('ERR Number of fields must be a positive integer'),
+      )
+      await assert.rejects(
+        () => directClient?.call('HGETEX', hashKey, 'FIELDS', '2', 'field'),
+        errorWithMessage(
+          'ERR The `numfields` parameter must match the number of arguments',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HGETEX',
+            hashKey,
+            'EX',
+            'abc',
+            'FIELDS',
+            '1',
+            'field',
+          ),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HGETEX',
+            hashKey,
+            'EX',
+            '-5',
+            'FIELDS',
+            '1',
+            'field',
+          ),
+        errorWithMessage('ERR invalid expire time, must be >= 0'),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HGETEX',
+            hashKey,
+            'EXAT',
+            '99999999999',
+            'FIELDS',
+            '1',
+            'field',
+          ),
+        errorWithMessage("ERR invalid expire time in 'hgetex' command"),
+      )
+    } finally {
+      await directClient?.del(hashKey, stringKey)
+      directClient?.disconnect()
+    }
+  })
+
   test('HEXPIRE family sets and lazily expires hash fields', async () => {
     const tag = `{hexpire:${randomKey()}}`
     const key = `${tag}:hash`


### PR DESCRIPTION
## Summary
- Implements `HGETEX key [EX seconds|PX ms|EXAT unix-s|PXAT unix-ms|PERSIST] FIELDS numfields field [field ...]` — returns field values like `HMGET` and optionally updates per-field TTLs.
- The issue listed `KEEPTTL` as an option, but real Redis 8.0 **does not** accept it for `HGETEX` (verified against `redis-server` 8.0.6). Omitting any expiration clause already leaves TTLs untouched; an unknown token like `KEEPTTL` yields `ERR Mandatory argument FIELDS is missing or not at the right position`, exactly as Redis does.
- Reuses the existing hash-field TTL infrastructure (`hashExpireTimeToTimestamp`, `parsePositiveFieldCount`, `setFieldExpiration`/`clearFieldExpiration`). Flags are `write`+`fast` (matches Redis `COMMAND INFO hgetex`, RW because it can change TTLs).
- Past/zero expire targets return the value but delete the field; emptying the hash deletes the key. Invalid expire times are reported even when the key is missing, matching `HEXPIRE` ordering.

Closes #256

(Part of #207 — Hash-field TTL family; parent stays open until `HGETEX`'s last sibling lands.)

## Test plan
- [x] New `HGETEX` integration tests in `tests-integration/ioredis/hash-integration.test.ts` reproduce the feature gap (red on mock before fix: 2/2 failing)
- [x] Tests pass against real Redis 8.0.6 (assertions ground-truthed: values, TTL set/keep/persist, past-expire deletion, key removal, and every error string)
- [x] Implementation makes the tests pass on mock too (2/2)
- [x] `npm run build` and `npm run lint` clean
- [x] `npm run test:all` passes (unit 197, mock 536, real 536)

🤖 Generated with [Claude Code](https://claude.com/claude-code)