### PR TITLE
fix: stop XGROUP/XACK from over-dirtying WATCH on the stream key (#274)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -361,9 +361,13 @@ explicit `forceDirty` flag for Redis-compatible semantics where a successful
 write dirties `WATCH` even when no helper operation changed the final value, such
 as identical STORE rewrites or `LTRIM key 0 -1`. Conversely, stream
 consumer-group, pending-entry, and last-id mutations (`XREADGROUP`, `XCLAIM`,
-`XAUTOCLAIM`, `XGROUP SETID`, `XSETID`) deliberately leave a `WATCH` on the
-stream key intact — matching real Redis, where only entry-set changes
-(`XADD`/`XDEL`/…) touch it.
+`XAUTOCLAIM`, `XGROUP SETID`, `XSETID`, `XACK`, `XGROUP
+CREATE`/`DESTROY`/`CREATECONSUMER`/`DELCONSUMER`) deliberately leave a `WATCH` on
+the stream key intact — matching real Redis, where only entry-set changes
+(`XADD`/`XDEL`/…) touch it. The one exception is `XGROUP CREATE ... MKSTREAM`
+when it creates the key: those helpers commit through `markCommitted()`, which
+persists the value but only dirties `WATCH` when the key is brand-new (coming
+into existence is itself a write).
 
 ## Concurrency model
 

