### PR TITLE
refactor(client): replace mock.client() with createInMemoryClient facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,33 +307,30 @@ const cluster = new Redis.Cluster(mock.clusterNodes())
 
 ### Socketless client
 
-If you don't need a real client library, `mock.client()` returns an in-process
-client that drives the **same** command pipeline directly — no TCP loopback, no
-RESP encoding — and resolves to native JS replies (throwing `RedisCommandError`
-on `-ERR`). Standalone mocks only; cluster mocks throw.
+If you don't need a real client library, `createInMemoryClient()` returns an
+in-process client with its **own** keyspace that drives the command pipeline
+directly — no TCP loopback, no RESP encoding — and resolves to native JS replies
+(throwing `RedisCommandError` on `-ERR`). It's the bespoke-client sibling of
+`createIoredisMock` / `createNodeRedisMock`; standalone only.
 
 ```typescript
-const mock = await createRedisMock()
-const client = mock.client() // { database?, returnBuffers? }
+import { createInMemoryClient } from 'js-redis-server'
+
+const client = await createInMemoryClient({
+  // databaseCount?, database?, returnBuffers?, seed?
+})
 
 await client.command('SET', 'k', 'v')
 await client.command('GET', 'k') // 'v'
 await client.command('INCR', 'n') // 1 (number)
 await client.command('HGETALL', 'h') // { field: 'value', ... }
 
-// clients are closed automatically when the mock closes
-await mock.close()
+client.close() // tears down its keyspace
 ```
 
-For a mock with **no network listener at all**, pass `transport: 'memory'`. Only
-`client()` works; the network accessors (`host`/`port`/`url`/`connectionOptions`/
-`clusterNodes`) throw.
-
-```typescript
-const mock = await createRedisMock({ transport: 'memory' })
-const client = mock.client()
-await client.command('PING') // 'PONG'
-```
+Need to drive an existing `createRedisMock()`'s keyspace instead of an
+independent one? Construct `InMemoryRedisClient` directly with that mock's
+`state` and an executor from `js-redis-server/core`.
 
 ### Drop-in ioredis mock
 
@@ -413,10 +410,12 @@ await mock.seed([
   { key: 'in-db-3', type: 'string', value: 'scoped', db: 3 },
 ])
 
