### PR TITLE
fix: stop stream metadata commands from dirtying WATCH (#218)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -356,10 +356,14 @@ In-place collection updates run through a keyspace-owned mutation tracker and
 typed helpers such as `TrackedHashData.setField()` and
 `TrackedListData.trim()`. Dirty tracking is operation-based rather than a
 before/after value diff: effective helper operations mark the key dirty as they
-run, even if a later operation restores the same final value. Commands use an
-explicit force-write escape hatch for Redis-compatible semantics where a
-successful write dirties `WATCH` even when no helper operation changed the final
-value, such as identical STORE rewrites or `LTRIM key 0 -1`.
+run, even if a later operation restores the same final value. Commands pass an
+explicit `forceDirty` flag for Redis-compatible semantics where a successful
+write dirties `WATCH` even when no helper operation changed the final value, such
+as identical STORE rewrites or `LTRIM key 0 -1`. Conversely, stream
+consumer-group, pending-entry, and last-id mutations (`XREADGROUP`, `XCLAIM`,
+`XAUTOCLAIM`, `XGROUP SETID`, `XSETID`) deliberately leave a `WATCH` on the
+stream key intact — matching real Redis, where only entry-set changes
+(`XADD`/`XDEL`/…) touch it.
 
 ## Concurrency model
 

--- a/src/commands/streams/groups.ts
+++ b/src/commands/streams/groups.ts
@@ -1,13 +1,18 @@
 import { RedisCommandError } from '../../core/redis-error'
 import type {
-  RedisStreamConsumer,
   RedisStreamConsumerGroup,
   RedisStreamData,
-  RedisStreamEntry,
-  RedisStreamPendingEntry,
   StreamId,
 } from '../../state/data-types'
 import { bufferId, cloneStreamId, compareStreamId, maxStreamId } from './ids'
+
+// Pure consumer-group lookups moved to the state layer (so TrackedStreamData can
+// use them); re-exported here for the streams command modules.
+export {
+  findEntry,
+  pendingEntriesSorted,
+  ensureConsumer,
+} from '../../state/stream-groups'
 
 export class BusyStreamGroupError extends RedisCommandError {
   constructor() {
@@ -32,44 +37,6 @@ export function updateMaxDeletedId(
 ): void {
   stream.maxDeletedEntryId = cloneStreamId(
     maxStreamId(stream.maxDeletedEntryId, id),
-  )
-}
-
-export function findEntry(
-  stream: RedisStreamData,
-  id: StreamId,
-): RedisStreamEntry | null {
-  return (
-    stream.entries.find(entry => compareStreamId(entry.id, id) === 0) ?? null
-  )
-}
-
-export function ensureConsumer(
-  group: RedisStreamConsumerGroup,
-  name: Buffer,
-  now: number,
-): RedisStreamConsumer {
-  const id = bufferId(name)
-  const existing = group.consumers.get(id)
-  if (existing) {
-    existing.seenAt = now
-    return existing
-  }
-
-  const consumer: RedisStreamConsumer = {
-    name: Buffer.from(name),
-    seenAt: now,
-    activeAt: null,
-  }
-  group.consumers.set(id, consumer)
-  return consumer
-}
-
-export function pendingEntriesSorted(
-  group: RedisStreamConsumerGroup,
-): RedisStreamPendingEntry[] {
-  return Array.from(group.pending.values()).sort((a, b) =>
-    compareStreamId(a.id, b.id),
   )
 }
 

--- a/src/commands/streams/ids.ts
+++ b/src/commands/streams/ids.ts
@@ -3,35 +3,24 @@ import {
   InvalidStreamIdError,
 } from '../../core/redis-error'
 import type { StreamId } from '../../state/data-types'
+import { MIN_ID } from '../../state/stream-ids'
+
+// StreamId arithmetic now lives in the state layer; re-export it here so the
+// streams command modules keep importing it from a single place.
+export {
+  MIN_ID,
+  formatStreamId,
+  streamIdKey,
+  compareStreamId,
+  cloneStreamId,
+  maxStreamId,
+} from '../../state/stream-ids'
 
 export const MAX_UINT64 = (1n << 64n) - 1n
-export const MIN_ID: StreamId = { ms: 0n, seq: 0n }
 export const MAX_ID: StreamId = { ms: MAX_UINT64, seq: MAX_UINT64 }
-
-export function formatStreamId(id: StreamId): string {
-  return `${id.ms}-${id.seq}`
-}
-
-export function streamIdKey(id: StreamId): string {
-  return formatStreamId(id)
-}
 
 export function bufferId(value: Buffer): string {
   return value.toString('hex')
-}
-
-export function compareStreamId(a: StreamId, b: StreamId): number {
-  if (a.ms !== b.ms) return a.ms < b.ms ? -1 : 1
-  if (a.seq !== b.seq) return a.seq < b.seq ? -1 : 1
-  return 0
-}
-
-export function cloneStreamId(id: StreamId): StreamId {
-  return { ms: id.ms, seq: id.seq }
-}
-
-export function maxStreamId(a: StreamId, b: StreamId): StreamId {
-  return compareStreamId(a, b) >= 0 ? a : b
 }
 
 export function parseUint64(token: string): bigint | null {

--- a/src/commands/streams/xautoclaim.ts
+++ b/src/commands/streams/xautoclaim.ts
@@ -7,21 +7,8 @@ import {
 import { RedisValue } from '../../core/redis-value'
 import type { StreamId } from '../../state/data-types'
 import { array } from '../helpers'
-import {
-  ensureConsumer,
-  findEntry,
-  pendingEntriesSorted,
-  requireStreamGroup,
-} from './groups'
-import {
-  bufferId,
-  cloneStreamId,
-  compareStreamId,
-  MIN_ID,
-  parseExactId,
-  parseNonNegativeInteger,
-  streamIdKey,
-} from './ids'
+import { requireStreamGroup } from './groups'
+import { parseExactId, parseNonNegativeInteger } from './ids'
 import { entryToReply, streamIdValue } from './replies'
 
 type XautoclaimArgs = {
@@ -98,53 +85,31 @@ export const xautoclaimCommand = defineCommand({
       command.group,
     )
     const result = ctx.db.updateStream(command.key, stream => {
-      const value = stream.value
-      const group = requireStreamGroup(value, command.key, command.group)
-      ensureConsumer(group, command.consumer, now).activeAt = now
-      const consumerId = bufferId(command.consumer)
-      const claimed: RedisValue[] = []
-      const deleted: RedisValue[] = []
-      let nextStartId: StreamId = MIN_ID
-
-      for (const pending of pendingEntriesSorted(group)) {
-        if (compareStreamId(pending.id, command.start) < 0) continue
-
-        const entry = findEntry(value, pending.id)
-        if (!entry) {
-          group.pending.delete(streamIdKey(pending.id))
-          deleted.push(streamIdValue(pending.id))
-          continue
-        }
-
-        const idleTime = Math.max(0, now - pending.deliveredAt)
-        if (idleTime < command.minIdleMs) continue
-
-        pending.consumerId = consumerId
-        pending.deliveredAt = now
-        if (!command.justId) pending.deliveryCount++
-        claimed.push(
-          command.justId
-            ? streamIdValue(entry.id)
-            : entryToReply(entry.id, entry.fields),
-        )
-
-        if (claimed.length >= command.count) {
-          const next = pendingEntriesSorted(group).find(
-            item => compareStreamId(item.id, pending.id) > 0,
-          )
-          nextStartId = next ? cloneStreamId(next.id) : MIN_ID
-          break
-        }
-      }
-
-      stream.forceWrite()
-      return { nextStartId, claimed, deleted }
+      const group = requireStreamGroup(stream.value, command.key, command.group)
+      return stream.autoClaim(
+        group,
+        command.consumer,
+        {
+          minIdleMs: command.minIdleMs,
+          start: command.start,
+          count: command.count,
+          justId: command.justId,
+        },
+        now,
+      )
     })
+
+    const claimed = result.claimed.map(entry =>
+      command.justId
+        ? streamIdValue(entry.id)
+        : entryToReply(entry.id, entry.fields),
+    )
+    const deleted = result.deleted.map(id => streamIdValue(id))
 
     return array([
       streamIdValue(result.nextStartId),
-      RedisValue.array(result.claimed),
-      RedisValue.array(result.deleted),
+      RedisValue.array(claimed),
+      RedisValue.array(deleted),
     ])
   },
 })

--- a/src/commands/streams/xclaim.ts
+++ b/src/commands/streams/xclaim.ts
@@ -4,17 +4,10 @@ import {
   RedisSyntaxError,
   WrongNumberOfArgumentsError,
 } from '../../core/redis-error'
-import { RedisValue } from '../../core/redis-value'
 import type { StreamId } from '../../state/data-types'
 import { array } from '../helpers'
-import { ensureConsumer, findEntry, requireStreamGroup } from './groups'
-import {
-  bufferId,
-  cloneStreamId,
-  parseExactId,
-  parseNonNegativeInteger,
-  streamIdKey,
-} from './ids'
+import { requireStreamGroup } from './groups'
+import { parseExactId, parseNonNegativeInteger } from './ids'
 import { entryToReply, streamIdValue } from './replies'
 
 type XclaimArgs = {
@@ -140,57 +133,29 @@ export const xclaimCommand = defineCommand({
       command.group,
     )
     const claimed = ctx.db.updateStream(command.key, stream => {
-      const value = stream.value
-      const group = requireStreamGroup(value, command.key, command.group)
-      ensureConsumer(group, command.consumer, now).activeAt = now
-      const consumerId = bufferId(command.consumer)
-      if (command.lastId) group.lastDeliveredId = cloneStreamId(command.lastId)
-
-      const replies: RedisValue[] = []
-      for (const id of command.ids) {
-        const pendingId = streamIdKey(id)
-        const entry = findEntry(value, id)
-        let pending = group.pending.get(pendingId)
-
-        if (!pending && command.force && entry) {
-          pending = {
-            id: cloneStreamId(id),
-            consumerId,
-            deliveredAt: now,
-            deliveryCount: 0,
-          }
-          group.pending.set(pendingId, pending)
-        }
-
-        if (!pending) continue
-        if (!entry) {
-          group.pending.delete(pendingId)
-          continue
-        }
-
-        const idleTime = Math.max(0, now - pending.deliveredAt)
-        if (idleTime < command.minIdleMs) continue
-
-        pending.consumerId = consumerId
-        pending.deliveredAt =
-          command.timeMs ??
-          (command.idleMs !== null ? now - command.idleMs : now)
-        if (command.retryCount !== null) {
-          pending.deliveryCount = command.retryCount
-        } else if (!command.justId) {
-          pending.deliveryCount++
-        }
-
-        replies.push(
-          command.justId
-            ? streamIdValue(entry.id)
-            : entryToReply(entry.id, entry.fields),
-        )
-      }
-      stream.forceWrite()
-      return replies
+      const group = requireStreamGroup(stream.value, command.key, command.group)
+      return stream.claim(
+        group,
+        command.consumer,
+        command.ids,
+        {
+          minIdleMs: command.minIdleMs,
+          idleMs: command.idleMs,
+          timeMs: command.timeMs,
+          retryCount: command.retryCount,
+          force: command.force,
+          justId: command.justId,
+          lastId: command.lastId,
+        },
+        now,
+      )
     })
 
-    return array(claimed)
+    const replies = claimed.map(entry =>
+      command.justId
+        ? streamIdValue(entry.id)
+        : entryToReply(entry.id, entry.fields),
+    )
+    return array(replies)
   },
 })

--- a/src/commands/streams/xgroup.ts
+++ b/src/commands/streams/xgroup.ts
@@ -188,12 +188,8 @@ export const xgroupCommand = defineCommand({
           command.key,
           command.group,
         )
-        group.lastDeliveredId =
-          command.id === '$'
-            ? cloneStreamId(stream.lastId)
-            : cloneStreamId(command.id)
-        group.entriesRead = command.entriesRead
-        stream.forceWrite()
+        const lastDeliveredId = command.id === '$' ? stream.lastId : command.id
+        stream.setGroupId(group, lastDeliveredId, command.entriesRead)
       })
       return ok()
     }

--- a/src/commands/streams/xreadgroup.ts
+++ b/src/commands/streams/xreadgroup.ts
@@ -6,20 +6,8 @@ import { RedisResult } from '../../core/redis-result'
 import { RedisValue } from '../../core/redis-value'
 import type { StreamId } from '../../state/data-types'
 import { bulk } from '../helpers'
-import {
-  ensureConsumer,
-  pendingEntriesSorted,
-  requireStreamGroup,
-  findEntry,
-} from './groups'
-import {
-  bufferId,
-  cloneStreamId,
-  compareStreamId,
-  parseExactId,
-  parseNonNegativeInteger,
-  streamIdKey,
-} from './ids'
+import { requireStreamGroup } from './groups'
+import { parseExactId, parseNonNegativeInteger } from './ids'
 import { bulkString, deletedEntryToReply, entryToReply } from './replies'
 
 type XreadGroupStream = { key: Buffer; id: StreamId | '>' }
@@ -122,53 +110,21 @@ function readGroupEntries(
   }
 
   for (const { key, id } of streams) {
-    const entries = ctx.db.updateStream(key, stream => {
-      const value = stream.value
-      const group = requireStreamGroup(value, key, groupName, 'XREADGROUP')
-      const consumer = ensureConsumer(group, consumerName, now)
-      consumer.activeAt = now
-
-      const consumerId = bufferId(consumerName)
-      const replies: RedisValue[] = []
-
-      if (id === '>') {
-        for (const entry of value.entries) {
-          if (compareStreamId(entry.id, group.lastDeliveredId) <= 0) continue
-
-          replies.push(entryToReply(entry.id, entry.fields))
-          group.lastDeliveredId = cloneStreamId(entry.id)
-          group.entriesRead = (group.entriesRead ?? 0) + 1
-
-          if (!noack) {
-            group.pending.set(streamIdKey(entry.id), {
-              id: cloneStreamId(entry.id),
-              consumerId,
-              deliveredAt: now,
-              deliveryCount: 1,
-            })
-          }
-
-          if (count !== null && count > 0 && replies.length >= count) break
-        }
-      } else {
-        for (const pending of pendingEntriesSorted(group)) {
-          if (pending.consumerId !== consumerId) continue
-          if (compareStreamId(pending.id, id) <= 0) continue
-
-          const entry = findEntry(value, pending.id)
-          replies.push(
-            entry
-              ? entryToReply(entry.id, entry.fields)
-              : deletedEntryToReply(pending.id),
-          )
-
-          if (count !== null && count > 0 && replies.length >= count) break
-        }
-      }
-
-      stream.forceWrite()
-      return replies
+    const delivered = ctx.db.updateStream(key, stream => {
+      const group = requireStreamGroup(
+        stream.value,
+        key,
+        groupName,
+        'XREADGROUP',
+      )
+      return stream.readGroup(group, consumerName, id, { count, noack }, now)
     })
+
+    const entries = delivered.map(item =>
+      item.fields === null
+        ? deletedEntryToReply(item.id)
+        : entryToReply(item.id, item.fields),
+    )
 
     if (entries.length > 0 || id !== '>') {
       results.push([bulkString(key), RedisValue.array(entries)])

--- a/src/commands/streams/xsetid.ts
+++ b/src/commands/streams/xsetid.ts
@@ -8,12 +8,7 @@ import {
 } from '../../core/redis-error'
 import type { StreamId } from '../../state/data-types'
 import { ok } from '../helpers'
-import {
-  cloneStreamId,
-  compareStreamId,
-  parseExactId,
-  parseNonNegativeInteger,
-} from './ids'
+import { compareStreamId, parseExactId, parseNonNegativeInteger } from './ids'
 
 class XsetidSmallerThanTopError extends RedisCommandError {
   constructor() {
@@ -90,14 +85,10 @@ export const xsetidCommand = defineCommand({
     }
 
     ctx.db.updateStream(command.key, writable => {
-      writable.value.lastId = cloneStreamId(command.id)
-      if (command.entriesAdded !== null) {
-        writable.value.entriesAdded = command.entriesAdded
-      }
-      if (command.maxDeletedId !== null) {
-        writable.value.maxDeletedEntryId = cloneStreamId(command.maxDeletedId)
-      }
-      writable.forceWrite()
+      writable.setId(command.id, {
+        entriesAdded: command.entriesAdded,
+        maxDeletedId: command.maxDeletedId,
+      })
     })
 
     return ok()

--- a/src/state/stream-groups.ts
+++ b/src/state/stream-groups.ts
@@ -1,0 +1,50 @@
+import type {
+  RedisStreamConsumer,
+  RedisStreamConsumerGroup,
+  RedisStreamData,
+  RedisStreamEntry,
+  RedisStreamPendingEntry,
+  StreamId,
+} from './data-types'
+import { compareStreamId } from './stream-ids'
+
+// Pure consumer-group lookups. State-layer so TrackedStreamData can reach them;
+// the command-layer groups module re-exports them.
+
+export function findEntry(
+  stream: RedisStreamData,
+  id: StreamId,
+): RedisStreamEntry | null {
+  return (
+    stream.entries.find(entry => compareStreamId(entry.id, id) === 0) ?? null
+  )
+}
+
+export function pendingEntriesSorted(
+  group: RedisStreamConsumerGroup,
+): RedisStreamPendingEntry[] {
+  return Array.from(group.pending.values()).sort((a, b) =>
+    compareStreamId(a.id, b.id),
+  )
+}
+
+export function ensureConsumer(
+  group: RedisStreamConsumerGroup,
+  name: Buffer,
+  now: number,
+): RedisStreamConsumer {
+  const id = name.toString('hex')
+  const existing = group.consumers.get(id)
+  if (existing) {
+    existing.seenAt = now
+    return existing
+  }
+
+  const consumer: RedisStreamConsumer = {
+    name: Buffer.from(name),
+    seenAt: now,
+    activeAt: null,
+  }
+  group.consumers.set(id, consumer)
+  return consumer
+}

--- a/src/state/stream-ids.ts
+++ b/src/state/stream-ids.ts
@@ -1,0 +1,29 @@
+import type { StreamId } from './data-types'
+
+// Pure StreamId arithmetic. Lives in the state layer (next to the StreamId type)
+// so state-layer code such as TrackedStreamData can use it without importing from
+// the command layer. The command-layer ids module re-exports these.
+
+export const MIN_ID: StreamId = { ms: 0n, seq: 0n }
+
+export function formatStreamId(id: StreamId): string {
+  return `${id.ms}-${id.seq}`
+}
+
+export function streamIdKey(id: StreamId): string {
+  return formatStreamId(id)
+}
+
+export function compareStreamId(a: StreamId, b: StreamId): number {
+  if (a.ms !== b.ms) return a.ms < b.ms ? -1 : 1
+  if (a.seq !== b.seq) return a.seq < b.seq ? -1 : 1
+  return 0
+}
+
+export function cloneStreamId(id: StreamId): StreamId {
+  return { ms: id.ms, seq: id.seq }
+}
+
+export function maxStreamId(a: StreamId, b: StreamId): StreamId {
+  return compareStreamId(a, b) >= 0 ? a : b
+}

--- a/src/state/tracked-values.ts
+++ b/src/state/tracked-values.ts
@@ -12,12 +12,25 @@ import type {
   StreamId,
 } from './data-types'
 import type { KeyspaceMutationTracker } from './keyspace'
+import {
+  ensureConsumer,
+  findEntry,
+  pendingEntriesSorted,
+} from './stream-groups'
+import {
+  cloneStreamId,
+  compareStreamId,
+  MIN_ID,
+  streamIdKey,
+} from './stream-ids'
 
 // Dirty tracking is operation-based, not a final-value diff. An effective
 // mutating helper marks the key dirty when the operation changes structure, and
-// commands use forceDirty/forceWrite for Redis writes that must dirty WATCH even
-// when the final value is equal (for example identical STORE rewrites or
-// full-range LTRIM).
+// commands pass forceDirty for Redis writes that must dirty WATCH even when the
+// final value is equal (for example identical STORE rewrites or full-range
+// LTRIM). Stream consumer-group / pending / last-id mutations deliberately do
+// NOT mark the key dirty: real Redis leaves a WATCH on the stream key intact for
+// those, only entry-set changes (XADD/XDEL/…) touch it.
 
 export class TrackedHashData {
   constructor(
@@ -401,6 +414,16 @@ export class TrackedSortedSetData {
   }
 }
 
+// XREADGROUP delivery: a present entry carries its fields; a history read of an
+// entry that has since been deleted carries fields === null.
+export type StreamDelivery = { id: StreamId; fields: Buffer[] | null }
+export type ClaimedEntry = { id: StreamId; fields: Buffer[] }
+export type AutoClaimResult = {
+  nextStartId: StreamId
+  claimed: ClaimedEntry[]
+  deleted: StreamId[]
+}
+
 export class TrackedStreamData {
   constructor(
     private readonly stream: RedisStreamData,
@@ -464,8 +487,197 @@ export class TrackedStreamData {
     return count
   }
 
-  forceWrite(): void {
-    this.tracker.markChanged()
+  // XSETID. The stream already exists (the command rejects a missing key), so
+  // mutating the live value in place is enough to persist; real Redis does not
+  // touch a WATCH on the stream key for a last-id change, so no markChanged().
+  setId(
+    id: StreamId,
+    options: { entriesAdded: number | null; maxDeletedId: StreamId | null },
+  ): void {
+    this.stream.lastId = cloneStreamId(id)
+    if (options.entriesAdded !== null) {
+      this.stream.entriesAdded = options.entriesAdded
+    }
+    if (options.maxDeletedId !== null) {
+      this.stream.maxDeletedEntryId = cloneStreamId(options.maxDeletedId)
+    }
+  }
+
+  // XGROUP SETID. Consumer-group metadata changes do not dirty a WATCH on the
+  // stream key in real Redis, so this never calls markChanged().
+  setGroupId(
+    group: RedisStreamConsumerGroup,
+    lastDeliveredId: StreamId,
+    entriesRead: number | null,
+  ): void {
+    group.lastDeliveredId = cloneStreamId(lastDeliveredId)
+    group.entriesRead = entriesRead
+  }
+
+  // XREADGROUP for a single stream. Returns the delivered entries (fields === null
+  // marks a history entry that was deleted from the stream) for the command to
+  // shape into a reply. Delivering messages / advancing the PEL does not dirty a
+  // WATCH on the stream key in real Redis.
+  readGroup(
+    group: RedisStreamConsumerGroup,
+    consumerName: Buffer,
+    id: StreamId | '>',
+    options: { count: number | null; noack: boolean },
+    now: number,
+  ): StreamDelivery[] {
+    ensureConsumer(group, consumerName, now).activeAt = now
+    const consumerId = consumerName.toString('hex')
+    const { count, noack } = options
+    const delivered: StreamDelivery[] = []
+    const limited = count !== null && count > 0
+
+    if (id === '>') {
+      for (const entry of this.stream.entries) {
+        if (compareStreamId(entry.id, group.lastDeliveredId) <= 0) continue
+
+        delivered.push({ id: entry.id, fields: entry.fields })
+        group.lastDeliveredId = cloneStreamId(entry.id)
+        group.entriesRead = (group.entriesRead ?? 0) + 1
+
+        if (!noack) {
+          group.pending.set(streamIdKey(entry.id), {
+            id: cloneStreamId(entry.id),
+            consumerId,
+            deliveredAt: now,
+            deliveryCount: 1,
+          })
+        }
+
+        if (limited && delivered.length >= count) break
+      }
+      return delivered
+    }
+
+    for (const pending of pendingEntriesSorted(group)) {
+      if (pending.consumerId !== consumerId) continue
+      if (compareStreamId(pending.id, id) <= 0) continue
+
+      const entry = findEntry(this.stream, pending.id)
+      delivered.push(
+        entry
+          ? { id: entry.id, fields: entry.fields }
+          : { id: pending.id, fields: null },
+      )
+
+      if (limited && delivered.length >= count) break
+    }
+    return delivered
+  }
+
+  // XCLAIM. Returns the claimed entries for the command to shape into a reply
+  // (justId vs full). Reassigning pending ownership does not dirty a WATCH on the
+  // stream key in real Redis.
+  claim(
+    group: RedisStreamConsumerGroup,
+    consumerName: Buffer,
+    ids: readonly StreamId[],
+    options: {
+      minIdleMs: number
+      idleMs: number | null
+      timeMs: number | null
+      retryCount: number | null
+      force: boolean
+      justId: boolean
+      lastId: StreamId | null
+    },
+    now: number,
+  ): ClaimedEntry[] {
+    ensureConsumer(group, consumerName, now).activeAt = now
+    const consumerId = consumerName.toString('hex')
+    if (options.lastId) group.lastDeliveredId = cloneStreamId(options.lastId)
+
+    const claimed: ClaimedEntry[] = []
+    for (const id of ids) {
+      const pendingId = streamIdKey(id)
+      const entry = findEntry(this.stream, id)
+      let pending = group.pending.get(pendingId)
+
+      if (!pending && options.force && entry) {
+        pending = {
+          id: cloneStreamId(id),
+          consumerId,
+          deliveredAt: now,
+          deliveryCount: 0,
+        }
+        group.pending.set(pendingId, pending)
+      }
+
+      if (!pending) continue
+      if (!entry) {
+        group.pending.delete(pendingId)
+        continue
+      }
+
+      const idleTime = Math.max(0, now - pending.deliveredAt)
+      if (idleTime < options.minIdleMs) continue
+
+      pending.consumerId = consumerId
+      pending.deliveredAt =
+        options.timeMs ?? (options.idleMs !== null ? now - options.idleMs : now)
+      if (options.retryCount !== null) {
+        pending.deliveryCount = options.retryCount
+      } else if (!options.justId) {
+        pending.deliveryCount++
+      }
+
+      claimed.push({ id: entry.id, fields: entry.fields })
+    }
+    return claimed
+  }
+
+  // XAUTOCLAIM. Returns the next cursor, the claimed entries, and the ids of
+  // pending entries dropped because their stream entry was gone. Does not dirty a
+  // WATCH on the stream key in real Redis.
+  autoClaim(
+    group: RedisStreamConsumerGroup,
+    consumerName: Buffer,
+    options: {
+      minIdleMs: number
+      start: StreamId
+      count: number
+      justId: boolean
+    },
+    now: number,
+  ): AutoClaimResult {
+    ensureConsumer(group, consumerName, now).activeAt = now
+    const consumerId = consumerName.toString('hex')
+    const claimed: ClaimedEntry[] = []
+    const deleted: StreamId[] = []
+    let nextStartId: StreamId = MIN_ID
+
+    for (const pending of pendingEntriesSorted(group)) {
+      if (compareStreamId(pending.id, options.start) < 0) continue
+
+      const entry = findEntry(this.stream, pending.id)
+      if (!entry) {
+        group.pending.delete(streamIdKey(pending.id))
+        deleted.push(pending.id)
+        continue
+      }
+
+      const idleTime = Math.max(0, now - pending.deliveredAt)
+      if (idleTime < options.minIdleMs) continue
+
+      pending.consumerId = consumerId
+      pending.deliveredAt = now
+      if (!options.justId) pending.deliveryCount++
+      claimed.push({ id: entry.id, fields: entry.fields })
+
+      if (claimed.length >= options.count) {
+        const next = pendingEntriesSorted(group).find(
+          item => compareStreamId(item.id, pending.id) > 0,
+        )
+        nextStartId = next ? cloneStreamId(next.id) : MIN_ID
+        break
+      }
+    }
+
+    return { nextStartId, claimed, deleted }
   }
 
   addGroup(groupId: string, group: RedisStreamConsumerGroup): void {
@@ -509,8 +721,4 @@ export class TrackedStreamData {
     this.tracker.markChanged()
     return removedPending
   }
-}
-
-function streamIdKey(id: StreamId): string {
-  return `${id.ms}-${id.seq}`
 }

--- a/tests-integration/ioredis/stream-watch.test.ts
+++ b/tests-integration/ioredis/stream-watch.test.ts
@@ -1,0 +1,176 @@
+import { Cluster, Redis } from 'ioredis'
+import { after, before, describe, test } from 'node:test'
+import assert from 'node:assert'
+import { TestRunner } from '../test-config'
+import { connectToSlotOwner, randomKey } from '../utils'
+
+const testRunner = new TestRunner()
+
+// Real Redis does NOT invalidate a WATCH on a stream key for consumer-group /
+// pending-entry / last-id metadata changes. Only changes to the stream's entry
+// set (XADD, XDEL, ...) touch the watched key. These tests pin that behavior so
+// the tracked-stream helpers never re-introduce the spurious WATCH dirtying that
+// the old unconditional forceWrite() produced.
+describe('Stream metadata WATCH semantics', () => {
+  let redisClient: Cluster | undefined
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster('stream-watch')
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  type Case = {
+    name: string
+    initialize(client: Redis, key: string): Promise<unknown>
+    mutate(client: Redis, key: string): Promise<unknown>
+  }
+
+  // Every command below mutates consumer-group / pending / last-id metadata but
+  // must leave the WATCH intact (the queued SET still runs -> EXEC === ['OK']).
+  const cleanCases: Case[] = [
+    {
+      name: 'XSETID to a different id',
+      initialize: (client, key) => client.call('XADD', key, '5-5', 'f', 'v'),
+      mutate: (client, key) => client.call('XSETID', key, '9-9'),
+    },
+    {
+      name: 'XGROUP SETID to a different id',
+      initialize: async (client, key) => {
+        await client.call('XADD', key, '1-1', 'f', 'v')
+        await client.call('XADD', key, '2-2', 'f', 'v')
+        await client.call('XGROUP', 'CREATE', key, 'g', '0')
+      },
+      mutate: (client, key) => client.call('XGROUP', 'SETID', key, 'g', '2'),
+    },
+    {
+      name: 'XREADGROUP > delivering new entries',
+      initialize: async (client, key) => {
+        await client.call('XADD', key, '1-1', 'f', 'v')
+        await client.call('XGROUP', 'CREATE', key, 'g', '0')
+      },
+      mutate: (client, key) =>
+        client.call(
+          'XREADGROUP',
+          'GROUP',
+          'g',
+          'c',
+          'COUNT',
+          '10',
+          'STREAMS',
+          key,
+          '>',
+        ),
+    },
+    {
+      name: 'XREADGROUP history read (explicit id)',
+      initialize: async (client, key) => {
+        await client.call('XADD', key, '1-1', 'f', 'v')
+        await client.call('XGROUP', 'CREATE', key, 'g', '0')
+        await client.call('XREADGROUP', 'GROUP', 'g', 'c', 'STREAMS', key, '>')
+      },
+      mutate: (client, key) =>
+        client.call('XREADGROUP', 'GROUP', 'g', 'c', 'STREAMS', key, '0'),
+    },
+    {
+      name: 'XREADGROUP > with no new entries',
+      initialize: async (client, key) => {
+        await client.call('XADD', key, '1-1', 'f', 'v')
+        await client.call('XGROUP', 'CREATE', key, 'g', '$')
+      },
+      mutate: (client, key) =>
+        client.call('XREADGROUP', 'GROUP', 'g', 'c', 'STREAMS', key, '>'),
+    },
+    {
+      name: 'XCLAIM that claims a pending entry',
+      initialize: async (client, key) => {
+        await client.call('XADD', key, '1-1', 'f', 'v')
+        await client.call('XGROUP', 'CREATE', key, 'g', '0')
+        await client.call('XREADGROUP', 'GROUP', 'g', 'c1', 'STREAMS', key, '>')
+      },
+      mutate: (client, key) =>
+        client.call('XCLAIM', key, 'g', 'c2', '0', '1-1'),
+    },
+    {
+      name: 'XCLAIM that claims nothing',
+      initialize: async (client, key) => {
+        await client.call('XADD', key, '1-1', 'f', 'v')
+        await client.call('XGROUP', 'CREATE', key, 'g', '0')
+      },
+      mutate: (client, key) =>
+        client.call('XCLAIM', key, 'g', 'c2', '0', '9-9'),
+    },
+    {
+      name: 'XAUTOCLAIM that claims a pending entry',
+      initialize: async (client, key) => {
+        await client.call('XADD', key, '1-1', 'f', 'v')
+        await client.call('XGROUP', 'CREATE', key, 'g', '0')
+        await client.call('XREADGROUP', 'GROUP', 'g', 'c1', 'STREAMS', key, '>')
+      },
+      mutate: (client, key) =>
+        client.call('XAUTOCLAIM', key, 'g', 'c2', '0', '0'),
+    },
+    {
+      name: 'XAUTOCLAIM that claims nothing',
+      initialize: async (client, key) => {
+        await client.call('XADD', key, '1-1', 'f', 'v')
+        await client.call('XGROUP', 'CREATE', key, 'g', '0')
+      },
+      mutate: (client, key) =>
+        client.call('XAUTOCLAIM', key, 'g', 'c2', '0', '0'),
+    },
+  ]
+
+  for (const item of cleanCases) {
+    test(`${item.name} does not dirty a watched stream`, async () => {
+      const key = `stream:{watch:${randomKey()}}`
+      const directClient = await connectToSlotOwner(redisClient!, key)
+
+      try {
+        await directClient.call('DEL', key)
+        await item.initialize(directClient, key)
+
+        assert.strictEqual(await directClient.call('WATCH', key), 'OK')
+        await item.mutate(directClient, key)
+
+        assert.strictEqual(await directClient.call('MULTI'), 'OK')
+        assert.strictEqual(
+          await directClient.call('SET', key, 'after'),
+          'QUEUED',
+        )
+
+        const result = await directClient.call('EXEC')
+        assert.deepStrictEqual(result, ['OK'], item.name)
+      } finally {
+        await directClient.call('UNWATCH').catch(() => undefined)
+        await directClient.call('DEL', key).catch(() => undefined)
+        directClient.disconnect()
+      }
+    })
+  }
+
+  test('XADD still dirties a watched stream', async () => {
+    const key = `stream:{watch:${randomKey()}}`
+    const directClient = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      await directClient.call('DEL', key)
+      await directClient.call('XADD', key, '1-1', 'f', 'v')
+
+      assert.strictEqual(await directClient.call('WATCH', key), 'OK')
+      await directClient.call('XADD', key, '2-2', 'f', 'v')
+
+      assert.strictEqual(await directClient.call('MULTI'), 'OK')
+      assert.strictEqual(await directClient.call('SET', key, 'after'), 'QUEUED')
+
+      const result = await directClient.call('EXEC')
+      assert.strictEqual(result, null)
+    } finally {
+      await directClient.call('UNWATCH').catch(() => undefined)
+      await directClient.call('DEL', key).catch(() => undefined)
+      directClient.disconnect()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Encapsulates the remaining complex stream metadata mutations behind explicit `TrackedStreamData` helpers (`setId`, `setGroupId`, `readGroup`, `claim`, `autoClaim`) and removes the `forceWrite()` escape hatch from the stream command call sites — completing the tracked-wrapper design from PR #217.

### Compatibility fix (root cause)

`forceWrite()` was called **unconditionally**, so `XREADGROUP`, `XCLAIM`, `XAUTOCLAIM`, `XGROUP SETID`, and `XSETID` invalidated a `WATCH` on the stream key on **every** call. Verified against real `redis-server` 8.0.6 (`WATCH`/`MULTI`/`EXEC`, methodology validated with `SET`/`XADD`/`XDEL` controls that correctly show DIRTY):

| Command (real mutation) | Dirties `WATCH` on stream key? |
|---|---|
| `XADD` / `XDEL` | **YES** |
| `XSETID` (diff id) | **NO** |
| `XGROUP SETID` (diff id) | **NO** |
| `XREADGROUP >` (delivers entries) | **NO** |
| `XCLAIM` (actually claims) | **NO** |
| `XAUTOCLAIM` (actually claims) | **NO** |

Consumer-group / pending-entry / last-id changes do not touch a `WATCH` on the stream key in real Redis; only entry-set changes do. The new helpers mutate the live value in place (all five commands require a pre-existing stream/group, so the keyspace entry is already committed via shared reference) and never mark the key dirty.

### Refactor / layering

Pure `StreamId` arithmetic and consumer-group lookups move to the state layer (`src/state/stream-ids.ts`, `src/state/stream-groups.ts`) so `TrackedStreamData` can use them without importing from the command layer. The command-layer `ids`/`groups` modules re-export them, so every other stream command import is untouched.

Closes #218

## Test plan
- [x] New `tests-integration/ioredis/stream-watch.test.ts` reproduces the bug — 9 metadata cases were RED on mock (over-dirtied), GREEN on real Redis (proving the bug is ours)
- [x] Fix makes all 10 cases pass on mock (incl. `XADD`-still-dirties control)
- [x] No-op cases (`XCLAIM`/`XAUTOCLAIM`/`XREADGROUP >` that change nothing) also covered
- [x] `npm run build` + `npm run lint` clean
- [x] `npm run test:all` passes (unit + mock + real integration, 546 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)