--- a/src/state/keyspace.ts
+++ b/src/state/keyspace.ts
@@ -22,7 +22,15 @@ export type SetOptions = {
 }
 
 export type KeyspaceMutationTracker = {
+  // A WATCH-dirtying write: persists the value AND dirties a WATCH on the key.
   markChanged(): void
+  // Persist the (possibly brand-new) value without, on its own, dirtying a
+  // WATCH. Used for stream consumer-group / pending-entry metadata changes,
+  // which real Redis does not treat as touching a WATCH on the stream key. A
+  // brand-new key still dirties — coming into existence is itself a write — so
+  // `keyspace.update` only suppresses the dirty signal for in-place changes to
+  // an already-existing key.
+  markCommitted(): void
 }
 
 export class WrongRedisTypeError extends Error {
@@ -151,17 +159,21 @@ export class RedisKeyspace {
       value: createValue(),
     }
 
-    let changed = false
+    let dirty = false
+    let committed = false
     const tracker: KeyspaceMutationTracker = {
       markChanged: () => {
-        changed = true
+        dirty = true
+      },
+      markCommitted: () => {
+        committed = true
       },
     }
 
     const result = mutator(entry.value as TValue, tracker)
     const id = keyId(key)
 
-    if (!changed) {
+    if (!dirty && !committed) {
       return result
     }
 
@@ -180,7 +192,13 @@ export class RedisKeyspace {
     }
 
     this.entries.set(id, entry)
-    this.emitWrite(entry)
+    // A markChanged write always dirties WATCH. A markCommitted-only change
+    // dirties only when it creates the key (`!existing`): real Redis treats
+    // bringing a watched key into existence as a write, but leaves a WATCH
+    // intact for in-place metadata changes to an already-existing key.
+    if (dirty || !existing) {
+      this.emitWrite(entry)
+    }
     return result
   }
 

--- a/src/state/tracked-values.ts
+++ b/src/state/tracked-values.ts
@@ -476,13 +476,13 @@ export class TrackedStreamData {
     return count
   }
 
+  // XACK. Clearing pending entries mutates the live group in place (the stream
+  // key already exists), so no commit is needed; real Redis does not dirty a
+  // WATCH on the stream key for a PEL change, so no markChanged().
   ack(group: RedisStreamConsumerGroup, ids: readonly StreamId[]): number {
     let count = 0
     for (const id of ids) {
       if (group.pending.delete(streamIdKey(id))) count++
-    }
-    if (count > 0) {
-      this.tracker.markChanged()
     }
     return count
   }
@@ -680,19 +680,24 @@ export class TrackedStreamData {
     return { nextStartId, claimed, deleted }
   }
 
+  // XGROUP CREATE. Adding a group does not dirty a WATCH on an existing stream
+  // key in real Redis, but XGROUP CREATE ... MKSTREAM can create a brand-new
+  // key that still must be persisted (and, as a key creation, does dirty the
+  // WATCH). markCommitted() commits the value while letting keyspace.update
+  // decide the dirty signal based on whether the key already existed.
   addGroup(groupId: string, group: RedisStreamConsumerGroup): void {
     this.stream.groups.set(groupId, group)
-    this.tracker.markChanged()
+    this.tracker.markCommitted()
   }
 
+  // XGROUP DESTROY. In-place change to an existing stream key; real Redis does
+  // not dirty a WATCH on the stream key, so no markChanged().
   deleteGroup(groupId: string): boolean {
-    const removed = this.stream.groups.delete(groupId)
-    if (removed) {
-      this.tracker.markChanged()
-    }
-    return removed
+    return this.stream.groups.delete(groupId)
   }
 
+  // XGROUP CREATECONSUMER. In-place change to an existing stream key; real
+  // Redis does not dirty a WATCH on the stream key, so no markChanged().
   addConsumer(
     group: RedisStreamConsumerGroup,
     consumerId: string,
@@ -703,10 +708,11 @@ export class TrackedStreamData {
     }
 
     group.consumers.set(consumerId, consumer)
-    this.tracker.markChanged()
     return true
   }
 
+  // XGROUP DELCONSUMER. In-place change to an existing stream key; real Redis
+  // does not dirty a WATCH on the stream key, so no markChanged().
   deleteConsumer(group: RedisStreamConsumerGroup, consumerId: string): number {
     if (!group.consumers.delete(consumerId)) {
       return 0
@@ -718,7 +724,6 @@ export class TrackedStreamData {
       group.pending.delete(pendingId)
       removedPending++
     }
-    this.tracker.markChanged()
     return removedPending
   }
 }

--- a/tests-integration/ioredis/stream-watch.test.ts
+++ b/tests-integration/ioredis/stream-watch.test.ts
@@ -121,6 +121,47 @@ describe('Stream metadata WATCH semantics', () => {
       mutate: (client, key) =>
         client.call('XAUTOCLAIM', key, 'g', 'c2', '0', '0'),
     },
+    {
+      name: 'XACK acknowledging a pending entry',
+      initialize: async (client, key) => {
+        await client.call('XADD', key, '1-1', 'f', 'v')
+        await client.call('XGROUP', 'CREATE', key, 'g', '0')
+        await client.call('XREADGROUP', 'GROUP', 'g', 'c', 'STREAMS', key, '>')
+      },
+      mutate: (client, key) => client.call('XACK', key, 'g', '1-1'),
+    },
+    {
+      name: 'XGROUP CREATE on an existing stream',
+      initialize: (client, key) => client.call('XADD', key, '1-1', 'f', 'v'),
+      mutate: (client, key) => client.call('XGROUP', 'CREATE', key, 'g', '0'),
+    },
+    {
+      name: 'XGROUP DESTROY removing a group',
+      initialize: async (client, key) => {
+        await client.call('XADD', key, '1-1', 'f', 'v')
+        await client.call('XGROUP', 'CREATE', key, 'g', '0')
+      },
+      mutate: (client, key) => client.call('XGROUP', 'DESTROY', key, 'g'),
+    },
+    {
+      name: 'XGROUP CREATECONSUMER creating a consumer',
+      initialize: async (client, key) => {
+        await client.call('XADD', key, '1-1', 'f', 'v')
+        await client.call('XGROUP', 'CREATE', key, 'g', '0')
+      },
+      mutate: (client, key) =>
+        client.call('XGROUP', 'CREATECONSUMER', key, 'g', 'c'),
+    },
+    {
+      name: 'XGROUP DELCONSUMER removing a consumer',
+      initialize: async (client, key) => {
+        await client.call('XADD', key, '1-1', 'f', 'v')
+        await client.call('XGROUP', 'CREATE', key, 'g', '0')
+        await client.call('XGROUP', 'CREATECONSUMER', key, 'g', 'c')
+      },
+      mutate: (client, key) =>
+        client.call('XGROUP', 'DELCONSUMER', key, 'g', 'c'),
+    },
   ]
 
   for (const item of cleanCases) {
@@ -150,6 +191,33 @@ describe('Stream metadata WATCH semantics', () => {
       }
     })
   }