-const client = mock.client()
-await client.command('GET', 'user:1') // 'alice'
-await client.command('HGETALL', 'h:1') // { name: 'bob', age: '30' }
+// any client connected to the mock now sees the seeded keys
+// (e.g. new Redis(mock.connectionOptions()) — GET user:1 → 'alice')
 ```
+
+`createInMemoryClient()` takes the same `seed` array to pre-populate its own
+keyspace before the first command.
 
 Each entry's shape is checked against its `type`:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -456,19 +456,18 @@ The returned `RedisMock` exposes connection helpers (`connectionOptions()`,
 `clusterNodes()`, `url`), `flush()`/`reset()` (→ `state.flushAllDatabases()` or
 a cluster fan-out), and `state`/`nodes` escape hatches.
 
-`mock.client()` returns an [`InMemoryRedisClient`](../src/in-memory-client.ts) —
-a socketless client that drives the **same** pipeline by holding a
-[`ClientSession`](../src/core/client-session.ts) and calling `session.execute`
-directly, bypassing both the TCP loopback and RESP encode/decode. Replies are
-decoded from `RedisValue` into native JS (integers narrowed to `number` when
-safe; `-ERR` surfaced as `RedisCommandError`). Streaming commands are rejected.
-The executor stays private to the facade — it is never exposed on `RedisMock` or
-the `createRedisServer` handle.
-
-The standalone transport is selectable via `transport: 'tcp' | 'memory'`. The
-default `'tcp'` starts a real `Resp2Server`; `'memory'` skips the listener
-entirely (no port), so only `mock.client()` works and the network accessors
-throw. Cluster mocks are always TCP.
+[`createInMemoryClient`](../src/in-memory-client.ts) returns an
+`InMemoryRedisClient` — a socketless client (the bespoke-client sibling of
+`createIoredisMock` / `createNodeRedisMock`) that drives the **same** pipeline by
+holding a [`ClientSession`](../src/core/client-session.ts) and calling
+`session.execute` directly, bypassing both the TCP loopback and RESP
+encode/decode. Replies are decoded from `RedisValue` into native JS (integers
+narrowed to `number` when safe; `-ERR` surfaced as `RedisCommandError`).
+Streaming commands are rejected. It owns its own `RedisServerState` + executor
+(built internally from `databaseCount`/`seed`), so `client.close()` tears them
+down. To drive an existing mock's keyspace instead, construct
+`InMemoryRedisClient` directly with that mock's `state` and a
+`createRedisCommandExecutor()` from `js-redis-server/core`.
 
 [`seed`](../src/seed.ts) converts a public `SeedEntry[]` into keyspace writes:
 each entry maps to a `RedisDataValue` via the existing tracked

--- a/src/in-memory-client.ts
+++ b/src/in-memory-client.ts
@@ -1,10 +1,14 @@
+import { createRedisCommandExecutor } from './commands'
 import { ClientSession } from './core/client-session'
 import type { CommandExecutor } from './core/command-executor'
 import { RedisCommandError } from './core/redis-error'
 import type { RedisValue } from './core/redis-value'
 import { RedisResult } from './core/redis-result'
 import { isResponseStream } from './core/response-stream'
-import type { RedisServerState } from './state'
+import { seedStandalone, type SeedEntry } from './seed'
+import { RedisServerState } from './state'
+
+const DEFAULT_DATABASE_COUNT = 16
 
 /** A command argument the in-memory client accepts. */
 export type RedisCommandArgument = string | number | Buffer
@@ -27,6 +31,8 @@ export type InMemoryRedisClientOptions = {
   database?: number
   /** Return `Buffer`s for bulk-string/verbatim replies instead of utf8 strings. */
   returnBuffers?: boolean
+  /** Called once when the client is closed — used to tear down owned state. */
+  onClose?: () => void
 }
 
 /**
@@ -42,6 +48,7 @@ export type InMemoryRedisClientOptions = {
 export class InMemoryRedisClient {
   private readonly session: ClientSession
   private readonly returnBuffers: boolean
+  private readonly onClose?: () => void
   private closed = false
 
   constructor(options: InMemoryRedisClientOptions) {
@@ -51,6 +58,7 @@ export class InMemoryRedisClient {
       database: options.database,
     })
     this.returnBuffers = options.returnBuffers ?? false
+    this.onClose = options.onClose
   }
 
   /**
@@ -97,6 +105,7 @@ export class InMemoryRedisClient {
     }
     this.closed = true
     this.session.close()
+    this.onClose?.()
   }
 
   private decode(value: RedisValue): RedisNativeReply {
@@ -150,10 +159,46 @@ export class InMemoryRedisClient {
   }
 }
 
-export function createInMemoryClient(
-  options: InMemoryRedisClientOptions,
-): InMemoryRedisClient {
-  return new InMemoryRedisClient(options)
+export type CreateInMemoryClientOptions = {
+  /** Logical database count (defaults to 16, matching real Redis). */
+  databaseCount?: number
+  /** Initial selected database (default 0). */
+  database?: number
+  /** Return `Buffer`s for bulk-string/verbatim replies instead of utf8 strings. */
+  returnBuffers?: boolean
+  /** Pre-populate the keyspace before the client is returned. */
+  seed?: readonly SeedEntry[]
+}
+
+/**
+ * A socketless, in-process {@link InMemoryRedisClient} backed by its own
+ * keyspace + command pipeline — the bespoke-client sibling of
+ * {@link createIoredisMock} / {@link createNodeRedisMock}. Owns its state, so
+ * `client.close()` tears everything down.
+ *
+ * Need to drive an existing mock's keyspace instead? Construct
+ * {@link InMemoryRedisClient} directly with that mock's `state` and an executor
+ * from `js-redis-server/core`.
+ */
+export async function createInMemoryClient(
+  options: CreateInMemoryClientOptions = {},
+): Promise<InMemoryRedisClient> {
+  const state = new RedisServerState({
+    databaseCount: options.databaseCount ?? DEFAULT_DATABASE_COUNT,
+  })
+  const executor = createRedisCommandExecutor()
+
+  if (options.seed) {
+    await seedStandalone(state, options.seed)
+  }
+
+  return new InMemoryRedisClient({
+    server: state,
+    executor,
+    database: options.database,
+    returnBuffers: options.returnBuffers,
+    onClose: () => state.close(),
+  })
 }
 
 function isSafeBigInt(value: bigint): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,9 +16,7 @@ export {
   type CreateRedisServerClusterOptions,
   type RedisAddress,
   type RedisMock,
-  type RedisMockClientOptions,
   type RedisMockClusterOptions,
-  type RedisMockTransport,
   type RedisServerHandle,
 } from './mock'
 export { seedCluster, seedStandalone, type SeedEntry } from './seed'
@@ -32,6 +30,7 @@ export {
 export {
   InMemoryRedisClient,
   createInMemoryClient,
+  type CreateInMemoryClientOptions,
   type InMemoryRedisClientOptions,
   type RedisCommandArgument,
   type RedisNativeReply,

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -8,10 +8,6 @@ import type { CommandExecutor } from './core/command-executor'
 import { Resp2Server } from './core/transports/resp2/server'
 import { RedisServerState } from './state'
 import { seedCluster, seedStandalone, type SeedEntry } from './seed'
-import {
-  InMemoryRedisClient,
-  type InMemoryRedisClientOptions,
-} from './in-memory-client'
 import type { Logger } from './logger'
 
 const DEFAULT_HOST = '127.0.0.1'
@@ -112,39 +108,25 @@ export type RedisMockClusterOptions = {
   replicas?: number
 }
 
-/**
- * Transport backing a standalone mock:
- *  - `'tcp'` (default): a real loopback {@link Resp2Server} you connect a normal
- *    client library to (and may also drive via {@link RedisMock.client}).
- *  - `'memory'`: no TCP listener at all — only the socketless
- *    {@link RedisMock.client} works. The network accessors (`host`/`port`/`url`/
- *    `connectionOptions`/`clusterNodes`) throw.
- */
-export type RedisMockTransport = 'tcp' | 'memory'
-
 export type CreateRedisMockOptions = {
   /** When set, builds a cluster mock instead of a standalone one. */
   cluster?: RedisMockClusterOptions
-  /** Standalone transport (defaults to `'tcp'`). Ignored for cluster mocks. */
-  transport?: RedisMockTransport
   /** Standalone-only: logical database count (defaults to 16). */
   databaseCount?: number
-  /** Standalone bind port (TCP transport). Defaults to `0` (OS-assigned). */
+  /** Standalone bind port. Defaults to `0` (OS-assigned). */
   port?: number
   /** Cluster base port. Defaults to `0` (each node OS-assigned). */
   basePort?: number
   logger?: Pick<Logger, 'error'>
 }
 
-export type RedisMockClientOptions = Pick<
-  InMemoryRedisClientOptions,
-  'database' | 'returnBuffers'
->
-
 /**
  * Friendly test-mock facade over a standalone server or a cluster. Exposes
- * connection helpers, seeding, a socketless client, reset-between-tests, and
- * escape hatches to the underlying state/nodes for power users.
+ * connection helpers, seeding, reset-between-tests, and escape hatches to the
+ * underlying state/nodes for power users.
+ *
+ * Need a socketless in-process client (no TCP, no RESP)? Use the standalone
+ * {@link createInMemoryClient} builder instead.
  */
 export interface RedisMock {
   readonly host: string
@@ -155,13 +137,6 @@ export interface RedisMock {
   /** Seed-node list for ioredis `Cluster` (single entry for standalone mocks). */
   clusterNodes(): RedisAddress[]
   seed(entries: readonly SeedEntry[]): Promise<void>
-  /**
-   * Socketless in-process client over the same command pipeline (no TCP, no
-   * RESP). Standalone mocks only — cluster mocks throw; connect a real cluster
-   * client to {@link RedisMock.clusterNodes} instead. Closed automatically when
-   * the mock closes.
-   */
-  client(options?: RedisMockClientOptions): InMemoryRedisClient
   flush(): Promise<void>
   /** Alias for {@link RedisMock.flush}. */
   reset(): Promise<void>
@@ -174,9 +149,8 @@ export interface RedisMock {
 
 /**
  * Creates a {@link RedisMock} — the entry point for test suites. Standalone by
- * default; pass `{ cluster: { masters } }` for a cluster mock. Adds seeding,
- * reset-between-tests, and an in-process socketless client on top of a real
- * server/cluster.
+ * default; pass `{ cluster: { masters } }` for a cluster mock. Adds seeding and
+ * reset-between-tests on top of a real server/cluster.
  *
  * To run a long-running server a separate process connects to (a CLI, a dev
  * tool) rather than drive it from test code, use {@link createRedisServer}
@@ -188,45 +162,9 @@ export async function createRedisMock(
   options: CreateRedisMockOptions = {},
 ): Promise<RedisMock> {
   if (options.cluster) {
-    if (options.transport === 'memory') {
-      throw new Error(
-        "the 'memory' transport is not supported for cluster mocks; use a tcp cluster mock",
-      )
-    }
     return createClusterMock(options.cluster, options)
   }
-  if (options.transport === 'memory') {
-    return createMemoryMock(options)
-  }
   return createTcpStandaloneMock(options)
-}
-
-/** Track and lazily build socketless clients over a standalone pipeline. */
-function createClientFactory(
-  state: RedisServerState,
-  executor: CommandExecutor,
-): {
-  client: (options?: RedisMockClientOptions) => InMemoryRedisClient
-  closeAll: () => void
-} {
-  const clients = new Set<InMemoryRedisClient>()
-  return {
-    client: clientOptions => {
-      const client = new InMemoryRedisClient({
-        server: state,
-        executor,
-        ...clientOptions,
-      })
-      clients.add(client)
-      return client
-    },
-    closeAll: () => {
-      for (const client of clients) {
-        client.close()
-      }
-      clients.clear()
-    },
-  }
 }
 
 async function createTcpStandaloneMock(
@@ -241,7 +179,6 @@ async function createTcpStandaloneMock(
   await server.listen(options.port ?? 0)
 
   const address: RedisAddress = { host: DEFAULT_HOST, port: server.getPort() }
-  const { client, closeAll } = createClientFactory(state, executor)
 
   return {
     host: address.host,
@@ -250,46 +187,10 @@ async function createTcpStandaloneMock(
     connectionOptions: () => ({ ...address }),
     clusterNodes: () => [{ ...address }],
     seed: entries => seedStandalone(state, entries),
-    client,
     flush: async () => state.flushAllDatabases(),
     reset: async () => state.flushAllDatabases(),
     close: async () => {
-      closeAll()
       await server.close()
-    },
-    state,
-  }
-}
-
-function createMemoryMock(options: CreateRedisMockOptions): RedisMock {
-  const { state, executor } = createStandalonePipeline(options.databaseCount)
-  const { client, closeAll } = createClientFactory(state, executor)
-
-  const noEndpoint = (): never => {
-    throw new Error(
-      'this mock uses the in-memory transport and has no TCP endpoint; use mock.client()',
-    )
-  }
-
-  return {
-    get host(): string {
-      return noEndpoint()
-    },
-    get port(): number {
-      return noEndpoint()
-    },
-    get url(): string {
-      return noEndpoint()
-    },
-    connectionOptions: noEndpoint,
-    clusterNodes: noEndpoint,
-    seed: entries => seedStandalone(state, entries),
-    client,
-    flush: async () => state.flushAllDatabases(),
-    reset: async () => state.flushAllDatabases(),
-    close: async () => {
-      closeAll()
-      state.close()
     },
     state,
   }
@@ -318,11 +219,6 @@ async function createClusterMock(
     clusterNodes: () =>
       built.nodes.map(node => ({ host: node.host, port: node.port })),
     seed: entries => seedCluster(built, entries),
-    client: () => {
-      throw new Error(
-        'client() is not supported for cluster mocks; connect a real cluster client to clusterNodes() instead',
-      )
-    },
     flush: () => flushCluster(built),
     reset: () => flushCluster(built),
     close: () => built.close(),

--- a/tests/in-memory-client.test.ts
+++ b/tests/in-memory-client.test.ts
@@ -1,33 +1,31 @@
 import { test, describe, afterEach } from 'node:test'
 import assert from 'node:assert'
-import { createRedisMock, type RedisMock } from '../src/mock'
+import { createInMemoryClient } from '../src'
+import type { InMemoryRedisClient } from '../src'
 import { RedisCommandError } from '../src/core/redis-error'
 
-describe('InMemoryRedisClient (via createRedisMock)', () => {
-  let mock: RedisMock
+describe('createInMemoryClient', () => {
+  let client: InMemoryRedisClient
 
-  afterEach(async () => {
-    await mock?.close()
+  afterEach(() => {
+    client?.close()
   })
 
   test('round-trips a string through the socketless client', async () => {
-    mock = await createRedisMock({ transport: 'memory' })
-    const client = mock.client()
+    client = await createInMemoryClient()
     assert.strictEqual(await client.command('SET', 'k', 'v'), 'OK')
     assert.strictEqual(await client.command('GET', 'k'), 'v')
   })
 
   test('returns integers as numbers, not bigint', async () => {
-    mock = await createRedisMock({ transport: 'memory' })
-    const client = mock.client()
+    client = await createInMemoryClient()
     const incremented = await client.command('INCR', 'counter')
     assert.strictEqual(incremented, 1)
     assert.strictEqual(typeof incremented, 'number')
   })
 
   test('decodes a hash reply into an object', async () => {
-    mock = await createRedisMock({ transport: 'memory' })
-    const client = mock.client()
+    client = await createInMemoryClient()
     await client.command('HSET', 'h', 'name', 'bob', 'age', '30')
     assert.deepStrictEqual(await client.command('HGETALL', 'h'), {
       name: 'bob',
@@ -36,8 +34,7 @@ describe('InMemoryRedisClient (via createRedisMock)', () => {
   })
 
   test('decodes a list reply into an array', async () => {
-    mock = await createRedisMock({ transport: 'memory' })
-    const client = mock.client()
+    client = await createInMemoryClient()
     await client.command('RPUSH', 'l', 'a', 'b', 'c')
     assert.deepStrictEqual(await client.command('LRANGE', 'l', 0, -1), [
       'a',
@@ -47,8 +44,7 @@ describe('InMemoryRedisClient (via createRedisMock)', () => {
   })
 
   test('throws a RedisCommandError on an error reply', async () => {
-    mock = await createRedisMock({ transport: 'memory' })
-    const client = mock.client()
+    client = await createInMemoryClient()
     await client.command('SET', 'k', 'v')
     await assert.rejects(
       client.command('INCR', 'k'),
@@ -57,8 +53,7 @@ describe('InMemoryRedisClient (via createRedisMock)', () => {
   })
 
   test('returnBuffers yields Buffer bulk replies', async () => {
-    mock = await createRedisMock({ transport: 'memory' })
-    const client = mock.client({ returnBuffers: true })
+    client = await createInMemoryClient({ returnBuffers: true })
     await client.command('SET', 'k', 'v')
     const value = await client.command('GET', 'k')
     assert.ok(Buffer.isBuffer(value))
@@ -66,63 +61,24 @@ describe('InMemoryRedisClient (via createRedisMock)', () => {
   })
 
   test('database option selects a logical db', async () => {
-    mock = await createRedisMock({ transport: 'memory' })
-    const onDb2 = mock.client({ database: 2 })
-    await onDb2.command('SET', 'k', 'v')
-    const onDb0 = mock.client()
-    assert.strictEqual(await onDb0.command('GET', 'k'), null)
-    assert.strictEqual(await onDb2.command('GET', 'k'), 'v')
+    client = await createInMemoryClient({ database: 2 })
+    await client.command('SET', 'k', 'v')
+    await client.command('SELECT', '0')
+    assert.strictEqual(await client.command('GET', 'k'), null)
+    await client.command('SELECT', '2')
+    assert.strictEqual(await client.command('GET', 'k'), 'v')
+  })
+
+  test('seed pre-populates the keyspace', async () => {
+    client = await createInMemoryClient({
+      seed: [{ key: 'k', type: 'string', value: 'v' }],
+    })
+    assert.strictEqual(await client.command('GET', 'k'), 'v')
   })
 
   test('rejects commands after close', async () => {
-    mock = await createRedisMock({ transport: 'memory' })
-    const client = mock.client()
+    client = await createInMemoryClient()
     client.close()
     await assert.rejects(client.command('PING'), /closed/)
-  })
-})
-
-describe('createRedisMock memory transport', () => {
-  let mock: RedisMock
-
-  afterEach(async () => {
-    await mock?.close()
-  })
-
-  test('has no TCP endpoint', async () => {
-    mock = await createRedisMock({ transport: 'memory' })
-    assert.throws(() => mock.connectionOptions(), /no TCP endpoint/)
-    assert.throws(() => mock.clusterNodes(), /no TCP endpoint/)
-    assert.throws(() => mock.host, /no TCP endpoint/)
-    assert.throws(() => mock.port, /no TCP endpoint/)
-  })
-})
-
-describe('createRedisMock client() on other modes', () => {
-  test('tcp standalone mock exposes a working socketless client', async () => {
-    const mock = await createRedisMock()
-    try {
-      const client = mock.client()
-      await client.command('SET', 'k', 'v')
-      assert.strictEqual(await client.command('GET', 'k'), 'v')
-    } finally {
-      await mock.close()
-    }
-  })
-
-  test('cluster mock client() throws', async () => {
-    const mock = await createRedisMock({ cluster: { masters: 3 } })
-    try {
-      assert.throws(() => mock.client(), /not supported for cluster/)
-    } finally {
-      await mock.close()
-    }
-  })
-
-  test('memory transport is rejected for cluster mocks', async () => {
-    await assert.rejects(
-      createRedisMock({ cluster: { masters: 3 }, transport: 'memory' }),
-      /not supported for cluster/,
-    )
   })
 })

--- a/tests/public-interface.test.ts
+++ b/tests/public-interface.test.ts
@@ -136,18 +136,17 @@ describe('public interface — createRedisMock', () => {
     assert.ok(mock.state)
     assert.strictEqual(mock.nodes, undefined)
 
+    // A socketless client over the mock's own state (the documented power-user
+    // escape hatch) sees the seed and the subsequent flush.
     await mock.seed([{ key: 'k', type: 'string', value: 'v' }])
-    const client = mock.client()
+    const client = new InMemoryRedisClient({
+      server: mock.state!,
+      executor: createRedisCommandExecutor(),
+    })
     assert.strictEqual(await client.command('GET', 'k'), 'v')
     await mock.flush()
     assert.strictEqual(await client.command('GET', 'k'), null)
-  })
-
-  test('memory transport has no endpoint but a working client', async () => {
-    mock = await createRedisMock({ transport: 'memory' })
-    assert.throws(() => mock.connectionOptions(), /no TCP endpoint/)
-    const client = mock.client()
-    assert.strictEqual(await client.command('PING'), 'PONG')
+    client.close()
   })
 
   test('cluster mock exposes nodes and a slot-routed seed', async () => {
@@ -161,15 +160,5 @@ describe('public interface — createRedisMock', () => {
         node.server.getDatabase(0).getString(Buffer.from('user:1')) !== null,
     )
     assert.ok(owner)
-  })
-
-  test('error replies surface as RedisCommandError', async () => {
-    mock = await createRedisMock({ transport: 'memory' })
-    const client = mock.client()
-    await client.command('SET', 'k', 'v')
-    await assert.rejects(
-      client.command('INCR', 'k'),
-      (err: unknown) => err instanceof RedisCommandError,
-    )
   })
 })


### PR DESCRIPTION
## What

Align the socketless in-process client with the other client mocks (`createIoredisMock` / `createNodeRedisMock`): a standalone **`createInMemoryClient`** builder that owns its own keyspace + pipeline, instead of a `client()` method hanging off `RedisMock`.

## Changes

- **`createInMemoryClient(options)`** is now an async, self-contained factory — `{ databaseCount?, database?, returnBuffers?, seed? }` → `InMemoryRedisClient`. It builds its own `RedisServerState` + executor, so `client.close()` tears them down (new `onClose` hook on `InMemoryRedisClient`).
- Removed `RedisMock.client()`, `createClientFactory`, and `RedisMockClientOptions`.
- Removed the **`'memory'` transport** (`RedisMockTransport`, the `transport` option, `createMemoryMock`) — it existed solely to host `client()` and is dead without it.
- Migrated tests, README, and ARCHITECTURE docs.

## Behavior change

`createInMemoryClient` gets its **own** keyspace — it no longer shares a running `createRedisMock`'s keyspace the way `mock.client()` did. Escape hatch preserved for power users: `new InMemoryRedisClient({ server: mock.state, executor: createRedisCommandExecutor() })` (now the verified path in `public-interface.test.ts`).

## Verification

- `npm test` — 281 unit tests pass
- `npm run lint` — clean
- `npm run build` — succeeds

No wire-protocol change; integration suites don't touch this surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)