### PR TITLE
ci: split integration tests into per-suite/backend jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,27 +51,29 @@ jobs:
       - name: Run unit tests
         run: npm test
 
-  integration-mock:
+  integration:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run integration tests (mock backend)
-        run: npm run test:integration:mock
-
-  integration-real:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: raw-mock
+            script: test:integration:raw:mock
+          - name: raw-real
+            script: test:integration:raw:real
+            needsRedis: true
+          - name: ioredis-mock
+            script: test:integration:mock:ioredis
+          - name: ioredis-real
+            script: test:integration:real:ioredis
+            needsRedis: true
+          - name: node-redis-mock
+            script: test:integration:mock:node-redis
+          - name: node-redis-real
+            script: test:integration:real:node-redis
+            needsRedis: true
 
     steps:
       - name: Checkout repository
@@ -87,17 +89,19 @@ jobs:
         run: npm ci
 
       - name: Start Redis (cluster + standalone)
+        if: matrix.needsRedis
         run: docker compose -f docker-compose.test.yml up -d --wait
 
-      - name: Run integration tests (real backend)
+      - name: Run integration tests (${{ matrix.name }})
         env:
           # Points the harness at the standalone service for SELECT/multi-DB
           # tests that cluster mode cannot serve (see test-config.ts).
+          # Ignored by the mock backend.
           REDIS_STANDALONE_PORT: 6399
           # Password-protected standalone for AUTH/NOAUTH enforcement tests.
           REDIS_STANDALONE_AUTH_PORT: 6400
-        run: npm run test:integration:real
+        run: npm run ${{ matrix.script }}
 
       - name: Stop Redis (cluster + standalone)
-        if: always()
+        if: always() && matrix.needsRedis
         run: docker compose -f docker-compose.test.yml down -v


### PR DESCRIPTION
## What

Replace the two combined integration CI jobs (`integration-mock` running all suites, `integration-real` running all suites) with a **6-way matrix** so each client suite runs separately per backend:

| Job | Script | Docker Redis |
|---|---|---|
| `raw-mock` | `test:integration:raw:mock` | no |
| `raw-real` | `test:integration:raw:real` | yes |
| `ioredis-mock` | `test:integration:mock:ioredis` | no |
| `ioredis-real` | `test:integration:real:ioredis` | yes |
| `node-redis-mock` | `test:integration:mock:node-redis` | no |
| `node-redis-real` | `test:integration:real:node-redis` | yes |

## Why

- **Isolated failures** — `fail-fast: false`, so one suite breaking doesn't cancel the rest; the CI matrix shows exactly which suite/backend failed.
- **Faster feedback** — the six jobs run in parallel instead of two serial all-suite runs.
- **Cheaper mock jobs** — only the real backends spin up the docker cluster/standalone (gated on `matrix.needsRedis`); mock jobs skip it.

`lint` and `unit` jobs are unchanged. Real env vars (`REDIS_STANDALONE_PORT`/`REDIS_STANDALONE_AUTH_PORT`) live on the run step and are ignored by the mock backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)