+
+  // Creating the watched key itself is a write, even via XGROUP CREATE MKSTREAM:
+  // real Redis dirties a WATCH on a key that comes into existence.
+  test('XGROUP CREATE MKSTREAM creating the watched key dirties it', async () => {
+    const key = `stream:{watch:${randomKey()}}`
+    const directClient = await connectToSlotOwner(redisClient!, key)
+
+    try {
+      await directClient.call('DEL', key)
+
+      assert.strictEqual(await directClient.call('WATCH', key), 'OK')
+      assert.strictEqual(
+        await directClient.call('XGROUP', 'CREATE', key, 'g', '0', 'MKSTREAM'),
+        'OK',
+      )
+
+      assert.strictEqual(await directClient.call('MULTI'), 'OK')
+      assert.strictEqual(await directClient.call('SET', key, 'after'), 'QUEUED')
+
+      const result = await directClient.call('EXEC')
+      assert.strictEqual(result, null)
+    } finally {
+      await directClient.call('UNWATCH').catch(() => undefined)
+      await directClient.call('DEL', key).catch(() => undefined)
+      directClient.disconnect()
+    }
+  })
 
   test('XADD still dirties a watched stream', async () => {
     const key = `stream:{watch:${randomKey()}}`


### PR DESCRIPTION
## Summary
- Follow-up to #218 / PR #273. The remaining stream consumer-group commands still dirtied a `WATCH` on the stream key because their tracked helpers called `markChanged()` unconditionally.
- Real `redis-server` 8.0.6: consumer-group / pending-entry changes do **not** touch a `WATCH` on the stream key — only entry-set changes (`XADD`/`XDEL`/…) do.
- `XACK`, `XGROUP DESTROY`/`CREATECONSUMER`/`DELCONSUMER` are in-place changes to an existing key — they now skip the dirty signal entirely (the live value is mutated through its shared reference).
- `XGROUP CREATE` no longer dirties an **existing** stream, but `XGROUP CREATE ... MKSTREAM` still must commit a brand-new key. `addGroup()` now routes through a new `markCommitted()` tracker method: `keyspace.update` persists the value but only emits a write (dirtying `WATCH`) when the key did not already exist.

### Note on the issue's "Fix" nuance
The issue speculated MKSTREAM should "commit without dirtying WATCH". Verified against real Redis — **creating the watched key via MKSTREAM does dirty the WATCH** (a key coming into existence is itself a write; `WATCH s; XGROUP CREATE s g 0 MKSTREAM; MULTI; SET s after; EXEC` → `(nil)`). The fix preserves that, so commit-of-new-key still dirties while in-place metadata changes stay clean.

Closes #274

## Test plan
- [x] Extended `tests-integration/ioredis/stream-watch.test.ts` with clean cases for `XACK`, `XGROUP CREATE` (existing), `DESTROY`, `CREATECONSUMER`, `DELCONSUMER` — red on mock before the fix (5 failures), green after.
- [x] Added a dirties-case asserting `XGROUP CREATE ... MKSTREAM` on the watched key aborts `EXEC` (`null`).
- [x] All 16 cases pass against **real Redis** (proves the bug was mock-only and expectations match real `redis-server`).
- [x] `npm run build`, `npm run lint`, `npm run test:all` (unit 197, mock 552, real 552) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)