### PR TITLE
feat(client-mocks): in-memory cluster router (case #2 — client-side slot routing, no MOVED)

### DIFF
--- a/src/client-mocks/in-memory-cluster.ts
+++ b/src/client-mocks/in-memory-cluster.ts
@@ -1,0 +1,153 @@
+import { buildClusterNodes, type ClusterNodePipeline } from '../cluster'
+import { ClientSession } from '../core/client-session'
+import type { RedisValue } from '../core/redis-value'
+import { isResponseStream, type ResponseStream } from '../core/response-stream'
+import { RedisClusterTopology } from '../state'
+
+export type InMemoryClusterOptions = {
+  masters: number
+  replicasPerMaster?: number
+}
+
+export type CommandArgument = string | Buffer
+
+/**
+ * Client-agnostic in-memory Redis cluster.
+ *
+ * Builds TCP-free node pipelines (via {@link buildClusterNodes}) and routes each
+ * command to the slot owner's {@link ClientSession} *up front* — the slot is
+ * computed client-side from the command's keys, so the node never has to answer
+ * with a `MOVED` redirect that a caller would then have to follow. That makes
+ * this the socket-free cluster path (the redirect-following alternative needs a
+ * fake-connection layer; this one sidesteps it entirely).
+ *
+ * Routing keys are extracted with a single-key (first-argument) heuristic, which
+ * covers single-key commands and the common case. Genuinely multi-key
+ * cross-slot commands are out of scope — they would misroute and the owning
+ * node would return its normal `-CROSSSLOT`/`-MOVED` error, surfaced to the
+ * caller unchanged.
+ */
+export class InMemoryCluster {
+  private readonly topology: RedisClusterTopology
+  private readonly masters: readonly ClusterNodePipeline[]
+  private readonly replicationLinks: readonly { close(): void }[]
+  private readonly sessions = new Map<string, ClientSession>()
+  private closed = false
+
+  private constructor(
+    topology: RedisClusterTopology,
+    masters: readonly ClusterNodePipeline[],
+    replicationLinks: readonly { close(): void }[],
+  ) {
+    this.topology = topology
+    this.masters = masters
+    this.replicationLinks = replicationLinks
+  }
+
+  static create(options: InMemoryClusterOptions): InMemoryCluster {
+    const { topology, nodes, replicationLinks } = buildClusterNodes({
+      masters: options.masters,
+      replicasPerMaster: options.replicasPerMaster ?? 0,
+      basePort: 0,
+    })
+    const masters = nodes.filter(node => node.role === 'master')
+    return new InMemoryCluster(topology, masters, replicationLinks)
+  }
+
+  /** The session on the master that owns the slot for this command's keys. */
+  route(commandArgs: readonly CommandArgument[]): ClientSession {
+    const keys = extractRoutingKeys(commandArgs)
+    const slot =
+      keys.length > 0 ? this.topology.calculateSlotForKeys(keys) : null
+    const owner =
+      slot === null
+        ? this.masters[0]
+        : (this.topology.getSlotOwner(slot) ?? this.masters[0])
+    return this.sessionFor(owner.id)
+  }
+
+  /** Route then execute, returning the raw {@link RedisValue} (callers decode). */
+  async execute(commandArgs: readonly CommandArgument[]): Promise<RedisValue> {
+    if (this.closed) {
+      throw new Error('in-memory cluster is closed')
+    }
+    if (commandArgs.length === 0) {
+      throw new Error('command requires at least a name')
+    }
+
+    const session = this.route(commandArgs)
+    const [name, ...rest] = commandArgs
+    const result = await session.execute(toBuffer(name), rest.map(toBuffer))
+
+    if (isResponseStream(result)) {
+      return drainStream(result)
+    }
+    return result.value
+  }
+
+  close(): void {
+    if (this.closed) {
+      return
+    }
+    this.closed = true
+    for (const session of this.sessions.values()) {
+      session.close()
+    }
+    this.sessions.clear()
+    for (const link of this.replicationLinks) {
+      link.close()
+    }
+  }
+
+  private sessionFor(nodeId: string): ClientSession {
+    const existing = this.sessions.get(nodeId)
+    if (existing) {
+      return existing
+    }
+    const node = this.masters.find(master => master.id === nodeId)
+    if (!node) {
+      throw new Error(`No master pipeline for cluster node ${nodeId}`)
+    }
+    const session = new ClientSession({
+      server: node.state,
+      executor: node.executor,
+      nodeRole: node.role,
+    })
+    this.sessions.set(nodeId, session)
+    return session
+  }
+}
+
+export function createInMemoryCluster(
+  options: InMemoryClusterOptions,
+): InMemoryCluster {
+  return InMemoryCluster.create(options)
+}
+
+function extractRoutingKeys(args: readonly CommandArgument[]): Buffer[] {
+  // Every routed command places its key in the first argument slot — covers
+  // single-key commands and the common case. Multi-key cross-slot commands are
+  // out of scope (see class doc).
+  if (args.length < 2) {
+    return []
+  }
+  return [toBuffer(args[1])]
+}
+
+/**
+ * Consume a streaming reply (e.g. multi-channel SUBSCRIBE confirmations) to
+ * completion and return the final frame's value. Out-of-band pushes are not
+ * delivered here.
+ */
+async function drainStream(stream: ResponseStream): Promise<RedisValue> {
+  let last: RedisValue = { kind: 'simple-string', value: 'OK' }
+  const abort = new AbortController()
+  for await (const frame of stream.frames(abort.signal)) {
+    last = frame.value
+  }
+  return last
+}
+
+function toBuffer(value: CommandArgument): Buffer {
+  return Buffer.isBuffer(value) ? value : Buffer.from(value)
+}

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -189,6 +189,14 @@ export {
   type RedisClusterNodeHandle,
   type RedisClusterOptions,
 } from './cluster'
+// Client-agnostic in-memory cluster that routes each command to its slot owner
+// up front (client-side routing — no MOVED round-trips).
+export {
+  InMemoryCluster,
+  createInMemoryCluster,
+  type InMemoryClusterOptions,
+  type CommandArgument,
+} from './client-mocks/in-memory-cluster'
 
 // Client-visible error classes (also re-exported from the package root).
 export * from './core/redis-error'

--- a/tests/client-mocks/in-memory-cluster.test.ts
+++ b/tests/client-mocks/in-memory-cluster.test.ts
@@ -1,0 +1,70 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import type { RedisValue } from '../../src/core/redis-value'
+import { ClientSession } from '../../src/internal'
+import { createInMemoryCluster } from '../../src/client-mocks/in-memory-cluster'
+
+function asText(value: RedisValue): string | null {
+  const inner = (value as { value?: unknown }).value
+  if (inner === null || inner === undefined) {
+    return null
+  }
+  return Buffer.isBuffer(inner) ? inner.toString() : String(inner)
+}
+
+describe('InMemoryCluster (client-side slot routing)', () => {
+  test('round-trips a value through the slot owner', async () => {
+    const cluster = createInMemoryCluster({ masters: 3 })
+    try {
+      assert.strictEqual(
+        asText(await cluster.execute(['SET', 'foo', 'bar'])),
+        'OK',
+      )
+      assert.strictEqual(asText(await cluster.execute(['GET', 'foo'])), 'bar')
+    } finally {
+      cluster.close()
+    }
+  })
+
+  test('spreads keys across more than one master — no MOVED needed', () => {
+    const cluster = createInMemoryCluster({ masters: 3 })
+    try {
+      const sessions = new Set<ClientSession>()
+      for (let i = 0; i < 50; i++) {
+        sessions.add(cluster.route(['GET', `key:${i}`]))
+      }
+      assert.ok(
+        sessions.size > 1,
+        `expected keys to route across masters, got ${sessions.size}`,
+      )
+    } finally {
+      cluster.close()
+    }
+  })
+
+  test('routes the same slot to the same cached session', () => {
+    const cluster = createInMemoryCluster({ masters: 3 })
+    try {
+      const a = cluster.route(['GET', 'samekey'])
+      const b = cluster.route(['SET', 'samekey', 'x'])
+      assert.strictEqual(a, b)
+    } finally {
+      cluster.close()
+    }
+  })
+
+  test('runs keyless commands on the first master', async () => {
+    const cluster = createInMemoryCluster({ masters: 3 })
+    try {
+      assert.strictEqual(asText(await cluster.execute(['PING'])), 'PONG')
+    } finally {
+      cluster.close()
+    }
+  })
+
+  test('execute rejects after close', async () => {
+    const cluster = createInMemoryCluster({ masters: 2 })
+    cluster.close()
+    await assert.rejects(() => cluster.execute(['GET', 'k']), /closed/)
+  })
+})


### PR DESCRIPTION
## What

Extracts a **client-agnostic in-memory cluster router** from the node-redis cluster facade (PR #285) so it stands alone. This is the socket-free cluster path for the browser target (design "case #2").

- **`InMemoryCluster` / `createInMemoryCluster({ masters, replicasPerMaster? })`** — builds TCP-free node pipelines via `buildClusterNodes()` and routes each command to the slot owner's `ClientSession` **up front** (slot computed client-side). The node therefore never returns a `MOVED` that a caller would have to follow — the redirect is sidestepped entirely.
- `route(args) → ClientSession`, `execute(args) → Promise<RedisValue>` (raw value; callers decode), `close()` (tears down sessions + replication links). Exposed via `src/internal.ts`.

## Why (browser refactor)
Per [docs/BROWSER-REFACTOR-PLAN.md](docs/BROWSER-REFACTOR-PLAN.md), this is the recommended browser cluster approach: no fake socket, no `MOVED` round-trip, no `node:stream`. (The redirect-following alternative — fake connections — is the separate sibling PR #286.)

## Scope / non-goals
- **Client-agnostic**: in `(string|Buffer)[]` → out `RedisValue`. No `ioredis`/`redis` dep, no `package.json` change.
- **Routing heuristic**: single-key (first-arg). Covers single-key commands and the common case; genuine multi-key cross-slot commands misroute and surface the node's normal `-CROSSSLOT`/`-MOVED` error unchanged (documented in the class).
- **Not yet browser-safe**: it imports `buildClusterNodes` from `cluster.ts`, whose module graph pulls in `Resp2Server` (→`net`). Making it browser-importable needs the `cluster.ts` `net` split (plan blocker #5) — separate follow-up.
- No consumer wired yet — this is the staged primitive a browser cluster client will build on.

## Tests
- `tests/client-mocks/in-memory-cluster.test.ts` (5): round-trip through the slot owner, keys spread across >1 master, same-slot session caching, keyless command on first master, `execute` rejects after `close`.

## Verification
tsc ✓ · lint ✓ · new tests 5/5 ✓ · build + d.ts ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)