### PR TITLE
docs(readme): testing-first rewrite; unify mock connection helper as addresses()

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,61 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js Version](https://img.shields.io/node/v/js-redis-server.svg)](https://nodejs.org)
 
-In-memory Redis-compatible server implementation in JavaScript. Useful for testing and development without requiring a real Redis instance.
+A real, in-memory Redis-compatible server in pure JavaScript. It starts
+instantly with no Redis installation, so **the main use case is testing** — point
+your normal Redis client at it instead of a real Redis, and your tests run fast,
+isolated, and reproducible.
+
+```typescript
+import { createRedisMock } from 'js-redis-server'
+import { Redis } from 'ioredis'
+
+const mock = await createRedisMock()
+const redis = new Redis(mock.addresses()[0])
+
+await redis.set('foo', 'bar')
+await redis.get('foo') // 'bar'
+
+redis.disconnect()
+await mock.close()
+```
+
+That's the recommended path: a real server + your real client over a real
+socket, so your client's own encoding and parsing are exercised exactly as in
+production. Jump to [Use as a Redis mock in tests](#use-as-a-redis-mock-in-tests).
 
 ## Table of Contents
 
+- [Why](#why)
 - [Features](#features)
 - [Installation](#installation)
-- [Quick Start](#quick-start)
-  - [As a Test Mock (recommended)](#as-a-test-mock-recommended)
-  - [As a Standalone Server](#as-a-standalone-server)
-  - [As a CLI](#as-a-cli)
-  - [CLI Options](#cli-options)
+- [Use as a Redis mock in tests](#use-as-a-redis-mock-in-tests)
+  - [node:test](#nodetest)
+  - [vitest / jest](#vitest--jest)
+  - [Cluster mocks](#cluster-mocks)
+  - [Seeding](#seeding)
+  - [`createRedisMock` options](#createredismock-options)
 - [Connecting Clients](#connecting-clients)
   - [Protocol Version (RESP2 / RESP3)](#protocol-version-resp2--resp3)
   - [Connecting with ioredis](#connecting-with-ioredis)
   - [Connecting with node-redis](#connecting-with-node-redis)
-  - [Using in Unit Tests](#using-in-unit-tests)
-- [Cluster Mode](#cluster-mode)
-- [API Reference](#api-reference)
+- [Experimental: socketless client mocks](#experimental-socketless-client-mocks)
+  - [`createIoredisMock` — ioredis-mock replacement](#createioredismock--ioredis-mock-replacement)
+  - [`createNodeRedisMock` — node-redis in-memory mock](#createnoderedismock--node-redis-in-memory-mock)
+  - [`createInMemoryClient` — our own socketless client](#createinmemoryclient--our-own-socketless-client)
+- [Running a server (not a test mock)](#running-a-server-not-a-test-mock)
 - [Supported Commands](docs/COMMANDS.md)
 - [Requirements](#requirements)
 - [Development](#development)
 - [Contributing](#contributing)
 - [License](#license)
+
+## Why
+
+- **No real Redis to install, start, or clean up** — it's in-memory and starts in milliseconds.
+- **Isolated and reproducible** — a fresh keyspace per test, reset between tests.
+- **High fidelity** — your real client talks RESP over a real socket, so client-side encoding/parsing is part of the test.
+- **Standalone and cluster** — same API, just pass a `cluster` option.
 
 ## Features
 
@@ -44,128 +76,175 @@ In-memory Redis-compatible server implementation in JavaScript. Useful for testi
 npm install js-redis-server
 ```
 
-## Quick Start
+## Use as a Redis mock in tests
 
-Picking an entry point comes down to **one** question — _are you driving it from test code, or running a server something else connects to?_ Both handle standalone **and** cluster via the same `cluster` option, so that's the only axis you choose:
+`createRedisMock()` owns the whole lifecycle: it spins up a standalone server
+(16 databases, random free port) or a whole cluster, seeds data, and resets
+between tests — you just connect your real client library to it.
 
-| Your situation                                                                                 | Use                    | Standalone                                                | Cluster                                          |
-| :--------------------------------------------------------------------------------------------- | :--------------------- | :-------------------------------------------------------- | :----------------------------------------------- |
-| Writing tests / want an in-memory Redis you control from code (seed, reset, in-process client) | `createRedisMock`      | `createRedisMock()`                                       | `createRedisMock({ cluster: { masters: 3 } })`   |
-| Running a real, listening server a separate process connects to (CLI, dev tool)                | `createRedisServer`    | `createRedisServer()`                                     | `createRedisServer({ cluster: { masters: 3 } })` |
-| Assembling the pipeline by hand (custom commands/policies/transport)                           | `js-redis-server/core` | see [Advanced](#advanced-assembling-the-pipeline-by-hand) | —                                                |
+`RedisMock` surface:
 
-**Most users want `createRedisMock`.** It wraps `createRedisServer` and adds the test ergonomics. Reach for `createRedisServer` only when you need a long-running server without the test helpers.
+| Member                  | Description                                                                               |
+| :---------------------- | :---------------------------------------------------------------------------------------- |
+| `host` / `port` / `url` | Connection coordinates of the (first) node.                                               |
+| `addresses()`           | `{ host, port }[]` — one entry standalone, every node for cluster. Client-agnostic.       |
+| `seed(entries)`         | Preload data (see [Seeding](#seeding)).                                                   |
+| `client(opts?)`         | Socketless in-process client (see [Experimental](#experimental-socketless-client-mocks)). |
+| `flush()` / `reset()`   | Clear all keyspace data between tests.                                                    |
+| `close()`               | Shut down the server / cluster.                                                           |
+| `state` / `nodes`       | Escape hatches to the underlying `RedisServerState` / node handles.                       |
 
-### As a Test Mock (recommended)
-
-For test suites use the `createRedisMock()` facade. It spins up a standalone
-server (16 databases, random free port) or a whole cluster, seeds data, and
-resets between tests — no manual wiring:
+### node:test
 
 ```typescript
-import { createRedisMock } from 'js-redis-server'
+import { test, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert'
 import { Redis } from 'ioredis'
+import { createRedisMock, type RedisMock } from 'js-redis-server'
 
+let mock: RedisMock
+let client: Redis
+
+beforeEach(async () => {
+  mock = await createRedisMock()
+  client = new Redis(mock.addresses()[0])
+})
+
+afterEach(async () => {
+  client.disconnect()
+  await mock.close()
+})
+
+test('basic set/get operations', async () => {
+  await client.set('foo', 'bar')
+  assert.strictEqual(await client.get('foo'), 'bar')
+})
+```
+
+### vitest / jest
+
+```typescript
+import { beforeEach, afterEach, test, expect } from 'vitest' // or '@jest/globals'
+import { Redis } from 'ioredis'
+import { createRedisMock, type RedisMock } from 'js-redis-server'
+
+let mock: RedisMock
+let client: Redis
+
+beforeEach(async () => {
+  mock = await createRedisMock()
+  await mock.seed([{ key: 'counter', type: 'string', value: 1 }])
+  client = new Redis(mock.addresses()[0])
+})
+
+afterEach(async () => {
+  client.disconnect()
+  await mock.close()
+})
+
+test('increments a seeded counter', async () => {
+  expect(await client.incr('counter')).toBe(2)
+})
+```
+
+Prefer a fresh `createRedisMock()` per test for full isolation; to reuse one
+instance across a file, call `await mock.flush()` in `afterEach` instead.
+
+### Cluster mocks
+
+Same facade — pass `cluster` and connect a cluster client:
+
+```typescript
+const mock = await createRedisMock({ cluster: { masters: 3, replicas: 1 } })
+const cluster = new Redis.Cluster(mock.addresses())
+```
+
+### Seeding
+
+`seed()` takes an explicit entries array — you supply keys, types, values, and
+optional `ttlMs` / `db`; the mock owns placement (including cluster slot
+routing) and the internal value conversion.
+
+```typescript
 const mock = await createRedisMock()
-// or: await createRedisMock({ cluster: { masters: 3, replicas: 1 } })
 
 await mock.seed([
   { key: 'user:1', type: 'string', value: 'alice' },
   { key: 'counter', type: 'string', value: 42 },
-  { key: 'h:1', type: 'hash', value: { name: 'bob' }, ttlMs: 5000 },
-  { key: 'l:1', type: 'list', value: ['a', 'b'] },
+  { key: 'h:1', type: 'hash', value: { name: 'bob', age: 30 } },
+  { key: 'l:1', type: 'list', value: ['a', 'b', 1] },
   { key: 's:1', type: 'set', value: ['x', 'y'] },
   { key: 'z:1', type: 'zset', value: { a: 1, b: 2 } },
+  { key: 'ttl:1', type: 'string', value: 'temp', ttlMs: 50_000 },
+  { key: 'in-db-3', type: 'string', value: 'scoped', db: 3 },
 ])
 
-const client = new Redis(mock.connectionOptions())
-// cluster: new Redis.Cluster(mock.clusterNodes())
-
-await mock.flush() // reset between tests
-await mock.close()
+// any client connected to the mock now sees the seeded keys
+// (e.g. new Redis(mock.addresses()[0]) — GET user:1 → 'alice')
 ```
 
-See [Use as a Redis mock in tests](#use-as-a-redis-mock-in-tests) for `beforeEach`/`afterEach` recipes.
-
-### As a Standalone Server
-
-To run a real server you connect to (not a mock), use `createRedisServer()` —
-it wires the state, executor, and `Resp2Server` for you and starts listening:
+Each entry's shape is checked against its `type`:
 
 ```typescript
-import { createRedisServer } from 'js-redis-server'
-
-const { host, port, close } = await createRedisServer({ port: 6379 })
-console.log(`Redis server listening at ${host}:${port}`)
-
-// Cleanup
-await close()
+type SeedEntry =
+  | {
+      key: string
+      type: 'string'
+      value: string | number
+      ttlMs?: number
+      db?: number
+    }
+  | {
+      key: string
+      type: 'hash'
+      value: Record<string, string | number>
+      ttlMs?: number
+      db?: number
+    }
+  | {
+      key: string
+      type: 'list'
+      value: (string | number)[]
+      ttlMs?: number
+      db?: number
+    }
+  | {
+      key: string
+      type: 'set'
+      value: (string | number)[]
+      ttlMs?: number
+      db?: number
+    }
+  | {
+      key: string
+      type: 'zset'
+      value: Record<string, number>
+      ttlMs?: number
+      db?: number
+    }
 ```
 
-### As a CLI
+`db` selects the logical database (standalone mocks). Streams are not seedable
+yet. For anything beyond these shapes, drive your client directly or reach for
+the `mock.state` escape hatch.
 
-```bash
-# Run a single server on default port 6379
-npx js-redis-server
-
-# Run on a specific port
-npx js-redis-server --port 6380
-
-# Run a cluster with 3 masters
-npx js-redis-server --cluster --masters 3
-
-# Run a cluster with replicas
-npx js-redis-server --cluster --masters 3 --slaves 1
-```
-
-### CLI Options
-
-```
-Modes:
-  --single               Run a single Redis server (default)
-  --cluster              Run a Redis cluster
-  --mode <single|cluster>
-
-Single server options:
-  --port <number>        Port to listen on (default 6379)
-
-Cluster options:
-  --masters <number>     Number of masters (default 3)
-  --slaves <number>      Number of replicas per master (default 0)
-  --base-port <number>   Starting port for cluster nodes (default 30000)
-
-General:
-  -d, --debug            Enable debug logging
-  -h, --help             Show help
-```
-
-## Cluster Mode
-
-Pass `cluster` to `createRedisServer` (or `createRedisMock` for tests) — it
-builds **and** starts the cluster, returning a live handle:
+### `createRedisMock` options
 
 ```typescript
-import { createRedisServer } from 'js-redis-server'
-
-const cluster = await createRedisServer({
-  cluster: { masters: 3, replicas: 1 },
-  basePort: 30000,
-})
-
-// Get all node addresses
-console.log(cluster.nodes.map(n => `${n.host}:${n.port}`))
-
-// Cleanup
-await cluster.close()
+createRedisMock(options?: CreateRedisMockOptions): Promise<RedisMock>
 ```
 
-> Need control over _when_ the cluster starts listening? The lower-level
-> `createRedisCluster()` builder returns an un-started `RedisCluster` you call
-> `.listen()` on yourself. (`buildRedisCluster` is a deprecated alias of it.)
+| Parameter       | Type                                     | Default     | Description                                                  |
+| :-------------- | :--------------------------------------- | :---------- | :----------------------------------------------------------- |
+| `cluster`       | `{ masters: number; replicas?: number }` | `undefined` | When set, builds a cluster mock instead of a standalone one. |
+| `databaseCount` | `number`                                 | `16`        | Standalone-only: logical database count.                     |
+| `port`          | `number`                                 | `0`         | Standalone bind port (`0` = OS-assigned).                    |
+| `basePort`      | `number`                                 | `0`         | Cluster base port (`0` = each node OS-assigned).             |
+| `logger`        | `Pick<Logger, 'error'>`                  | `undefined` | Optional logger.                                             |
 
 ## Connecting Clients
 
-You can connect to `js-redis-server` using any standard Redis client.
+You can connect to a running mock (or server) using any standard Redis client.
 
 ### Protocol Version (RESP2 / RESP3)
 
@@ -222,124 +301,32 @@ const cluster = createCluster({
 await cluster.connect()
 ```
 
-## Use as a Redis mock in tests
+## Experimental: socketless client mocks
 
-`js-redis-server` starts instantly with no external Redis, so it makes a clean
-drop-in mock for test suites. The `createRedisMock()` facade owns the server
-lifecycle, seeding, and reset-between-tests; you just connect your real client
-library to it.
+> ⚠️ **Not recommended.** These return a client object directly — no socket, no
+> port — so they skip the real network round-trip and (in some cases) real RESP
+> encoding. They're faster and need no `addresses()` wiring, but they're
+> **lower fidelity** than the recommended path and the surfaces are still
+> evolving. Prefer [`createRedisMock`](#use-as-a-redis-mock-in-tests) + a real
+> client unless you have a specific reason not to.
 
-`RedisMock` surface:
+Three flavours, depending on which client you want to look like:
 
-| Member                  | Description                                                                 |
-| :---------------------- | :-------------------------------------------------------------------------- |
-| `host` / `port` / `url` | Connection coordinates of the (first) node.                                 |
-| `connectionOptions()`   | ioredis-shaped `{ host, port }` for a single client.                        |
-| `clusterNodes()`        | Seed-node list for `Redis.Cluster` (one entry for standalone).              |
-| `seed(entries)`         | Preload data (see [Seeding](#seeding)).                                     |
-| `client(opts?)`         | Socketless in-process client (see [Socketless client](#socketless-client)). |
-| `flush()` / `reset()`   | Clear all keyspace data between tests.                                      |
-| `close()`               | Shut down the server / cluster.                                             |
-| `state` / `nodes`       | Escape hatches to the underlying `RedisServerState` / node handles.         |
+| Helper                 | Looks like      | How                                                        |
+| :--------------------- | :-------------- | :--------------------------------------------------------- |
+| `createIoredisMock`    | `ioredis`       | the **real** ioredis client over a fake `net.Socket`       |
+| `createNodeRedisMock`  | `node-redis`    | a hand-written facade mirroring node-redis' public surface |
+| `createInMemoryClient` | our own bespoke | a thin client that returns native JS replies, no RESP      |
 
-### node:test
+### `createIoredisMock` — ioredis-mock replacement
 
-```typescript
-import { test, beforeEach, afterEach } from 'node:test'
-import assert from 'node:assert'
-import { Redis } from 'ioredis'
-import { createRedisMock, type RedisMock } from 'js-redis-server'
-
-let mock: RedisMock
-let client: Redis
-
-beforeEach(async () => {
-  mock = await createRedisMock()
-  client = new Redis(mock.connectionOptions())
-})
-
-afterEach(async () => {
-  client.disconnect()
-  await mock.close()
-})
-
-test('basic set/get operations', async () => {
-  await client.set('foo', 'bar')
-  assert.strictEqual(await client.get('foo'), 'bar')
-})
-```
-
-### vitest / jest
-
-```typescript
-import { beforeEach, afterEach, test, expect } from 'vitest' // or '@jest/globals'
-import { Redis } from 'ioredis'
-import { createRedisMock, type RedisMock } from 'js-redis-server'
-
-let mock: RedisMock
-let client: Redis
-
-beforeEach(async () => {
-  mock = await createRedisMock()
-  await mock.seed([{ key: 'counter', type: 'string', value: 1 }])
-  client = new Redis(mock.connectionOptions())
-})
-
-afterEach(async () => {
-  client.disconnect()
-  await mock.close()
-})
-
-test('increments a seeded counter', async () => {
-  expect(await client.incr('counter')).toBe(2)
-})
-```
-
-Prefer a fresh `createRedisMock()` per test for full isolation; to reuse one
-instance across a file, call `await mock.flush()` in `afterEach` instead.
-
-### Cluster mocks
-
-```typescript
-const mock = await createRedisMock({ cluster: { masters: 3, replicas: 1 } })
-const cluster = new Redis.Cluster(mock.clusterNodes())
-```
-
-### Socketless client
-
-If you don't need a real client library, `createInMemoryClient()` returns an
-in-process client with its **own** keyspace that drives the command pipeline
-directly — no TCP loopback, no RESP encoding — and resolves to native JS replies
-(throwing `RedisCommandError` on `-ERR`). It's the bespoke-client sibling of
-`createIoredisMock` / `createNodeRedisMock`; standalone only.
-
-```typescript
-import { createInMemoryClient } from 'js-redis-server'
-
-const client = await createInMemoryClient({
-  // databaseCount?, database?, returnBuffers?, seed?
-})
-
-await client.command('SET', 'k', 'v')
-await client.command('GET', 'k') // 'v'
-await client.command('INCR', 'n') // 1 (number)
-await client.command('HGETALL', 'h') // { field: 'value', ... }
-
-client.close() // tears down its keyspace
-```
-
-Need to drive an existing `createRedisMock()`'s keyspace instead of an
-independent one? Construct `InMemoryRedisClient` directly with that mock's
-`state` and an executor from `js-redis-server/core`.
-
-### Drop-in ioredis mock
-
-`createIoredisMock()` returns a **real** `ioredis` client wired to the in-memory
-pipeline over a fake `net.Socket` — no TCP port, no loopback. Because it's the
-genuine client speaking real RESP, typed methods, pipelines, `multi`, pub/sub,
-and `scanStream` all work unchanged. `ioredis` is an optional peer dependency,
-imported lazily, so the core stays dependency-free — install `ioredis` yourself
-to use this.
+A drop-in alternative to the [`ioredis-mock`](https://www.npmjs.com/package/ioredis-mock)
+library. `createIoredisMock()` returns a **real** `ioredis` client wired to the
+in-memory pipeline over a fake `net.Socket` — no TCP port, no loopback. Because
+it's the genuine client speaking real RESP, typed methods, pipelines, `multi`,
+pub/sub, and `scanStream` all work unchanged. `ioredis` is an optional peer
+dependency, imported lazily, so the core stays dependency-free — install
+`ioredis` yourself to use this.
 
 ```typescript
 import { createIoredisMock } from 'js-redis-server'
@@ -390,261 +377,76 @@ await redis.get('user:1') // 'alice'
 // cluster: createIoredisMock({ cluster: { masters: 3 }, seed: [...] })
 ```
 
-### Seeding
+### `createNodeRedisMock` — node-redis in-memory mock
 
-`seed()` takes an explicit entries array — you supply keys, types, values, and
-optional `ttlMs` / `db`; the mock owns placement (including cluster slot
-routing) and the internal value conversion.
-
-```typescript
-const mock = await createRedisMock()
-
-await mock.seed([
-  { key: 'user:1', type: 'string', value: 'alice' },
-  { key: 'counter', type: 'string', value: 42 },
-  { key: 'h:1', type: 'hash', value: { name: 'bob', age: 30 } },
-  { key: 'l:1', type: 'list', value: ['a', 'b', 1] },
-  { key: 's:1', type: 'set', value: ['x', 'y'] },
-  { key: 'z:1', type: 'zset', value: { a: 1, b: 2 } },
-  { key: 'ttl:1', type: 'string', value: 'temp', ttlMs: 50_000 },
-  { key: 'in-db-3', type: 'string', value: 'scoped', db: 3 },
-])
-
-// any client connected to the mock now sees the seeded keys
-// (e.g. new Redis(mock.connectionOptions()) — GET user:1 → 'alice')
-```
-
-`createInMemoryClient()` takes the same `seed` array to pre-populate its own
-keyspace before the first command.
-
-Each entry's shape is checked against its `type`:
+node-redis exposes no socket hook, so this can't drive the real client over a
+virtual socket the way `createIoredisMock` does. Instead `createNodeRedisMock()`
+returns a **hand-written facade** that mirrors node-redis' public surface — a
+curated set of camelCase methods with node-redis-correct return types — and
+routes every command through the same in-memory pipeline. Anything not curated
+falls through to the generic `sendCommand()` escape hatch, which decodes replies
+to native JS.
 
 ```typescript
-type SeedEntry =
-  | {
-      key: string
-      type: 'string'
-      value: string | number
-      ttlMs?: number
-      db?: number
-    }
-  | {
-      key: string
-      type: 'hash'
-      value: Record<string, string | number>
-      ttlMs?: number
-      db?: number
-    }
-  | {
-      key: string
-      type: 'list'
-      value: (string | number)[]
-      ttlMs?: number
-      db?: number
-    }
-  | {
-      key: string
-      type: 'set'
-      value: (string | number)[]
-      ttlMs?: number
-      db?: number
-    }
-  | {
-      key: string
-      type: 'zset'
-      value: Record<string, number>
-      ttlMs?: number
-      db?: number
-    }
+import { createNodeRedisMock } from 'js-redis-server'
+
+const client = await createNodeRedisMock() // 16 logical DBs by default
+
+await client.set('k', 'v')
+await client.get('k') // 'v'
+await client.sendCommand(['HSET', 'h', 'f1', 'a']) // escape hatch
+
+await client.quit() // tears down the in-memory state
 ```
 
-`db` selects the logical database (standalone mocks). Streams are not seedable
-yet. For anything beyond these shapes, drive your client directly or reach for
-the `mock.state` escape hatch.
-
-### Package entry points
-
-The package ships dual ESM + CJS builds with two import surfaces:
-
-**Root (`js-redis-server`)** — the curated consumer surface: the `create*`
-builders, seeding, the socketless client, and the client-visible error classes.
-This is all most users ever need.
+Pass `cluster` for a cluster facade; keyed commands route by slot in-process:
 
 ```typescript
-import {
-  createRedisMock,
-  createRedisCluster,
-  RedisCommandError,
-} from 'js-redis-server'
+const cluster = await createNodeRedisMock({
+  cluster: { masters: 3, replicas: 1 },
+})
+
+await cluster.set('alpha', '1')
+await cluster.get('alpha') // '1'
+
+await cluster.quit()
 ```
 
-**Core (`js-redis-server/core`)** — the building blocks for assembling the
-pipeline by hand: `Resp2Server`, `RedisServerState`, `createRedisCommandExecutor`,
-`defineCommand`, the `t` schema builder, execution policies, transports, the Lua
-runtime, data-type helpers, etc. These are **not** exported from the root.
+### `createInMemoryClient` — our own socketless client
+
+If you don't need to look like any particular client library,
+`createInMemoryClient()` returns an in-process client with its **own** keyspace
+that drives the command pipeline directly — no TCP loopback, no RESP encoding —
+and resolves to native JS replies (throwing `RedisCommandError` on `-ERR`).
+Standalone only.
 
 ```typescript
-import {
-  Resp2Server,
-  RedisServerState,
-  createRedisCommandExecutor,
-  defineCommand,
-  t,
-} from 'js-redis-server/core'
+import { createInMemoryClient } from 'js-redis-server'
+
+const client = await createInMemoryClient({
+  // databaseCount?, database?, returnBuffers?, seed?
+})
+
+await client.command('SET', 'k', 'v')
+await client.command('GET', 'k') // 'v'
+await client.command('INCR', 'n') // 1 (number)
+await client.command('HGETALL', 'h') // { field: 'value', ... }
+
+client.close() // tears down its keyspace
 ```
 
-### Advanced: assembling the pipeline by hand
+It takes the same `seed` array as `createRedisMock().seed()` to pre-populate its
+keyspace before the first command. Need to drive an existing `createRedisMock()`'s
+keyspace instead of an independent one? Construct `InMemoryRedisClient` directly
+with that mock's `state` and an executor from `js-redis-server/core`.
 
-`createRedisServer()` is the supported way to run a standalone server. If you
-need full control — a custom command registry, extra execution policies, a
-non-default transport — wire the pieces yourself from `js-redis-server/core`:
+## Running a server (not a test mock)
 
-```typescript
-import {
-  RedisServerState,
-  createRedisCommandExecutor,
-  Resp2Server,
-} from 'js-redis-server/core'
-
-const state = new RedisServerState()
-const executor = createRedisCommandExecutor()
-const server = new Resp2Server({ server: state, executor })
-
-await server.listen(6379)
-console.log(`Redis server listening at ${server.getAddress()}`)
-
-await server.close()
-```
-
-## API Reference
-
-### `Resp2Server`
-
-Creates a TCP server running the RESP2 protocol. Most users should prefer
-[`createRedisServer`](#createredisserver), which wires this up for you.
-
-> Imported from the `js-redis-server/core` subpath, not the package root.
-
-```typescript
-import { Resp2Server } from 'js-redis-server/core'
-
-new Resp2Server(options: Resp2ServerOptions)
-```
-
-**Options (`Resp2ServerOptions`)**:
-
-| Parameter  | Type                    | Required | Description                                                    |
-| :--------- | :---------------------- | :------- | :------------------------------------------------------------- |
-| `server`   | `RedisServerState`      | Yes      | The database server state containing database instances.       |
-| `executor` | `CommandExecutor`       | Yes      | The command executor handling pipeline and execution policies. |
-| `logger`   | `Pick<Logger, 'error'>` | No       | Optional logger for error logging.                             |
-| `encoder`  | `RespEncodeOptions`     | No       | Custom RESP protocol encoding options.                         |
-
----
-
-### `RedisServerState`
-
-Holds the database and keyspace state for the server.
-
-> Imported from the `js-redis-server/core` subpath, not the package root.
-
-```typescript
-import { RedisServerState } from 'js-redis-server/core'
-
-new RedisServerState(options?: RedisServerStateOptions)
-```
-
-**Options (`RedisServerStateOptions`)**:
-
-| Parameter         | Type                   | Default     | Description                                 |
-| :---------------- | :--------------------- | :---------- | :------------------------------------------ |
-| `databaseCount`   | `number`               | `1`         | Number of databases to initialize.          |
-| `clusterTopology` | `RedisClusterTopology` | `undefined` | Optional cluster topology for slot routing. |
-| `pubsubBroker`    | `RedisPubSubBroker`    | `undefined` | Optional broker for pub/sub operations.     |
-| `scriptCache`     | `RedisScriptCache`     | `undefined` | Optional cache for Lua scripts.             |
-
----
-
-### `createRedisCluster`
-
-Low-level builder that returns an **un-started** `RedisCluster` — call
-`.listen()` yourself.
-
-> **Prefer [`createRedisServer`](#createredisserver) with the `cluster` option**,
-> which builds and starts the cluster in one call. Use this builder only when you
-> need control over when `listen()` runs. (`buildRedisCluster` is a deprecated
-> alias of this function.)
-
-```typescript
-createRedisCluster(options: RedisClusterOptions): RedisCluster
-```
-
-**Options (`RedisClusterOptions`)**:
-
-| Parameter           | Type                    | Default       | Description                                            |
-| :------------------ | :---------------------- | :------------ | :----------------------------------------------------- |
-| `masters`           | `number`                | **Required**  | Number of master nodes in the cluster.                 |
-| `replicasPerMaster` | `number`                | `0`           | Replicas per master node.                              |
-| `basePort`          | `number`                | **Required**  | Base port range. If `0`, random OS ports are assigned. |
-| `host`              | `string`                | `'127.0.0.1'` | Host address to bind to.                               |
-| `databasesPerNode`  | `number`                | `1`           | Number of databases per cluster node.                  |
-| `logger`            | `Pick<Logger, 'error'>` | `undefined`   | Optional logger.                                       |
-
----
-
-### `createRedisMock`
-
-High-level test-mock facade. Returns a `RedisMock` wrapping a standalone server
-(default) or a cluster.
-
-```typescript
-createRedisMock(options?: CreateRedisMockOptions): Promise<RedisMock>
-```
-
-**Options (`CreateRedisMockOptions`)**:
-
-| Parameter       | Type                                     | Default     | Description                                                  |
-| :-------------- | :--------------------------------------- | :---------- | :----------------------------------------------------------- |
-| `cluster`       | `{ masters: number; replicas?: number }` | `undefined` | When set, builds a cluster mock instead of a standalone one. |
-| `databaseCount` | `number`                                 | `16`        | Standalone-only: logical database count.                     |
-| `port`          | `number`                                 | `0`         | Standalone bind port (`0` = OS-assigned).                    |
-| `basePort`      | `number`                                 | `0`         | Cluster base port (`0` = each node OS-assigned).             |
-| `logger`        | `Pick<Logger, 'error'>`                  | `undefined` | Optional logger.                                             |
-
----
-
-### `createRedisServer`
-
-Runs a real, **listening** server. Standalone by default — wires
-`RedisServerState` (16 databases), the command executor, and a `Resp2Server`,
-then listens, returning a `{ host, port, state, server, close() }` handle. Pass
-`cluster` to build and start a whole cluster instead; that overload resolves to
-a live `RedisCluster` (same shape `createRedisCluster` returns, already
-listening).
-
-```typescript
-// standalone
-createRedisServer(options?: CreateRedisServerOptions): Promise<RedisServerHandle>
-// cluster
-createRedisServer(options: CreateRedisServerClusterOptions): Promise<RedisCluster>
-```
-
-**Standalone options (`CreateRedisServerOptions`)**:
-
-| Parameter       | Type                    | Default     | Description                                  |
-| :-------------- | :---------------------- | :---------- | :------------------------------------------- |
-| `port`          | `number`                | `0`         | Bind port (`0` = OS-assigned).               |
-| `databaseCount` | `number`                | `16`        | Logical database count (matches real Redis). |
-| `logger`        | `Pick<Logger, 'error'>` | `undefined` | Optional logger.                             |
-
-**Cluster options (`CreateRedisServerClusterOptions`)**:
-
-| Parameter          | Type                                     | Default      | Description                                      |
-| :----------------- | :--------------------------------------- | :----------- | :----------------------------------------------- |
-| `cluster`          | `{ masters: number; replicas?: number }` | **Required** | Builds a cluster instead of a standalone server. |
-| `basePort`         | `number`                                 | `0`          | Cluster base port (`0` = each node OS-assigned). |
-| `databasesPerNode` | `number`                                 | `1`          | Databases per cluster node.                      |
-| `logger`           | `Pick<Logger, 'error'>`                  | `undefined`  | Optional logger.                                 |
+Need a real, **listening** server a separate process connects to (a CLI, a dev
+tool), or want to assemble the pipeline by hand with custom commands/policies?
+That lives in the **[Server & Low-Level API](docs/API.md)** doc:
+`createRedisServer`, `createRedisCluster`, the CLI, `Resp2Server`,
+`RedisServerState`, and package entry points.
 
 ## Requirements
 
@@ -684,8 +486,7 @@ npm run test:all
 
 ## Further Documentation
 
-For more details on the architecture, testing infrastructure, and command support, see:
-
+- [Server & Low-Level API](docs/API.md) — running a listening server, the CLI, cluster builders, and the `core` building blocks
 - [Architecture](docs/ARCHITECTURE.md) — layers, command pipeline, execution policies, cluster routing, RESP2/RESP3, and diagrams
 - [Detailed Command Implementation Status](docs/COMMANDS.md)
 - [Integration Testing Infrastructure](docs/TEST-INTEGRATION.md)

--- a/README.md
+++ b/README.md
@@ -35,15 +35,12 @@ production. Jump to [Use as a Redis mock in tests](#use-as-a-redis-mock-in-tests
 - [Features](#features)
 - [Installation](#installation)
 - [Use as a Redis mock in tests](#use-as-a-redis-mock-in-tests)
+  - [Connecting your client](#connecting-your-client)
   - [node:test](#nodetest)
   - [vitest / jest](#vitest--jest)
   - [Cluster mocks](#cluster-mocks)
   - [Seeding](#seeding)
   - [`createRedisMock` options](#createredismock-options)
-- [Connecting Clients](#connecting-clients)
-  - [Protocol Version (RESP2 / RESP3)](#protocol-version-resp2--resp3)
-  - [Connecting with ioredis](#connecting-with-ioredis)
-  - [Connecting with node-redis](#connecting-with-node-redis)
 - [Experimental: socketless client mocks](#experimental-socketless-client-mocks)
   - [`createIoredisMock` — ioredis-mock replacement](#createioredismock--ioredis-mock-replacement)
   - [`createNodeRedisMock` — node-redis in-memory mock](#createnoderedismock--node-redis-in-memory-mock)
@@ -84,14 +81,34 @@ between tests — you just connect your real client library to it.
 
 `RedisMock` surface:
 
-| Member                  | Description                                                                               |
-| :---------------------- | :---------------------------------------------------------------------------------------- |
-| `host` / `port` / `url` | Connection coordinates of the (first) node.                                               |
-| `addresses()`           | `{ host, port }[]` — one entry standalone, every node for cluster. Client-agnostic.       |
-| `seed(entries)`         | Preload data (see [Seeding](#seeding)).                                                   |
-| `flush()` / `reset()`   | Clear all keyspace data between tests.                                                    |
-| `close()`               | Shut down the server / cluster.                                                           |
-| `state` / `nodes`       | Escape hatches to the underlying `RedisServerState` / node handles.                       |
+| Member                  | Description                                                                         |
+| :---------------------- | :---------------------------------------------------------------------------------- |
+| `host` / `port` / `url` | Connection coordinates of the (first) node.                                         |
+| `addresses()`           | `{ host, port }[]` — one entry standalone, every node for cluster. Client-agnostic. |
+| `seed(entries)`         | Preload data (see [Seeding](#seeding)).                                             |
+| `flush()` / `reset()`   | Clear all keyspace data between tests.                                              |
+| `close()`               | Shut down the server / cluster.                                                     |
+| `state` / `nodes`       | Escape hatches to the underlying `RedisServerState` / node handles.                 |
+
+### Connecting your client
+
+A mock is a real server on a random free port, so connect any standard client
+to `mock.addresses()` / `mock.url`:
+
+```typescript
+// ioredis
+import { Redis } from 'ioredis'
+const redis = new Redis(mock.addresses()[0])
+
+// node-redis
+import { createClient } from 'redis'
+const client = createClient({ url: mock.url })
+await client.connect()
+```
+
+Connections start on RESP2 and upgrade to RESP3 when the client asks for it
+(ioredis sends `HELLO 3`; node-redis takes a `RESP: 3` option) — negotiated
+per-connection, no special setup.
 
 ### node:test
 
@@ -151,11 +168,25 @@ instance across a file, call `await mock.flush()` in `afterEach` instead.
 
 ### Cluster mocks
 
-Same facade — pass `cluster` and connect a cluster client:
+Same facade — pass `cluster`, then point a cluster client at every node via
+`mock.addresses()`:
 
 ```typescript
 const mock = await createRedisMock({ cluster: { masters: 3, replicas: 1 } })
+```
+
+```typescript
+// ioredis
 const cluster = new Redis.Cluster(mock.addresses())
+```
+
+```typescript
+// node-redis
+import { createCluster } from 'redis'
+const cluster = createCluster({
+  rootNodes: mock.addresses().map(n => ({ url: `redis://${n.host}:${n.port}` })),
+})
+await cluster.connect()
 ```
 
 ### Seeding
@@ -240,65 +271,6 @@ createRedisMock(options?: CreateRedisMockOptions): Promise<RedisMock>
 | `port`          | `number`                                 | `0`         | Standalone bind port (`0` = OS-assigned).                    |
 | `basePort`      | `number`                                 | `0`         | Cluster base port (`0` = each node OS-assigned).             |
 | `logger`        | `Pick<Logger, 'error'>`                  | `undefined` | Optional logger.                                             |
-
-## Connecting Clients
-
-You can connect to a running mock (or server) using any standard Redis client.
-
-### Protocol Version (RESP2 / RESP3)
-
-Each connection starts on RESP2 and can switch to RESP3 by sending `HELLO 3`
-(handled per-session, no server restart needed). Clients that support RESP3
-negotiate this automatically:
-
-```typescript
-import { createClient } from 'redis'
-
-// node-redis negotiates RESP3 via the `RESP` option
-const client = createClient({
-  url: 'redis://127.0.0.1:6379',
-  RESP: 3,
-})
-await client.connect()
-```
-
-### Connecting with ioredis
-
-```typescript
-import Redis from 'ioredis'
-
-// Single Node
-const redis = new Redis(6379, '127.0.0.1')
-
-// Cluster Node
-const cluster = new Redis.Cluster([
-  { host: '127.0.0.1', port: 30000 },
-  { host: '127.0.0.1', port: 30001 },
-  { host: '127.0.0.1', port: 30002 },
-])
-```
-
-### Connecting with node-redis
-
-```typescript
-import { createClient, createCluster } from 'redis'
-
-// Single Node
-const client = createClient({
-  url: 'redis://127.0.0.1:6379',
-})
-await client.connect()
-
-// Cluster Node
-const cluster = createCluster({
-  rootNodes: [
-    { url: 'redis://127.0.0.1:30000' },
-    { url: 'redis://127.0.0.1:30001' },
-    { url: 'redis://127.0.0.1:30002' },
-  ],
-})
-await cluster.connect()
-```
 
 ## Experimental: socketless client mocks
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ between tests — you just connect your real client library to it.
 | `host` / `port` / `url` | Connection coordinates of the (first) node.                                               |
 | `addresses()`           | `{ host, port }[]` — one entry standalone, every node for cluster. Client-agnostic.       |
 | `seed(entries)`         | Preload data (see [Seeding](#seeding)).                                                   |
-| `client(opts?)`         | Socketless in-process client (see [Experimental](#experimental-socketless-client-mocks)). |
 | `flush()` / `reset()`   | Clear all keyspace data between tests.                                                    |
 | `close()`               | Shut down the server / cluster.                                                           |
 | `state` / `nodes`       | Escape hatches to the underlying `RedisServerState` / node handles.                       |

--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ const cluster = new Redis.Cluster(mock.addresses())
 // node-redis
 import { createCluster } from 'redis'
 const cluster = createCluster({
-  rootNodes: mock.addresses().map(n => ({ url: `redis://${n.host}:${n.port}` })),
+  rootNodes: mock
+    .addresses()
+    .map(n => ({ url: `redis://${n.host}:${n.port}` })),
 })
 await cluster.connect()
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,261 @@
+# Server & Low-Level API
+
+The [README](../README.md) covers the primary use case — an in-memory Redis
+mock for tests. This document covers the rest: running a **real, listening**
+server, building a cluster, and assembling the pipeline by hand.
+
+> Most users never need anything here. If you're writing tests, use
+> [`createRedisMock`](../README.md#use-as-a-redis-mock-in-tests).
+
+## Table of Contents
+
+- [Running a Standalone Server](#running-a-standalone-server)
+- [Running a Cluster](#running-a-cluster)
+- [CLI](#cli)
+- [Package Entry Points](#package-entry-points)
+- [Advanced: Assembling the Pipeline by Hand](#advanced-assembling-the-pipeline-by-hand)
+- [API Reference](#api-reference)
+  - [`createRedisServer`](#createredisserver)
+  - [`createRedisCluster`](#createrediscluster)
+  - [`Resp2Server`](#resp2server)
+  - [`RedisServerState`](#redisserverstate)
+
+## Running a Standalone Server
+
+To run a real server you connect to (not a test mock), use `createRedisServer()`
+— it wires the state, executor, and `Resp2Server` for you and starts listening:
+
+```typescript
+import { createRedisServer } from 'js-redis-server'
+
+const { host, port, close } = await createRedisServer({ port: 6379 })
+console.log(`Redis server listening at ${host}:${port}`)
+
+// Cleanup
+await close()
+```
+
+## Running a Cluster
+
+Pass `cluster` to `createRedisServer` — it builds **and** starts the cluster,
+returning a live handle:
+
+```typescript
+import { createRedisServer } from 'js-redis-server'
+
+const cluster = await createRedisServer({
+  cluster: { masters: 3, replicas: 1 },
+  basePort: 30000,
+})
+
+// Get all node addresses
+console.log(cluster.nodes.map(n => `${n.host}:${n.port}`))
+
+// Cleanup
+await cluster.close()
+```
+
+> Need control over _when_ the cluster starts listening? The lower-level
+> [`createRedisCluster()`](#createrediscluster) builder returns an un-started
+> `RedisCluster` you call `.listen()` on yourself. (`buildRedisCluster` is a
+> deprecated alias of it.)
+
+## CLI
+
+```bash
+# Run a single server on default port 6379
+npx js-redis-server
+
+# Run on a specific port
+npx js-redis-server --port 6380
+
+# Run a cluster with 3 masters
+npx js-redis-server --cluster --masters 3
+
+# Run a cluster with replicas
+npx js-redis-server --cluster --masters 3 --slaves 1
+```
+
+CLI options:
+
+```
+Modes:
+  --single               Run a single Redis server (default)
+  --cluster              Run a Redis cluster
+  --mode <single|cluster>
+
+Single server options:
+  --port <number>        Port to listen on (default 6379)
+
+Cluster options:
+  --masters <number>     Number of masters (default 3)
+  --slaves <number>      Number of replicas per master (default 0)
+  --base-port <number>   Starting port for cluster nodes (default 30000)
+
+General:
+  -d, --debug            Enable debug logging
+  -h, --help             Show help
+```
+
+## Package Entry Points
+
+The package ships dual ESM + CJS builds with two import surfaces:
+
+**Root (`js-redis-server`)** — the curated consumer surface: the `create*`
+builders, seeding, the socketless client, and the client-visible error classes.
+This is all most users ever need.
+
+```typescript
+import {
+  createRedisMock,
+  createRedisCluster,
+  RedisCommandError,
+} from 'js-redis-server'
+```
+
+**Core (`js-redis-server/core`)** — the building blocks for assembling the
+pipeline by hand: `Resp2Server`, `RedisServerState`, `createRedisCommandExecutor`,
+`defineCommand`, the `t` schema builder, execution policies, transports, the Lua
+runtime, data-type helpers, etc. These are **not** exported from the root.
+
+```typescript
+import {
+  Resp2Server,
+  RedisServerState,
+  createRedisCommandExecutor,
+  defineCommand,
+  t,
+} from 'js-redis-server/core'
+```
+
+## Advanced: Assembling the Pipeline by Hand
+
+`createRedisServer()` is the supported way to run a standalone server. If you
+need full control — a custom command registry, extra execution policies, a
+non-default transport — wire the pieces yourself from `js-redis-server/core`:
+
+```typescript
+import {
+  RedisServerState,
+  createRedisCommandExecutor,
+  Resp2Server,
+} from 'js-redis-server/core'
+
+const state = new RedisServerState()
+const executor = createRedisCommandExecutor()
+const server = new Resp2Server({ server: state, executor })
+
+await server.listen(6379)
+console.log(`Redis server listening at ${server.getAddress()}`)
+
+await server.close()
+```
+
+## API Reference
+
+### `createRedisServer`
+
+Runs a real, **listening** server. Standalone by default — wires
+`RedisServerState` (16 databases), the command executor, and a `Resp2Server`,
+then listens, returning a `{ host, port, state, server, close() }` handle. Pass
+`cluster` to build and start a whole cluster instead; that overload resolves to
+a live `RedisCluster` (same shape `createRedisCluster` returns, already
+listening).
+
+```typescript
+// standalone
+createRedisServer(options?: CreateRedisServerOptions): Promise<RedisServerHandle>
+// cluster
+createRedisServer(options: CreateRedisServerClusterOptions): Promise<RedisCluster>
+```
+
+**Standalone options (`CreateRedisServerOptions`)**:
+
+| Parameter       | Type                    | Default     | Description                                  |
+| :-------------- | :---------------------- | :---------- | :------------------------------------------- |
+| `port`          | `number`                | `0`         | Bind port (`0` = OS-assigned).               |
+| `databaseCount` | `number`                | `16`        | Logical database count (matches real Redis). |
+| `logger`        | `Pick<Logger, 'error'>` | `undefined` | Optional logger.                             |
+
+**Cluster options (`CreateRedisServerClusterOptions`)**:
+
+| Parameter          | Type                                     | Default      | Description                                      |
+| :----------------- | :--------------------------------------- | :----------- | :----------------------------------------------- |
+| `cluster`          | `{ masters: number; replicas?: number }` | **Required** | Builds a cluster instead of a standalone server. |
+| `basePort`         | `number`                                 | `0`          | Cluster base port (`0` = each node OS-assigned). |
+| `databasesPerNode` | `number`                                 | `1`          | Databases per cluster node.                      |
+| `logger`           | `Pick<Logger, 'error'>`                  | `undefined`  | Optional logger.                                 |
+
+---
+
+### `createRedisCluster`
+
+Low-level builder that returns an **un-started** `RedisCluster` — call
+`.listen()` yourself.
+
+> **Prefer [`createRedisServer`](#createredisserver) with the `cluster` option**,
+> which builds and starts the cluster in one call. Use this builder only when you
+> need control over when `listen()` runs. (`buildRedisCluster` is a deprecated
+> alias of this function.)
+
+```typescript
+createRedisCluster(options: RedisClusterOptions): RedisCluster
+```
+
+**Options (`RedisClusterOptions`)**:
+
+| Parameter           | Type                    | Default       | Description                                            |
+| :------------------ | :---------------------- | :------------ | :----------------------------------------------------- |
+| `masters`           | `number`                | **Required**  | Number of master nodes in the cluster.                 |
+| `replicasPerMaster` | `number`                | `0`           | Replicas per master node.                              |
+| `basePort`          | `number`                | **Required**  | Base port range. If `0`, random OS ports are assigned. |
+| `host`              | `string`                | `'127.0.0.1'` | Host address to bind to.                               |
+| `databasesPerNode`  | `number`                | `1`           | Number of databases per cluster node.                  |
+| `logger`            | `Pick<Logger, 'error'>` | `undefined`   | Optional logger.                                       |
+
+---
+
+### `Resp2Server`
+
+Creates a TCP server running the RESP2 protocol. Most users should prefer
+[`createRedisServer`](#createredisserver), which wires this up for you.
+
+> Imported from the `js-redis-server/core` subpath, not the package root.
+
+```typescript
+import { Resp2Server } from 'js-redis-server/core'
+
+new Resp2Server(options: Resp2ServerOptions)
+```
+
+**Options (`Resp2ServerOptions`)**:
+
+| Parameter  | Type                    | Required | Description                                                    |
+| :--------- | :---------------------- | :------- | :------------------------------------------------------------- |
+| `server`   | `RedisServerState`      | Yes      | The database server state containing database instances.       |
+| `executor` | `CommandExecutor`       | Yes      | The command executor handling pipeline and execution policies. |
+| `logger`   | `Pick<Logger, 'error'>` | No       | Optional logger for error logging.                             |
+| `encoder`  | `RespEncodeOptions`     | No       | Custom RESP protocol encoding options.                         |
+
+---
+
+### `RedisServerState`
+
+Holds the database and keyspace state for the server.
+
+> Imported from the `js-redis-server/core` subpath, not the package root.
+
+```typescript
+import { RedisServerState } from 'js-redis-server/core'
+
+new RedisServerState(options?: RedisServerStateOptions)
+```
+
+**Options (`RedisServerStateOptions`)**:
+
+| Parameter         | Type                   | Default     | Description                                 |
+| :---------------- | :--------------------- | :---------- | :------------------------------------------ |
+| `databaseCount`   | `number`               | `1`         | Number of databases to initialize.          |
+| `clusterTopology` | `RedisClusterTopology` | `undefined` | Optional cluster topology for slot routing. |
+| `pubsubBroker`    | `RedisPubSubBroker`    | `undefined` | Optional broker for pub/sub operations.     |
+| `scriptCache`     | `RedisScriptCache`     | `undefined` | Optional cache for Lua scripts.             |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -452,8 +452,8 @@ beside it:
   and the mock never drift.
 - cluster mocks delegate straight to `createRedisCluster`.
 
-The returned `RedisMock` exposes connection helpers (`connectionOptions()`,
-`clusterNodes()`, `url`), `flush()`/`reset()` (→ `state.flushAllDatabases()` or
+The returned `RedisMock` exposes connection helpers (`addresses()`, `url`),
+`flush()`/`reset()` (→ `state.flushAllDatabases()` or
 a cluster fan-out), and `state`/`nodes` escape hatches.
 
 [`createInMemoryClient`](../src/in-memory-client.ts) returns an

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -415,7 +415,7 @@ then encode as their native RESP3 types (`%`, `%`, `~`, `,`, `#`, `(`, `>`)
 instead of being downgraded to arrays/bulk-strings. `map` downgrades to a flat
 RESP2 key/value array, while `mapPairs` downgrades to a RESP2 array of
 `[key, value]` pairs for commands like `XREAD`. See the
-[README's protocol-version section](../README.md#protocol-version-resp2--resp3)
+[README's "Connecting your client" section](../README.md#connecting-your-client)
 for the client-facing view of this negotiation.
 
 ## Cluster mode

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -132,10 +132,15 @@ export interface RedisMock {
   readonly host: string
   readonly port: number
   readonly url: string
-  /** ioredis-shaped single-node connection options. */
-  connectionOptions(): RedisAddress
-  /** Seed-node list for ioredis `Cluster` (single entry for standalone mocks). */
-  clusterNodes(): RedisAddress[]
+  /**
+   * Node addresses as `{ host, port }[]` — a single entry for standalone mocks,
+   * every node for cluster mocks. Client-agnostic: index `[0]` for a single
+   * client, or pass the whole array to a cluster client.
+   *
+   * @example new Redis(mock.addresses()[0])         // ioredis, standalone
+   * @example new Redis.Cluster(mock.addresses())    // ioredis, cluster
+   */
+  addresses(): RedisAddress[]
   seed(entries: readonly SeedEntry[]): Promise<void>
   flush(): Promise<void>
   /** Alias for {@link RedisMock.flush}. */
@@ -184,8 +189,7 @@ async function createTcpStandaloneMock(
     host: address.host,
     port: address.port,
     url: `redis://${address.host}:${address.port}`,
-    connectionOptions: () => ({ ...address }),
-    clusterNodes: () => [{ ...address }],
+    addresses: () => [{ ...address }],
     seed: entries => seedStandalone(state, entries),
     flush: async () => state.flushAllDatabases(),
     reset: async () => state.flushAllDatabases(),
@@ -215,8 +219,7 @@ async function createClusterMock(
     host: first.host,
     port: first.port,
     url: `redis://${first.host}:${first.port}`,
-    connectionOptions: () => ({ host: first.host, port: first.port }),
-    clusterNodes: () =>
+    addresses: () =>
       built.nodes.map(node => ({ host: node.host, port: node.port })),
     seed: entries => seedCluster(built, entries),
     flush: () => flushCluster(built),

--- a/tests-integration/ioredis/seed-mock.test.ts
+++ b/tests-integration/ioredis/seed-mock.test.ts
@@ -23,7 +23,7 @@ describe('createRedisMock seed readback via ioredis (standalone)', () => {
       { key: 'ttl:1', type: 'string', value: 'temp', ttlMs: 50_000 },
       { key: 'in-db-3', type: 'string', value: 'scoped', db: 3 },
     ])
-    client = new Redis({ ...mock.connectionOptions(), lazyConnect: true })
+    client = new Redis({ ...mock.addresses()[0], lazyConnect: true })
     await client.connect()
   })
 
@@ -98,7 +98,7 @@ describe('createRedisMock seed readback via ioredis (cluster)', () => {
       { key: 's:1', type: 'set', value: ['x', 'y'] },
       { key: 'z:1', type: 'zset', value: { a: 1, b: 2 } },
     ])
-    cluster = new Redis.Cluster(mock.clusterNodes(), {
+    cluster = new Redis.Cluster(mock.addresses(), {
       lazyConnect: true,
       slotsRefreshTimeout: 10_000_000,
     })

--- a/tests-integration/node-redis/seed-mock.test.ts
+++ b/tests-integration/node-redis/seed-mock.test.ts
@@ -106,7 +106,7 @@ describe('createRedisMock seed readback via node-redis (cluster)', () => {
       { key: 'z:1', type: 'zset', value: { a: 1, b: 2 } },
     ])
     cluster = createCluster({
-      rootNodes: mock.clusterNodes().map(node => ({
+      rootNodes: mock.addresses().map(node => ({
         url: `redis://${node.host}:${node.port}`,
       })),
     }) as RedisClusterType

--- a/tests/mock.test.ts
+++ b/tests/mock.test.ts
@@ -36,11 +36,7 @@ describe('createRedisMock standalone', () => {
     assert.strictEqual(mock.host, '127.0.0.1')
     assert.ok(mock.port > 0)
     assert.strictEqual(mock.url, `redis://127.0.0.1:${mock.port}`)
-    assert.deepStrictEqual(mock.connectionOptions(), {
-      host: '127.0.0.1',
-      port: mock.port,
-    })
-    assert.deepStrictEqual(mock.clusterNodes(), [
+    assert.deepStrictEqual(mock.addresses(), [
       { host: '127.0.0.1', port: mock.port },
     ])
     assert.ok(mock.state)
@@ -71,7 +67,7 @@ describe('createRedisMock cluster', () => {
 
   test('exposes cluster node list and escape hatch', async () => {
     mock = await createRedisMock({ cluster: { masters: 3 } })
-    assert.strictEqual(mock.clusterNodes().length, 3)
+    assert.strictEqual(mock.addresses().length, 3)
     assert.ok(mock.nodes)
     assert.strictEqual(mock.state, undefined)
   })

--- a/tests/public-interface.test.ts
+++ b/tests/public-interface.test.ts
@@ -126,11 +126,7 @@ describe('public interface — createRedisMock', () => {
   test('tcp standalone exposes the documented surface', async () => {
     mock = await createRedisMock()
     assert.strictEqual(mock.url, `redis://127.0.0.1:${mock.port}`)
-    assert.deepStrictEqual(mock.connectionOptions(), {
-      host: '127.0.0.1',
-      port: mock.port,
-    })
-    assert.deepStrictEqual(mock.clusterNodes(), [
+    assert.deepStrictEqual(mock.addresses(), [
       { host: '127.0.0.1', port: mock.port },
     ])
     assert.ok(mock.state)
@@ -151,7 +147,7 @@ describe('public interface — createRedisMock', () => {
 
   test('cluster mock exposes nodes and a slot-routed seed', async () => {
     mock = await createRedisMock({ cluster: { masters: 3 } })
-    assert.strictEqual(mock.clusterNodes().length, 3)
+    assert.strictEqual(mock.addresses().length, 3)
     assert.ok(mock.nodes)
     assert.strictEqual(mock.state, undefined)
     await mock.seed([{ key: 'user:1', type: 'string', value: 'alice' }])


### PR DESCRIPTION
## What

Make the README user-friendly and testing-first, split the server / low-level API into a dedicated doc, and replace the two mock connection helpers with a single client-agnostic `addresses()`.

### README
- **Leads with the recommended path**: `createRedisMock` + a real client over a real socket (the main purpose — a drop-in for connecting directly to Redis in tests). New **Why** section.
- **New "Experimental: socketless client mocks (not recommended)" section** with a fidelity warning, covering the three non-recommended approaches:
  - `createIoredisMock` — replacement for the `ioredis-mock` library
  - `createNodeRedisMock` — in-memory mock for node-redis (was undocumented)
  - `createInMemoryClient` — our own bespoke socketless client
- Server / low-level API (`createRedisServer`, `createRedisCluster`, `Resp2Server`, `RedisServerState`, the CLI, package entry points, manual pipeline) **moved to `docs/API.md`** with a pointer.

### API change
- `RedisMock.connectionOptions()` + `clusterNodes()` → single **`addresses(): RedisAddress[]`** — one entry for standalone, every node for cluster. Client-agnostic (different clients shape connection options differently); `[0]` for a single client, whole array for a cluster client.
- Updated all usages (unit + integration tests, ARCHITECTURE.md).

> `clusterNodes()` in `src/commands/cluster.ts` is the `CLUSTER NODES` command — untouched.

## Verification
- `tsc --noEmit` clean, `eslint` clean
- Unit: 16/16 (`tests/mock.test.ts`, `tests/public-interface.test.ts`)
- Integration (mock backend): 20/20 (ioredis + node-redis `seed-mock.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)