### PR TITLE
feat(transports): socketless connection layer (case #3 — in-process MOVED following)

### DIFF
--- a/src/client-mocks/node-registry.ts
+++ b/src/client-mocks/node-registry.ts
@@ -1,0 +1,47 @@
+import type { CommandExecutor } from '../core/command-executor'
+import type { RedisClusterNodeRole, RedisServerState } from '../state'
+
+/**
+ * The in-memory pipeline behind one synthetic `host:port`: the node's keyspace
+ * state, its command executor (cluster-aware for cluster nodes), and its role.
+ */
+export type NodePipeline = {
+  state: RedisServerState
+  executor: CommandExecutor
+  nodeRole?: RedisClusterNodeRole
+}
+
+export type RegisteredNode = NodePipeline & {
+  host: string
+  port: number
+}
+
+/**
+ * Maps a synthetic `host:port` to its in-memory {@link NodePipeline} so a client
+ * library's per-node connections resolve to the right state/executor without any
+ * TCP socket. A standalone mock registers a single entry; a cluster mock
+ * registers one entry per node (the synthetic ports advertised by CLUSTER SLOTS).
+ */
+export class InMemoryNodeRegistry {
+  private readonly nodesByAddress = new Map<string, RegisteredNode>()
+
+  register(host: string, port: number, pipeline: NodePipeline): void {
+    this.nodesByAddress.set(addressKey(host, port), {
+      ...pipeline,
+      host,
+      port,
+    })
+  }
+
+  resolve(host: string, port: number): NodePipeline | undefined {
+    return this.nodesByAddress.get(addressKey(host, port))
+  }
+
+  nodes(): readonly RegisteredNode[] {
+    return [...this.nodesByAddress.values()]
+  }
+}
+
+function addressKey(host: string, port: number): string {
+  return `${host}:${port}`
+}

--- a/src/core/transports/attach-session.ts
+++ b/src/core/transports/attach-session.ts
@@ -1,0 +1,64 @@
+import { ClientSession } from '../client-session'
+import type { CommandExecutor } from '../command-executor'
+import type { RespEncodeOptions } from '../resp-encoder'
+import type { Logger } from '../../logger'
+import type { RedisClusterNodeRole, RedisServerState } from '../../state'
+import type { ConnectionTransport } from './connection-transport'
+import { Resp2SessionAdapter } from './resp2/session-adapter'
+
+export type AttachSessionOptions = {
+  state: RedisServerState
+  executor: CommandExecutor
+  nodeRole?: RedisClusterNodeRole
+  logger?: Pick<Logger, 'error'>
+  encoder?: RespEncodeOptions
+  clientAddress?: string
+}
+
+export type AttachedSession = {
+  session: ClientSession
+  adapter: Resp2SessionAdapter
+  /** Resolves once the adapter's read/write loop finishes (transport closed). */
+  done: Promise<void>
+  /** Tear down the transport (which aborts the adapter and closes the session). */
+  close(): void
+}
+
+/**
+ * Wire a {@link ConnectionTransport} to a fresh {@link ClientSession} driven by
+ * a {@link Resp2SessionAdapter}, kicking off the adapter's run loop.
+ *
+ * This is the transport-agnostic core extracted from `Resp2Server.handleConnection`:
+ * the socket-backed server and the in-memory virtual connection share it, so the
+ * RESP framing / session lifecycle never diverges between them. The returned
+ * `done` promise settles when the adapter loop ends; `close()` closes the
+ * transport, which aborts the adapter and (via the adapter's `finally`) the
+ * session.
+ */
+export function attachSession(
+  transport: ConnectionTransport,
+  opts: AttachSessionOptions,
+): AttachedSession {
+  const session = new ClientSession({
+    server: opts.state,
+    executor: opts.executor,
+    nodeRole: opts.nodeRole,
+    clientAddress: opts.clientAddress,
+  })
+
+  const adapter = new Resp2SessionAdapter({
+    transport,
+    session,
+    logger: opts.logger,
+    encoder: opts.encoder,
+  })
+
+  const done = adapter.run().catch(err => opts.logger?.error(err))
+
+  return {
+    session,
+    adapter,
+    done,
+    close: () => transport.close('attach-session closed'),
+  }
+}

--- a/src/core/transports/resp2/server.ts
+++ b/src/core/transports/resp2/server.ts
@@ -1,10 +1,10 @@
 import { AddressInfo, Server, Socket, createServer } from 'net'
-import { ClientSession } from '../../client-session'
 import type { CommandExecutor } from '../../command-executor'
 import type { Logger } from '../../../logger'
 import type { RedisClusterNodeRole, RedisServerState } from '../../../state'
 import type { RespEncodeOptions } from '../../resp-encoder'
 import { formatHostPort, formatSocketAddressParts } from '../../network-address'
+import { attachSession } from '../attach-session'
 import { SocketConnectionTransport } from '../socket-connection-transport'
 import { Resp2SessionAdapter } from './session-adapter'
 
@@ -87,26 +87,19 @@ export class Resp2Server {
 
   private handleConnection(socket: Socket) {
     const transport = new SocketConnectionTransport(socket)
-    const session = new ClientSession({
-      server: this.state,
+    const { adapter, done } = attachSession(transport, {
+      state: this.state,
       executor: this.executor,
       nodeRole: this.nodeRole,
+      logger: this.logger,
+      encoder: this.encoder,
       clientAddress: formatSocketAddressParts(
         socket.remoteAddress,
         socket.remotePort,
       ),
     })
-    const adapter = new Resp2SessionAdapter({
-      transport,
-      session,
-      logger: this.logger,
-      encoder: this.encoder,
-    })
 
     this.adapters.add(adapter)
-    adapter
-      .run()
-      .catch(err => this.logger?.error(err))
-      .finally(() => this.adapters.delete(adapter))
+    void done.finally(() => this.adapters.delete(adapter))
   }
 }

--- a/src/core/transports/virtual-connection.ts
+++ b/src/core/transports/virtual-connection.ts
@@ -3,6 +3,7 @@ import type { CommandExecutor } from '../command-executor'
 import type { RespEncodeOptions } from '../resp-encoder'
 import type { Logger } from '../../logger'
 import type { RedisClusterNodeRole, RedisServerState } from '../../state'
+import { formatSocketAddressParts } from '../network-address'
 import { attachSession } from './attach-session'
 import {
   type ConnectionTransport,
@@ -98,8 +99,12 @@ export class VirtualClientSocket extends Duplex {
     encoding: BufferEncoding,
     callback: (error?: Error | null) => void,
   ): void {
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding)
-    this.onClientWrite?.(Buffer.from(buffer))
+    // Defensive copy of caller-owned Buffer input; the string branch already
+    // allocates a fresh Buffer, so it needs no second copy.
+    const owned = Buffer.isBuffer(chunk)
+      ? Buffer.from(chunk)
+      : Buffer.from(chunk, encoding)
+    this.onClientWrite?.(owned)
     callback()
   }
 
@@ -166,6 +171,9 @@ class DuplexConnectionTransport implements ConnectionTransport {
 
   /** Feed a chunk the client wrote into the server-side read loop. */
   feed(chunk: Buffer): void {
+    // Deliberate divergence from InMemoryConnectionTransport.feed (a strict test
+    // harness that throws on a closed transport): a real socket silently drops
+    // writes after close, and this transport models a socket — so drop, not throw.
     if (this.inputEnded || this.closed) {
       return
     }
@@ -301,9 +309,10 @@ export function createVirtualConnection(
     nodeRole: opts.nodeRole,
     logger: opts.logger,
     encoder: opts.encoder,
-    clientAddress: `${opts.remoteAddress ?? '127.0.0.1'}:${
-      opts.remotePort ?? 6379
-    }`,
+    clientAddress: formatSocketAddressParts(
+      opts.remoteAddress ?? '127.0.0.1',
+      opts.remotePort ?? 6379,
+    ),
   })
 
   return {

--- a/src/core/transports/virtual-connection.ts
+++ b/src/core/transports/virtual-connection.ts
@@ -1,0 +1,314 @@
+import { Duplex } from 'node:stream'
+import type { CommandExecutor } from '../command-executor'
+import type { RespEncodeOptions } from '../resp-encoder'
+import type { Logger } from '../../logger'
+import type { RedisClusterNodeRole, RedisServerState } from '../../state'
+import { attachSession } from './attach-session'
+import {
+  type ConnectionTransport,
+  type ConnectionTransportEvent,
+  type ConnectionTransportListener,
+  type ConnectionTransportUnsubscribe,
+} from './connection-transport'
+
+export type CreateVirtualConnectionOptions = {
+  state: RedisServerState
+  executor: CommandExecutor
+  nodeRole?: RedisClusterNodeRole
+  logger?: Pick<Logger, 'error'>
+  encoder?: RespEncodeOptions
+  /** Synthetic remote address reported to the client lib. Default 127.0.0.1. */
+  remoteAddress?: string
+  /** Synthetic remote port reported to the client lib. Default 6379. */
+  remotePort?: number
+}
+
+export type VirtualConnection = {
+  /** The fake `net.Socket`-shaped stream handed to the client library. */
+  clientSocket: VirtualClientSocket
+  /** Resolves once the server-side adapter loop ends and the session is closed. */
+  done: Promise<void>
+  /** Tear down both ends of the wire and the server-side session. */
+  close(): void
+}
+
+/**
+ * A `net.Socket`-compatible {@link Duplex} handed to a client library (ioredis)
+ * as its connection stream. Only the surface the client touches is implemented:
+ * duplex read/write, the no-op socket tuning methods, the `remoteAddress` /
+ * `remotePort` getters, and the `'connect'` event (emitted on `nextTick`, like
+ * ioredis' `StandaloneConnector`). Bytes written by the client are forwarded to
+ * the server side via {@link feedServer}; bytes from the server are pushed back
+ * out as `'data'`.
+ */
+export class VirtualClientSocket extends Duplex {
+  readonly remoteAddress: string
+  readonly remotePort: number
+  readonly localAddress = '127.0.0.1'
+  readonly localPort = 0
+
+  /** Called with each chunk the client writes; set by the wiring below. */
+  private onClientWrite?: (chunk: Buffer) => void
+  /** Called once when the client side initiates teardown. */
+  private onClientDestroy?: () => void
+
+  constructor(remoteAddress: string, remotePort: number) {
+    super()
+    this.remoteAddress = remoteAddress
+    this.remotePort = remotePort
+    // ioredis resolves the connector's promise and then waits for 'connect';
+    // StandaloneConnector resolves on process.nextTick, so match that timing.
+    process.nextTick(() => {
+      if (!this.destroyed) {
+        this.emit('connect')
+        this.emit('ready')
+      }
+    })
+  }
+
+  /** @internal Wire the server-bound write + destroy hooks. */
+  bindServer(hooks: {
+    onClientWrite: (chunk: Buffer) => void
+    onClientDestroy: () => void
+  }): void {
+    this.onClientWrite = hooks.onClientWrite
+    this.onClientDestroy = hooks.onClientDestroy
+  }
+
+  /** @internal Push a chunk produced by the server out to the client reader. */
+  feedClient(chunk: Buffer): void {
+    if (!this.destroyed) {
+      this.push(chunk)
+    }
+  }
+
+  /** @internal Signal the client reader that the server closed the wire. */
+  endClient(): void {
+    if (!this.destroyed) {
+      this.push(null)
+    }
+  }
+
+  override _read(): void {
+    // Backpressure is not modeled — the server pushes proactively via feedClient.
+  }
+
+  override _write(
+    chunk: Buffer | string,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding)
+    this.onClientWrite?.(Buffer.from(buffer))
+    callback()
+  }
+
+  override _destroy(
+    error: Error | null,
+    callback: (error: Error | null) => void,
+  ): void {
+    this.onClientDestroy?.()
+    callback(error)
+  }
+
+  // --- net.Socket-shaped no-ops the client library calls during setup ---
+
+  setNoDelay(): this {
+    return this
+  }
+
+  setKeepAlive(): this {
+    return this
+  }
+
+  setTimeout(): this {
+    return this
+  }
+
+  ref(): this {
+    return this
+  }
+
+  unref(): this {
+    return this
+  }
+}
+
+/**
+ * A server-side {@link ConnectionTransport} over the in-process virtual wire.
+ * `read()` yields the bytes the client wrote; `write()` pushes bytes back to the
+ * client socket; `close()` aborts the read loop and tears both ends down.
+ */
+class DuplexConnectionTransport implements ConnectionTransport {
+  private static nextId = 0
+
+  readonly id: string
+  readonly signal: AbortSignal
+
+  private readonly controller = new AbortController()
+  private readonly incoming: Buffer[] = []
+  private readonly waiters = new Set<() => void>()
+  private readonly listeners = new Map<
+    ConnectionTransportEvent,
+    Set<ConnectionTransportListener>
+  >()
+  private readerActive = false
+  private inputEnded = false
+  private closed = false
+
+  constructor(
+    private readonly clientSocket: VirtualClientSocket,
+    id?: string,
+  ) {
+    this.id = id ?? `virtual-${++DuplexConnectionTransport.nextId}`
+    this.signal = this.controller.signal
+  }
+
+  /** Feed a chunk the client wrote into the server-side read loop. */
+  feed(chunk: Buffer): void {
+    if (this.inputEnded || this.closed) {
+      return
+    }
+    this.incoming.push(Buffer.from(chunk))
+    this.wakeReaders()
+  }
+
+  /** Mark the client→server direction finished (client ended its writable). */
+  endInput(): void {
+    this.inputEnded = true
+    this.wakeReaders()
+  }
+
+  async *read(): AsyncIterable<Buffer> {
+    if (this.readerActive) {
+      throw new Error('ConnectionTransport only supports one reader')
+    }
+    this.readerActive = true
+
+    try {
+      while (!this.closed && !this.signal.aborted) {
+        const chunk = this.incoming.shift()
+        if (chunk) {
+          yield Buffer.from(chunk)
+          continue
+        }
+        if (this.inputEnded) {
+          return
+        }
+        await this.waitForInput()
+      }
+    } finally {
+      this.readerActive = false
+    }
+  }
+
+  write(chunk: Buffer): void {
+    if (this.closed) {
+      return
+    }
+    this.clientSocket.feedClient(Buffer.from(chunk))
+  }
+
+  close(_reason?: string): void {
+    if (this.closed) {
+      return
+    }
+    this.closed = true
+    this.inputEnded = true
+    this.abort()
+    this.wakeReaders()
+    this.clientSocket.endClient()
+    if (!this.clientSocket.destroyed) {
+      this.clientSocket.destroy()
+    }
+    this.emit('close')
+  }
+
+  on(
+    event: ConnectionTransportEvent,
+    listener: ConnectionTransportListener,
+  ): ConnectionTransportUnsubscribe {
+    let bucket = this.listeners.get(event)
+    if (!bucket) {
+      bucket = new Set()
+      this.listeners.set(event, bucket)
+    }
+    bucket.add(listener)
+    return () => {
+      bucket?.delete(listener)
+    }
+  }
+
+  private waitForInput(): Promise<void> {
+    return new Promise(resolve => {
+      this.waiters.add(resolve)
+    })
+  }
+
+  private wakeReaders(): void {
+    const waiters = Array.from(this.waiters)
+    this.waiters.clear()
+    for (const waiter of waiters) {
+      waiter()
+    }
+  }
+
+  private abort(): void {
+    if (!this.controller.signal.aborted) {
+      this.controller.abort()
+    }
+  }
+
+  private emit(event: ConnectionTransportEvent, error?: Error): void {
+    const bucket = this.listeners.get(event)
+    if (!bucket) {
+      return
+    }
+    for (const listener of bucket) {
+      listener(error)
+    }
+  }
+}
+
+/**
+ * Build an in-process virtual connection: a fake client-facing `net.Socket`
+ * already wired to a fresh server-side {@link ClientSession}. The reusable
+ * primitive behind {@link createIoredisMock} — no TCP socket, no port bind.
+ *
+ * Bytes the client writes flow into a {@link DuplexConnectionTransport} that
+ * {@link attachSession} drives exactly like a real socket connection; the
+ * server's replies are pushed back out as `'data'` on the client socket. Tearing
+ * down either end (client `destroy()` or {@link VirtualConnection.close}) closes
+ * the transport, which aborts the adapter and the session.
+ */
+export function createVirtualConnection(
+  opts: CreateVirtualConnectionOptions,
+): VirtualConnection {
+  const clientSocket = new VirtualClientSocket(
+    opts.remoteAddress ?? '127.0.0.1',
+    opts.remotePort ?? 6379,
+  )
+  const transport = new DuplexConnectionTransport(clientSocket)
+
+  clientSocket.bindServer({
+    onClientWrite: chunk => transport.feed(chunk),
+    onClientDestroy: () => transport.endInput(),
+  })
+
+  const attached = attachSession(transport, {
+    state: opts.state,
+    executor: opts.executor,
+    nodeRole: opts.nodeRole,
+    logger: opts.logger,
+    encoder: opts.encoder,
+    clientAddress: `${opts.remoteAddress ?? '127.0.0.1'}:${
+      opts.remotePort ?? 6379
+    }`,
+  })
+
+  return {
+    clientSocket,
+    done: attached.done,
+    close: () => attached.close(),
+  }
+}

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -173,6 +173,26 @@ export {
 } from './core/transports/resp2'
 export { InMemoryConnectionTransport } from './core/transports/in-memory-connection-transport'
 export { SocketConnectionTransport } from './core/transports/socket-connection-transport'
+// Socketless connection layer — drive a session over any transport without a
+// TCP server (`attachSession`), a net.Socket-shaped in-memory wire
+// (`createVirtualConnection`), and a synthetic `host:port → pipeline` resolver
+// for following cluster `MOVED` redirects in-process (`InMemoryNodeRegistry`).
+export {
+  attachSession,
+  type AttachSessionOptions,
+  type AttachedSession,
+} from './core/transports/attach-session'
+export {
+  createVirtualConnection,
+  VirtualClientSocket,
+  type CreateVirtualConnectionOptions,
+  type VirtualConnection,
+} from './core/transports/virtual-connection'
+export {
+  InMemoryNodeRegistry,
+  type NodePipeline,
+  type RegisteredNode,
+} from './client-mocks/node-registry'
 
 // Pipeline assembly building blocks — the pieces `createRedisMock` /
 // `createRedisServer` / `createRedisCluster` wire together. Power users who

--- a/tests/client-mocks/node-registry.test.ts
+++ b/tests/client-mocks/node-registry.test.ts
@@ -1,0 +1,59 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import {
+  RedisServerState,
+  createRedisCommandExecutor,
+  InMemoryNodeRegistry,
+} from '../../src/internal'
+
+function pipeline() {
+  return {
+    state: new RedisServerState(),
+    executor: createRedisCommandExecutor(),
+  }
+}
+
+describe('InMemoryNodeRegistry', () => {
+  test('resolves a registered host:port to its pipeline', () => {
+    const registry = new InMemoryNodeRegistry()
+    const p = pipeline()
+    registry.register('127.0.0.1', 7000, p)
+
+    const resolved = registry.resolve('127.0.0.1', 7000)
+    assert.strictEqual(resolved?.state, p.state)
+    assert.strictEqual(resolved?.executor, p.executor)
+  })
+
+  test('returns undefined for an unknown address', () => {
+    const registry = new InMemoryNodeRegistry()
+    registry.register('127.0.0.1', 7000, pipeline())
+
+    assert.strictEqual(registry.resolve('127.0.0.1', 7001), undefined)
+    assert.strictEqual(registry.resolve('10.0.0.1', 7000), undefined)
+  })
+
+  test('nodes() lists every registered entry with its host/port', () => {
+    const registry = new InMemoryNodeRegistry()
+    registry.register('127.0.0.1', 7000, pipeline())
+    registry.register('127.0.0.1', 7001, pipeline())
+
+    const addresses = registry
+      .nodes()
+      .map(node => `${node.host}:${node.port}`)
+      .sort()
+    assert.deepStrictEqual(addresses, ['127.0.0.1:7000', '127.0.0.1:7001'])
+  })
+
+  test('re-registering an address overwrites the pipeline', () => {
+    const registry = new InMemoryNodeRegistry()
+    registry.register('127.0.0.1', 7000, pipeline())
+    const replacement = pipeline()
+    registry.register('127.0.0.1', 7000, replacement)
+
+    assert.strictEqual(registry.nodes().length, 1)
+    assert.strictEqual(
+      registry.resolve('127.0.0.1', 7000)?.state,
+      replacement.state,
+    )
+  })
+})

--- a/tests/core/virtual-connection.test.ts
+++ b/tests/core/virtual-connection.test.ts
@@ -1,0 +1,110 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import { once } from 'node:events'
+import {
+  RedisServerState,
+  createRedisCommandExecutor,
+} from '../../src/internal'
+import { createVirtualConnection } from '../../src/core/transports/virtual-connection'
+import { commandFrame } from '../shared-test-helpers'
+
+/** Read exactly `byteLength` bytes off the client socket, buffering chunks. */
+async function readBytes(
+  socket: NodeJS.ReadableStream,
+  byteLength: number,
+): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  let total = 0
+  while (total < byteLength) {
+    const chunk = (socket.read() as Buffer | null) ?? null
+    if (chunk) {
+      chunks.push(chunk)
+      total += chunk.length
+      continue
+    }
+    await once(socket, 'readable')
+  }
+  return Buffer.concat(chunks)
+}
+
+function freshPipeline() {
+  const state = new RedisServerState({ databaseCount: 16 })
+  const executor = createRedisCommandExecutor()
+  return { state, executor }
+}
+
+describe('createVirtualConnection', () => {
+  test('emits connect on next tick and round-trips RESP bytes', async () => {
+    const { state, executor } = freshPipeline()
+    const { clientSocket, close } = createVirtualConnection({ state, executor })
+
+    // ioredis StandaloneConnector resolves the stream then waits for 'connect'.
+    await once(clientSocket, 'connect')
+
+    clientSocket.write(commandFrame('SET', 'k', 'v'))
+    const setReply = await readBytes(clientSocket, '+OK\r\n'.length)
+    assert.strictEqual(setReply.toString(), '+OK\r\n')
+
+    clientSocket.write(commandFrame('GET', 'k'))
+    const getReply = await readBytes(clientSocket, '$1\r\nv\r\n'.length)
+    assert.strictEqual(getReply.toString(), '$1\r\nv\r\n')
+
+    close()
+  })
+
+  test('exposes net.Socket-shaped no-op methods used by ioredis', async () => {
+    const { state, executor } = freshPipeline()
+    const { clientSocket, close } = createVirtualConnection({ state, executor })
+
+    // These must exist and be chainable/no-throw — ioredis calls them on its
+    // stream during setup. They must not throw.
+    assert.strictEqual(typeof clientSocket.setNoDelay, 'function')
+    assert.strictEqual(typeof clientSocket.setKeepAlive, 'function')
+    assert.strictEqual(typeof clientSocket.setTimeout, 'function')
+    assert.strictEqual(typeof clientSocket.ref, 'function')
+    assert.strictEqual(typeof clientSocket.unref, 'function')
+    assert.doesNotThrow(() => {
+      clientSocket.setNoDelay(true)
+      clientSocket.setKeepAlive(true, 0)
+      clientSocket.setTimeout(0)
+      clientSocket.ref()
+      clientSocket.unref()
+    })
+    assert.strictEqual(typeof clientSocket.remoteAddress, 'string')
+    assert.strictEqual(typeof clientSocket.remotePort, 'number')
+
+    close()
+  })
+
+  test('close() tears down the server session (no leaked sessions)', async () => {
+    const { state, executor } = freshPipeline()
+    assert.strictEqual(state.getConnectedClients().length, 0)
+
+    const { clientSocket, close, done } = createVirtualConnection({
+      state,
+      executor,
+    })
+    await once(clientSocket, 'connect')
+
+    assert.strictEqual(state.getConnectedClients().length, 1)
+
+    close()
+    // The adapter loop tears the session down in its finally; await it.
+    await done
+    assert.strictEqual(state.getConnectedClients().length, 0)
+  })
+
+  test('destroying the client socket tears down the server session', async () => {
+    const { state, executor } = freshPipeline()
+    const { clientSocket } = createVirtualConnection({ state, executor })
+    await once(clientSocket, 'connect')
+    assert.strictEqual(state.getConnectedClients().length, 1)
+
+    clientSocket.destroy()
+    await once(clientSocket, 'close')
+    // Give the server-side read loop a tick to observe the closed transport.
+    await new Promise(resolve => setImmediate(resolve))
+
+    assert.strictEqual(state.getConnectedClients().length, 0)
+  })
+})

--- a/tests/core/virtual-connection.test.ts
+++ b/tests/core/virtual-connection.test.ts
@@ -96,15 +96,40 @@ describe('createVirtualConnection', () => {
 
   test('destroying the client socket tears down the server session', async () => {
     const { state, executor } = freshPipeline()
-    const { clientSocket } = createVirtualConnection({ state, executor })
+    const { clientSocket, done } = createVirtualConnection({ state, executor })
     await once(clientSocket, 'connect')
     assert.strictEqual(state.getConnectedClients().length, 1)
 
     clientSocket.destroy()
-    await once(clientSocket, 'close')
-    // Give the server-side read loop a tick to observe the closed transport.
-    await new Promise(resolve => setImmediate(resolve))
+    // Await the adapter loop settling rather than a single tick — robust if the
+    // disposal chain ever grows an extra await.
+    await done
 
+    assert.strictEqual(state.getConnectedClients().length, 0)
+  })
+
+  test('tearing down with an active SUBSCRIBE settles cleanly', async () => {
+    const { state, executor } = freshPipeline()
+    const { clientSocket, close, done } = createVirtualConnection({
+      state,
+      executor,
+    })
+    await once(clientSocket, 'connect')
+
+    // Open a push stream over the virtual wire, then read the subscribe
+    // confirmation so the subscription is established server-side.
+    clientSocket.write(commandFrame('SUBSCRIBE', 'ch'))
+    const confirmation = await readBytes(
+      clientSocket,
+      '*3\r\n$9\r\nsubscribe\r\n$2\r\nch\r\n:1\r\n'.length,
+    )
+    assert.match(confirmation.toString(), /subscribe/)
+    assert.strictEqual(state.getConnectedClients().length, 1)
+
+    close()
+    // The adapter's finally must drain the active push stream; if it didn't,
+    // `done` would never settle and this test would time out.
+    await done
     assert.strictEqual(state.getConnectedClients().length, 0)
   })
 })


### PR DESCRIPTION
## What

Extracts the **socketless connection layer** from the ioredis-mock work (PR #284) so it stands on its own, independent of any client mock. This is the infrastructure a browser/in-memory **cluster** target needs to follow `MOVED` redirects without a TCP socket (design "case #3").

### Pieces
- **`attachSession(transport, opts)`** — drives a fresh `ClientSession` over *any* `ConnectionTransport` + runs the RESP adapter loop, extracted out of `Resp2Server.handleConnection`. Net-free; `Resp2Server` now delegates to it. This is the run-loop that previously only existed inside the TCP server.
- **`VirtualClientSocket` / `createVirtualConnection()`** — a `net.Socket`-shaped `Duplex` bridged to a server-side session via `attachSession`. Lets a client lib "open a connection" with no real socket.
- **`InMemoryNodeRegistry`** — synthetic `host:port → pipeline` resolver: the lookup a client does when redirected by `-MOVED slot host:port` to reach the target node's state/executor in-process.

All exposed via `src/internal.ts`.

## Why (browser refactor)
Per [docs/BROWSER-REFACTOR-PLAN.md](docs/BROWSER-REFACTOR-PLAN.md), the browser drives the mock by feeding RESP bytes through a socketless transport — but the run-loop that consumes a transport was trapped inside the `net`-coupled `Resp2Server`. `attachSession` frees it (net-free, stream-free). The registry + virtual connection are the "fake connection" needed if a browser cluster client follows real `MOVED` redirects.

> `virtual-connection` imports `node:stream` `Duplex` — polyfillable in a browser bundle (same approach as the planned `buffer` polyfill). `attach-session` and `node-registry` are net- and stream-free.

## Scope / non-goals
- **No client mock**, no `ioredis`/`redis` dependency, no `package.json` change.
- Does **not** make `cluster.ts` browser-safe (the `Resp2Server`→`net` module split, plan blocker #5) — separate follow-up.
- Sibling PR (case #2, client-side slot routing) is independent; it sidesteps `MOVED` entirely and needs none of this.

## Tests
- `tests/core/virtual-connection.test.ts` — wire round-trip + teardown (no leaked sessions/sockets). 4 tests.
- `tests/client-mocks/node-registry.test.ts` — register/resolve/list/overwrite. 4 tests.

## Verification
tsc ✓ · lint ✓ · new tests 8/8 ✓ · build + d.ts ✓ (`InMemoryNodeRegistry`/`attachSession`/`createVirtualConnection` in `dist/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)