### PR TITLE
[codex] add compatibility profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ available under newer Redis profiles. Unsupported commands remain unsupported
 regardless of profile.
 
 Supported presets: `redis-6.2`, `redis-7.0`, `redis-7.2`, `redis-7.4`,
-`valkey-8.0`, and `valkey-9.0`.
+`redis-8.0`, `valkey-8.0`, and `valkey-9.0`.
 
 ### Seeding
 
@@ -295,7 +295,7 @@ createRedisMock(options?: CreateRedisMockOptions): Promise<RedisMock>
 | :-------------- | :--------------------------------------- | :------------ | :----------------------------------------------------------- |
 | `cluster`       | `{ masters: number; replicas?: number }` | `undefined`   | When set, builds a cluster mock instead of a standalone one. |
 | `databaseCount` | `number`                                 | `16`          | Standalone-only: logical database count.                     |
-| `compatibility` | `CompatibilitySpec`                      | `'redis-7.4'` | Redis / Valkey compatibility profile.                        |
+| `compatibility` | `CompatibilitySpec`                      | `'redis-8.0'` | Redis / Valkey compatibility profile.                        |
 | `port`          | `number`                                 | `0`           | Standalone bind port (`0` = OS-assigned).                    |
 | `basePort`      | `number`                                 | `0`           | Cluster base port (`0` = each node OS-assigned).             |
 | `logger`        | `Pick<Logger, 'error'>`                  | `undefined`   | Optional logger.                                             |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ production. Jump to [Use as a Redis mock in tests](#use-as-a-redis-mock-in-tests
   - [node:test](#nodetest)
   - [vitest / jest](#vitest--jest)
   - [Cluster mocks](#cluster-mocks)
+  - [Compatibility profiles](#compatibility-profiles)
   - [Seeding](#seeding)
   - [`createRedisMock` options](#createredismock-options)
 - [Experimental: socketless client mocks](#experimental-socketless-client-mocks)
@@ -63,6 +64,8 @@ production. Jump to [Use as a Redis mock in tests](#use-as-a-redis-mock-in-tests
 
 - **RESP2 and RESP3 protocols** - Per-session version negotiation via `HELLO`
 - **Standalone and Cluster modes** - Run a single server or a full cluster
+- **Redis / Valkey compatibility profiles** - Pin implemented command behavior to
+  older Redis or Valkey versions
 - **Lua scripting support** - Execute Redis Lua scripts via WebAssembly
 - **No external dependencies** - Pure JavaScript, no Redis installation needed
 - **TypeScript support** - Ships with full type definitions
@@ -191,6 +194,28 @@ const cluster = createCluster({
 await cluster.connect()
 ```
 
+### Compatibility profiles
+
+By default the mock exposes the newest implemented Redis behavior. Pass
+`compatibility` when a test needs to match an older Redis or Valkey target:
+
+```typescript
+const redis62 = await createRedisMock({ compatibility: 'redis-6.2' })
+
+const valkeyCluster = await createRedisMock({
+  cluster: { masters: 3 },
+  compatibility: 'valkey-9.0',
+})
+```
+
+Profiles gate implemented commands, subcommands, options, and known behavioral
+differences. For example, `EXPIRETIME key` is unavailable under `redis-6.2` but
+available under newer Redis profiles. Unsupported commands remain unsupported
+regardless of profile.
+
+Supported presets: `redis-6.2`, `redis-7.0`, `redis-7.2`, `redis-7.4`,
+`valkey-8.0`, and `valkey-9.0`.
+
 ### Seeding
 
 `seed()` takes an explicit entries array — you supply keys, types, values, and
@@ -266,13 +291,14 @@ the `mock.state` escape hatch.
 createRedisMock(options?: CreateRedisMockOptions): Promise<RedisMock>
 ```
 
-| Parameter       | Type                                     | Default     | Description                                                  |
-| :-------------- | :--------------------------------------- | :---------- | :----------------------------------------------------------- |
-| `cluster`       | `{ masters: number; replicas?: number }` | `undefined` | When set, builds a cluster mock instead of a standalone one. |
-| `databaseCount` | `number`                                 | `16`        | Standalone-only: logical database count.                     |
-| `port`          | `number`                                 | `0`         | Standalone bind port (`0` = OS-assigned).                    |
-| `basePort`      | `number`                                 | `0`         | Cluster base port (`0` = each node OS-assigned).             |
-| `logger`        | `Pick<Logger, 'error'>`                  | `undefined` | Optional logger.                                             |
+| Parameter       | Type                                     | Default       | Description                                                  |
+| :-------------- | :--------------------------------------- | :------------ | :----------------------------------------------------------- |
+| `cluster`       | `{ masters: number; replicas?: number }` | `undefined`   | When set, builds a cluster mock instead of a standalone one. |
+| `databaseCount` | `number`                                 | `16`          | Standalone-only: logical database count.                     |
+| `compatibility` | `CompatibilitySpec`                      | `'redis-7.4'` | Redis / Valkey compatibility profile.                        |
+| `port`          | `number`                                 | `0`           | Standalone bind port (`0` = OS-assigned).                    |
+| `basePort`      | `number`                                 | `0`           | Cluster base port (`0` = each node OS-assigned).             |
+| `logger`        | `Pick<Logger, 'error'>`                  | `undefined`   | Optional logger.                                             |
 
 ## Experimental: socketless client mocks
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -119,7 +119,7 @@ const cluster = createRedisCluster({
 ```
 
 Supported presets are `redis-6.2`, `redis-7.0`, `redis-7.2`, `redis-7.4`,
-`valkey-8.0`, and `valkey-9.0`. The default is `redis-7.4`.
+`redis-8.0`, `valkey-8.0`, and `valkey-9.0`. The default is `redis-8.0`.
 
 Profiles gate implemented commands, subcommands, options, and known behavioral
 differences. Unsupported commands are still unsupported regardless of profile.
@@ -202,7 +202,7 @@ createRedisServer(options: CreateRedisServerClusterOptions): Promise<RedisCluste
 | :-------------- | :---------------------- | :------------ | :------------------------------------------- |
 | `port`          | `number`                | `0`           | Bind port (`0` = OS-assigned).               |
 | `databaseCount` | `number`                | `16`          | Logical database count (matches real Redis). |
-| `compatibility` | `CompatibilitySpec`     | `'redis-7.4'` | Redis / Valkey compatibility profile.        |
+| `compatibility` | `CompatibilitySpec`     | `'redis-8.0'` | Redis / Valkey compatibility profile.        |
 | `logger`        | `Pick<Logger, 'error'>` | `undefined`   | Optional logger.                             |
 
 **Cluster options (`CreateRedisServerClusterOptions`)**:
@@ -212,7 +212,7 @@ createRedisServer(options: CreateRedisServerClusterOptions): Promise<RedisCluste
 | `cluster`          | `{ masters: number; replicas?: number }` | **Required**  | Builds a cluster instead of a standalone server. |
 | `basePort`         | `number`                                 | `0`           | Cluster base port (`0` = each node OS-assigned). |
 | `databasesPerNode` | `number`                                 | `1`           | Databases per cluster node.                      |
-| `compatibility`    | `CompatibilitySpec`                      | `'redis-7.4'` | Redis / Valkey compatibility profile.            |
+| `compatibility`    | `CompatibilitySpec`                      | `'redis-8.0'` | Redis / Valkey compatibility profile.            |
 | `logger`           | `Pick<Logger, 'error'>`                  | `undefined`   | Optional logger.                                 |
 
 ---
@@ -240,7 +240,7 @@ createRedisCluster(options: RedisClusterOptions): RedisCluster
 | `basePort`          | `number`                | **Required**  | Base port range. If `0`, random OS ports are assigned. |
 | `host`              | `string`                | `'127.0.0.1'` | Host address to bind to.                               |
 | `databasesPerNode`  | `number`                | `1`           | Number of databases per cluster node.                  |
-| `compatibility`     | `CompatibilitySpec`     | `'redis-7.4'` | Redis / Valkey compatibility profile.                  |
+| `compatibility`     | `CompatibilitySpec`     | `'redis-8.0'` | Redis / Valkey compatibility profile.                  |
 | `logger`            | `Pick<Logger, 'error'>` | `undefined`   | Optional logger.                                       |
 
 ---
@@ -286,7 +286,7 @@ new RedisServerState(options?: RedisServerStateOptions)
 | Parameter         | Type                   | Default       | Description                                 |
 | :---------------- | :--------------------- | :------------ | :------------------------------------------ |
 | `databaseCount`   | `number`               | `1`           | Number of databases to initialize.          |
-| `compatibility`   | `CompatibilitySpec`    | `'redis-7.4'` | Redis / Valkey compatibility profile.       |
+| `compatibility`   | `CompatibilitySpec`    | `'redis-8.0'` | Redis / Valkey compatibility profile.       |
 | `clusterTopology` | `RedisClusterTopology` | `undefined`   | Optional cluster topology for slot routing. |
 | `pubsubBroker`    | `RedisPubSubBroker`    | `undefined`   | Optional broker for pub/sub operations.     |
 | `scriptCache`     | `RedisScriptCache`     | `undefined`   | Optional cache for Lua scripts.             |

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,6 +12,7 @@ server, building a cluster, and assembling the pipeline by hand.
 - [Running a Standalone Server](#running-a-standalone-server)
 - [Running a Cluster](#running-a-cluster)
 - [CLI](#cli)
+- [Compatibility Profiles](#compatibility-profiles)
 - [Package Entry Points](#package-entry-points)
 - [Advanced: Assembling the Pipeline by Hand](#advanced-assembling-the-pipeline-by-hand)
 - [API Reference](#api-reference)
@@ -74,6 +75,9 @@ npx js-redis-server --cluster --masters 3
 
 # Run a cluster with replicas
 npx js-redis-server --cluster --masters 3 --slaves 1
+
+# Run as Redis 6.2 compatibility
+npx js-redis-server --compat redis-6.2
 ```
 
 CLI options:
@@ -93,9 +97,32 @@ Cluster options:
   --base-port <number>   Starting port for cluster nodes (default 30000)
 
 General:
+  --compat <preset>       Compatibility profile (or REDIS_COMPAT env)
   -d, --debug            Enable debug logging
   -h, --help             Show help
 ```
+
+## Compatibility Profiles
+
+Pass `compatibility` to pin implemented command behavior to a Redis or Valkey
+target:
+
+```typescript
+await createRedisServer({ compatibility: 'redis-6.2' })
+
+const cluster = createRedisCluster({
+  masters: 3,
+  basePort: 30000,
+  compatibility: 'valkey-9.0',
+  databasesPerNode: 16,
+})
+```
+
+Supported presets are `redis-6.2`, `redis-7.0`, `redis-7.2`, `redis-7.4`,
+`valkey-8.0`, and `valkey-9.0`. The default is `redis-7.4`.
+
+Profiles gate implemented commands, subcommands, options, and known behavioral
+differences. Unsupported commands are still unsupported regardless of profile.
 
 ## Package Entry Points
 
@@ -171,20 +198,22 @@ createRedisServer(options: CreateRedisServerClusterOptions): Promise<RedisCluste
 
 **Standalone options (`CreateRedisServerOptions`)**:
 
-| Parameter       | Type                    | Default     | Description                                  |
-| :-------------- | :---------------------- | :---------- | :------------------------------------------- |
-| `port`          | `number`                | `0`         | Bind port (`0` = OS-assigned).               |
-| `databaseCount` | `number`                | `16`        | Logical database count (matches real Redis). |
-| `logger`        | `Pick<Logger, 'error'>` | `undefined` | Optional logger.                             |
+| Parameter       | Type                    | Default       | Description                                  |
+| :-------------- | :---------------------- | :------------ | :------------------------------------------- |
+| `port`          | `number`                | `0`           | Bind port (`0` = OS-assigned).               |
+| `databaseCount` | `number`                | `16`          | Logical database count (matches real Redis). |
+| `compatibility` | `CompatibilitySpec`     | `'redis-7.4'` | Redis / Valkey compatibility profile.        |
+| `logger`        | `Pick<Logger, 'error'>` | `undefined`   | Optional logger.                             |
 
 **Cluster options (`CreateRedisServerClusterOptions`)**:
 
-| Parameter          | Type                                     | Default      | Description                                      |
-| :----------------- | :--------------------------------------- | :----------- | :----------------------------------------------- |
-| `cluster`          | `{ masters: number; replicas?: number }` | **Required** | Builds a cluster instead of a standalone server. |
-| `basePort`         | `number`                                 | `0`          | Cluster base port (`0` = each node OS-assigned). |
-| `databasesPerNode` | `number`                                 | `1`          | Databases per cluster node.                      |
-| `logger`           | `Pick<Logger, 'error'>`                  | `undefined`  | Optional logger.                                 |
+| Parameter          | Type                                     | Default       | Description                                      |
+| :----------------- | :--------------------------------------- | :------------ | :----------------------------------------------- |
+| `cluster`          | `{ masters: number; replicas?: number }` | **Required**  | Builds a cluster instead of a standalone server. |
+| `basePort`         | `number`                                 | `0`           | Cluster base port (`0` = each node OS-assigned). |
+| `databasesPerNode` | `number`                                 | `1`           | Databases per cluster node.                      |
+| `compatibility`    | `CompatibilitySpec`                      | `'redis-7.4'` | Redis / Valkey compatibility profile.            |
+| `logger`           | `Pick<Logger, 'error'>`                  | `undefined`   | Optional logger.                                 |
 
 ---
 
@@ -211,6 +240,7 @@ createRedisCluster(options: RedisClusterOptions): RedisCluster
 | `basePort`          | `number`                | **Required**  | Base port range. If `0`, random OS ports are assigned. |
 | `host`              | `string`                | `'127.0.0.1'` | Host address to bind to.                               |
 | `databasesPerNode`  | `number`                | `1`           | Number of databases per cluster node.                  |
+| `compatibility`     | `CompatibilitySpec`     | `'redis-7.4'` | Redis / Valkey compatibility profile.                  |
 | `logger`            | `Pick<Logger, 'error'>` | `undefined`   | Optional logger.                                       |
 
 ---
@@ -253,9 +283,10 @@ new RedisServerState(options?: RedisServerStateOptions)
 
 **Options (`RedisServerStateOptions`)**:
 
-| Parameter         | Type                   | Default     | Description                                 |
-| :---------------- | :--------------------- | :---------- | :------------------------------------------ |
-| `databaseCount`   | `number`               | `1`         | Number of databases to initialize.          |
-| `clusterTopology` | `RedisClusterTopology` | `undefined` | Optional cluster topology for slot routing. |
-| `pubsubBroker`    | `RedisPubSubBroker`    | `undefined` | Optional broker for pub/sub operations.     |
-| `scriptCache`     | `RedisScriptCache`     | `undefined` | Optional cache for Lua scripts.             |
+| Parameter         | Type                   | Default       | Description                                 |
+| :---------------- | :--------------------- | :------------ | :------------------------------------------ |
+| `databaseCount`   | `number`               | `1`           | Number of databases to initialize.          |
+| `compatibility`   | `CompatibilitySpec`    | `'redis-7.4'` | Redis / Valkey compatibility profile.       |
+| `clusterTopology` | `RedisClusterTopology` | `undefined`   | Optional cluster topology for slot routing. |
+| `pubsubBroker`    | `RedisPubSubBroker`    | `undefined`   | Optional broker for pub/sub operations.     |
+| `scriptCache`     | `RedisScriptCache`     | `undefined`   | Optional cache for Lua scripts.             |

--- a/docs/COMPATIBILITY-PROFILES-PLAN.md
+++ b/docs/COMPATIBILITY-PROFILES-PLAN.md
@@ -44,6 +44,7 @@ await cluster.listen()
 ```
 
 Public API requirements:
+
 - `createRedisServer({ compatibility })` is the documented standalone entry point and
   internally wires one resolved profile into both `RedisServerState` and
   `CommandExecutor`.
@@ -63,13 +64,13 @@ Public API requirements:
 One resolved `CompatibilityProfile` is the single source of truth, reachable from every
 layer of the pipeline. It is held in **two** places (which see the same object):
 
-1. **CommandExecutor** (constructor-held) — needed for the two sites that run *before* any
+1. **CommandExecutor** (constructor-held) — needed for the two sites that run _before_ any
    `ctx` exists, inside `executor.plan()`:
    - **Registry filtering**: build the registry with only the commands that exist in the
      target version → absent commands return real `unknown command`.
    - **Parse-time option gating**: inject the profile into `ParseContext` so arg schemas
      reject too-new options.
-2. **RedisServerState** (`ctx.server.profile`) — reachable at *execute* and *policy* time
+2. **RedisServerState** (`ctx.server.profile`) — reachable at _execute_ and _policy_ time
    (every `execute(args, ctx)` and every `ExecutionPolicy.beforeExecute(plan, ctx)` already
    carries `ctx`), used for version strings **and** version-divergent semantics/routing.
 
@@ -77,14 +78,15 @@ Divergences are **not** only command/option existence. They span four gate sites
 reading the same profile via one evaluation primitive (`gateSatisfied(gate, profile)` /
 `profile.has(feature)`):
 
-| Site | Where | Example divergence |
-|------|-------|--------------------|
-| Registry build | `createRedisCommandRegistry` (executor) | `EXPIRETIME` absent < 7.0 ⇒ `unknown command` |
+| Site                           | Where                                                                                               | Example divergence                                                                         |
+| ------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Registry build                 | `createRedisCommandRegistry` (executor)                                                             | `EXPIRETIME` absent < 7.0 ⇒ `unknown command`                                              |
 | Arg parser / subcommand parser | `t.custom` schemas via `ParseContext.profile`, command `execute` where subcommands are parsed today | `EXPIRE … NX` invalid < 7.0; `SET … GET/EXAT` invalid < 6.2; `CLIENT SETINFO` absent < 7.2 |
-| **Execution policy** | `ExecutionPolicy.beforeExecute(plan, ctx)` via `ctx.server.profile` | **Valkey cluster allows non-zero `SELECT` / multi-DB; Redis cluster forbids it** |
-| **Command execute** | `execute(args, ctx)` via `ctx.server.profile` | version strings, reply-shape/semantic tweaks |
+| **Execution policy**           | `ExecutionPolicy.beforeExecute(plan, ctx)` via `ctx.server.profile`                                 | **Valkey cluster allows non-zero `SELECT` / multi-DB; Redis cluster forbids it**           |
+| **Command execute**            | `execute(args, ctx)` via `ctx.server.profile`                                                       | version strings, reply-shape/semantic tweaks                                               |
 
 Two declarative primitives feed all four sites:
+
 - **Command existence** → `since` (a `VersionGate`) on the `CommandDefinition`.
 - **Everything else** (subcommands, options, policy behavior, semantics) → named
   **feature flags** in a central table, checked via `profile.has('feature')`.
@@ -97,6 +99,7 @@ need **no construction-time wiring** — they already receive `ctx`, so reading
 ## New module: `src/core/compatibility/`
 
 `profile.ts`:
+
 ```ts
 export type RedisFlavor = 'redis' | 'valkey'
 
@@ -104,29 +107,38 @@ export type RedisFlavor = 'redis' | 'valkey'
 export type VersionGate = { redis?: string; valkey?: string }
 
 export type FeatureId =
-  | 'expire.conditions'   // EXPIRE/PEXPIRE/EXPIREAT/PEXPIREAT  NX|XX|GT|LT  (parser)
-  | 'set.get'             // SET … GET                                       (parser)
-  | 'set.exat-pxat'       // SET … EXAT|PXAT                                 (parser)
-  | 'command.docs'        // COMMAND DOCS                                    (subcommand)
+  | 'expire.conditions' // EXPIRE/PEXPIRE/EXPIREAT/PEXPIREAT  NX|XX|GT|LT  (parser)
+  | 'set.get' // SET … GET                                       (parser)
+  | 'set.exat-pxat' // SET … EXAT|PXAT                                 (parser)
+  | 'command.docs' // COMMAND DOCS                                    (subcommand)
   | 'command.getkeysandflags' // COMMAND GETKEYSANDFLAGS                     (subcommand)
-  | 'client.setinfo'      // CLIENT SETINFO                                  (subcommand)
-  | 'cluster.multi-db'    // SELECT non-zero db / multi-DB in cluster mode   (policy)
+  | 'client.setinfo' // CLIENT SETINFO                                  (subcommand)
+  | 'cluster.multi-db' // SELECT non-zero db / multi-DB in cluster mode   (policy)
 
 export interface CompatibilityProfile {
   readonly flavor: RedisFlavor
-  readonly version: string      // display, e.g. '6.2.14'
-  readonly versionNum: number   // comparable: major*10000 + minor*100 + patch
+  readonly version: string // display, e.g. '6.2.14'
+  readonly versionNum: number // comparable: major*10000 + minor*100 + patch
   has(feature: FeatureId): boolean
 }
 
 export type CompatibilitySpec =
   | CompatibilityProfile
   | { flavor?: RedisFlavor; version?: string }
-  | 'redis-6.2' | 'redis-7.0' | 'redis-7.2' | 'redis-7.4'
-  | 'valkey-8.0' | 'valkey-9.0' // presets (arbitrary {flavor,version} also accepted)
+  | 'redis-6.2'
+  | 'redis-7.0'
+  | 'redis-7.2'
+  | 'redis-7.4'
+  | 'valkey-8.0'
+  | 'valkey-9.0' // presets (arbitrary {flavor,version} also accepted)
 
-export function resolveCompatibilityProfile(spec?: CompatibilitySpec): CompatibilityProfile
-export function gateSatisfied(gate: VersionGate, profile: CompatibilityProfile): boolean
+export function resolveCompatibilityProfile(
+  spec?: CompatibilitySpec,
+): CompatibilityProfile
+export function gateSatisfied(
+  gate: VersionGate,
+  profile: CompatibilityProfile,
+): boolean
 ```
 
 - `resolveCompatibilityProfile()` with no arg ⇒ newest Redis (**`redis-7.4` / `7.4.4`**) ⇒ identical to today.
@@ -135,17 +147,18 @@ export function gateSatisfied(gate: VersionGate, profile: CompatibilityProfile):
 - `gateSatisfied(gate, p)` = `gate[p.flavor] !== undefined && p.versionNum >= parseVersion(gate[p.flavor])`.
 
 `feature-gates.ts`:
+
 ```ts
 export const FEATURE_GATES: Record<FeatureId, VersionGate> = {
   'expire.conditions': { redis: '7.0.0', valkey: '7.2.0' },
-  'set.get':           { redis: '6.2.0', valkey: '7.2.0' },
-  'set.exat-pxat':     { redis: '6.2.0', valkey: '7.2.0' },
-  'command.docs':      { redis: '7.0.0', valkey: '7.2.0' },
+  'set.get': { redis: '6.2.0', valkey: '7.2.0' },
+  'set.exat-pxat': { redis: '6.2.0', valkey: '7.2.0' },
+  'command.docs': { redis: '7.0.0', valkey: '7.2.0' },
   'command.getkeysandflags': { redis: '7.0.0', valkey: '7.2.0' },
-  'client.setinfo':    { redis: '7.2.0', valkey: '7.2.0' },
+  'client.setinfo': { redis: '7.2.0', valkey: '7.2.0' },
   // No `redis` key ⇒ never present in any Redis cluster; Valkey added cluster
   // multi-DB. Version is per the user's "valkey 9" example and easily tuned.
-  'cluster.multi-db':  { valkey: '9.0.0' },
+  'cluster.multi-db': { valkey: '9.0.0' },
 }
 // Valkey forked from Redis 7.2.4, so any modeled valkey >= 7.2 has the 7.2 features above.
 ```
@@ -155,10 +168,12 @@ export const FEATURE_GATES: Record<FeatureId, VersionGate> = {
 ## Changes by file
 
 ### Plumb the profile into parsing
+
 - `src/core/command-schema.ts`: extend `ParseContext` → `{ commandName; profile: CompatibilityProfile }`. `parseCommandArgs(schema, input, commandName, profile = resolveCompatibilityProfile())` builds the ctx (optional param keeps the public export backward-compatible).
 - `src/core/command-executor.ts`: add `profile?: CompatibilityProfile` to `CommandExecutorOptions` (default resolved-newest); store it; pass it in `createPlan` → `parseCommandArgs(...)`.
 
 ### Command-existence gating
+
 - `src/core/command-definition.ts`: add `readonly since?: VersionGate` to `CommandDefinition`. `defineCommand` passes it through unchanged. Untagged commands (≈180 legacy ones) are always present.
 - Audit every implemented command and tag every root command introduced after Redis 6.0.
   Current known set includes:
@@ -173,6 +188,7 @@ export const FEATURE_GATES: Record<FeatureId, VersionGate> = {
 Side benefit: `COMMAND COUNT/DOCS/INFO` read `registry.getAll()`, so introspection auto-reflects the profile.
 
 ### Subcommand / option gating
+
 - Subcommands need their own gates because the root command may predate the subcommand.
   Add `since?: VersionGate` to subcommand introspection metadata or filter the existing
   `subcommands` array through a helper before exposing `COMMAND INFO/DOCS`.
@@ -189,7 +205,9 @@ Side benefit: `COMMAND COUNT/DOCS/INFO` read `registry.getAll()`, so introspecti
 Rule of thumb for any future option gate: replicate what the real old server does — fixed-arity commands surface a trailing unsupported option as `WrongNumberOfArgumentsError` (don't consume), variadic commands as `RedisSyntaxError` (throw).
 
 ### Policy / semantic gating (execute-time, no new wiring)
+
 Policies and `execute` already receive `ctx`, so they read `ctx.server.profile` directly — `createClusterPolicy` etc. keep their current signatures.
+
 - `src/core/execution-policies/cluster-policy.ts`: keep using the existing
   `capabilities.clusterMode === 'singleDb'` branch. Its non-zero DB rejection becomes
   conditional on `!ctx.server.profile.has('cluster.multi-db')`.
@@ -197,15 +215,18 @@ Policies and `execute` already receive `ctx`, so they read `ctx.server.profile` 
 - This is the template for any future policy- or execute-layer divergence (routing rules, reply shape, default RESP version): add a `FeatureId`, branch on `ctx.server.profile.has(...)`. No policy/command constructor changes.
 
 ### Version reporting reads the profile
+
 - `src/state/server-state.ts`: add `compatibility?: CompatibilitySpec` to `RedisServerStateOptions`; add `readonly profile: CompatibilityProfile = resolveCompatibilityProfile(options?.compatibility)`.
 - `src/commands/connection.ts`: delete the `REDIS_VERSION` const.
   - `INFO` server section: `redis_version:${ctx.server.profile.version}`; when `flavor === 'valkey'` also emit `server_name:valkey` and `valkey_version:${ctx.server.profile.version}` (Valkey keeps a compat `redis_version` line too — use a 7.x compat string for that line).
   - `HELLO`: `server` field = `ctx.server.profile.flavor`; `version` field = `ctx.server.profile.version`.
 
 ### Public builders own profile wiring
+
 Both public builders compose `RedisServerState` + `createRedisCommandExecutor` +
 `Resp2Server`. Resolve the profile **once** and hand the same object to both state
 (version strings / server-wide behavior) and executor (registry filtering / parsing).
+
 - `src/mock.ts`: add `compatibility?: CompatibilitySpec` to `CreateRedisServerOptions`,
   `CreateRedisServerClusterOptions`, and `CreateRedisMockOptions`. `createStandalonePipeline`
   resolves the profile once, constructs `RedisServerState({ …, compatibility: profile })`,
@@ -225,11 +246,13 @@ Both public builders compose `RedisServerState` + `createRedisCommandExecutor` +
   This catches advanced users who manually wire mismatched low-level objects.
 
 ### Exports
+
 - `src/index.ts`: export `createRedisServer`, `createRedisMock`, `createRedisCluster`, `resolveCompatibilityProfile`, `gateSatisfied`, and the `CompatibilityProfile` / `CompatibilitySpec` / `RedisFlavor` / `VersionGate` / `FeatureId` types. Keep `buildRedisCluster` as the existing deprecated alias only.
 
 ## Package-user documentation
 
 Add a short compatibility-profile section to the README/API docs:
+
 - Show `createRedisServer({ compatibility: 'redis-6.2' })` for standalone tests.
 - Show `createRedisMock({ compatibility: 'redis-6.2' })` for test suites that use the mock facade.
 - Show `createRedisCluster({ compatibility: 'valkey-9.0', databasesPerNode: 16 })`
@@ -249,6 +272,7 @@ Tests should validate the package-user API first. Low-level state/executor tests
 useful, but they are supporting coverage rather than the interface users should copy.
 
 Unit (`tests/compatibility/` + co-located):
+
 - `profile.test.ts`: `parseVersion`, `versionNum` ordering, `gateSatisfied` per flavor,
   named-preset resolution, default = `redis-7.4`, Valkey 7.2 inherits Redis 7.2-era
   gates, and Valkey 9.0 enables Valkey-specific gates such as `cluster.multi-db`.
@@ -266,6 +290,7 @@ Unit (`tests/compatibility/` + co-located):
 
 Integration (`tests-integration/`, **mock only** — in-process servers built through the
 public builders with explicit `compatibility`), TDD red-first per the integration-first rule:
+
 - standalone `createRedisServer({ compatibility:'redis-6.2' })`: `EXPIRETIME k` →
   `unknown command`; `EXPIRE k 10 NX` → wrong-args error, asserted through a real client.
 - standalone `createRedisServer({ compatibility:'redis-7.0' })`: `CLIENT SETINFO` is
@@ -280,6 +305,54 @@ asserting the mock matches each) can be follow-up automation, but implementation
 capture enough real-server responses manually or in fixtures before encoding exact error
 shapes for older profiles.
 
+## Implementation sequencing and parallelism
+
+Do the shared profile plumbing first; every gate depends on it. After that, split by file
+ownership so parallel workers do not fight each other.
+
+### Serial foundation
+
+1. **Profile primitives**
+   - Files: `src/core/compatibility/profile.ts`, `src/core/compatibility/feature-gates.ts`,
+     `src/core/compatibility/index.ts`, `src/internal.ts`, `src/index.ts`,
+     `tests/compatibility/profile.test.ts`.
+   - Build `CompatibilitySpec`, `CompatibilityProfile`, `resolveCompatibilityProfile`,
+     `parseVersion`, `gateSatisfied`, and `FEATURE_GATES`.
+
+2. **Pipeline plumbing**
+   - Files: `src/core/command-schema.ts`, `src/core/command-executor.ts`,
+     `src/state/server-state.ts`.
+   - Put the same resolved profile on `CommandExecutor`, `ParseContext`, and
+     `RedisServerState`.
+
+3. **Registry gate hook**
+   - Files: `src/core/command-definition.ts`, `src/commands/index.ts`,
+     `tests/compatibility/registry.test.ts`.
+   - Add `CommandDefinition.since`, filter base + extra commands in
+     `createRedisCommandRegistry`, and pass `compatibility` through
+     `createRedisCommandExecutor`.
+
+### Parallel tracks after the foundation
+
+| Track                              | Files                                                                        | Can run with                              | Notes                                                                                                                      |
+| ---------------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Public builder wiring              | `src/mock.ts`, `src/cluster.ts`, `src/cli.ts`, public-interface tests        | All command-gate tracks                   | Resolve once per builder and pass the same profile to state + executor.                                                    |
+| Root command audit                 | command modules under `src/commands/`, registry tests                        | Builder wiring, cluster policy            | May touch `keys.ts`, `strings.ts`, and `connection.ts`; coordinate before running parser/subcommand tracks in those files. |
+| EXPIRE option gate                 | `src/commands/keys.ts`, parse tests                                          | SET gate, COMMAND gate, builder wiring    | Depends on `ParseContext.profile`; keep fixed-arity wrong-args behavior.                                                   |
+| SET option gate                    | `src/commands/strings.ts`, parse tests                                       | EXPIRE gate, COMMAND gate, builder wiring | Depends on `ParseContext.profile`; unsupported variadic option throws `RedisSyntaxError`.                                  |
+| COMMAND subcommand gate            | `src/commands/command.ts`, `src/commands/introspection.ts`, subcommand tests | EXPIRE/SET gates, builder wiring          | Filter dispatch and introspection for `COMMAND DOCS` / `GETKEYSANDFLAGS`.                                                  |
+| Connection reporting + CLIENT gate | `src/commands/connection.ts`, reporting/subcommand tests                     | EXPIRE/SET/COMMAND gates, builder wiring  | Keep `CLIENT SETINFO`, `INFO`, and `HELLO` together because they share this file.                                          |
+| Cluster multi-DB policy            | `src/core/execution-policies/cluster-policy.ts`, cluster policy tests        | Most command gates                        | Use existing `capabilities.clusterMode === 'singleDb'`; integration smoke waits for cluster builder wiring.                |
+| README/API docs                    | `README.md`, package docs                                                    | All code tracks after API shape is stable | Do last enough to avoid documenting churn.                                                                                 |
+
+### Final serial verification
+
+1. Run focused unit tests for each touched area while merging tracks.
+2. Run `npm run build && npm run lint`.
+3. Run `npm test`.
+4. Run `npm run test:integration:mock`.
+5. Run `npm run test:integration:real` to prove default compatibility stayed unchanged.
+
 ## Verification
 
 ```bash
@@ -288,7 +361,9 @@ npm test                          # unit incl. new compatibility tests
 npm run test:integration:mock     # incl. new 6.2 standalone gating test
 npm run test:integration:real     # must stay green — default profile unchanged
 ```
+
 Manual smoke:
+
 ```bash
 REDIS_COMPAT=redis-6.2 npm start
 redis-cli -p <port> EXPIRETIME k   # (error) ERR unknown command 'EXPIRETIME'
@@ -302,6 +377,7 @@ redis-cli -p <port> INFO server    # server_name:valkey, valkey_version:9.0.0
 ```
 
 ## Extensibility (designed-in, not built now)
+
 - New version-introduced command → add `since` to its definition. Done.
 - New version-introduced subcommand → add a `FeatureId` + `FEATURE_GATES` row, gate
   subcommand dispatch, and filter subcommand introspection.

--- a/docs/COMPATIBILITY-PROFILES-PLAN.md
+++ b/docs/COMPATIBILITY-PROFILES-PLAN.md
@@ -1,8 +1,8 @@
-# Compatibility Profiles: emulate Redis 6.2 / 7.0 / 7.2 / 7.4 / Valkey
+# Compatibility Profiles: emulate Redis 6.2 / 7.0 / 7.2 / 7.4 / 8.0 / Valkey
 
 ## Context
 
-The mock currently hardcodes one behavior set = newest Redis (`REDIS_VERSION = '7.4.4'`).
+The mock currently hardcodes one behavior set = newest implemented Redis.
 Package users who depend on this mock in their own test suites can get false greens when
 their production target is older Redis (6.2, 7.0) or Valkey: commands, subcommands, and
 options that did not exist yet (e.g. `EXPIRETIME`, `COMMAND DOCS`, `CLIENT SETINFO`,
@@ -129,6 +129,7 @@ export type CompatibilitySpec =
   | 'redis-7.0'
   | 'redis-7.2'
   | 'redis-7.4'
+  | 'redis-8.0'
   | 'valkey-8.0'
   | 'valkey-9.0' // presets (arbitrary {flavor,version} also accepted)
 
@@ -141,7 +142,7 @@ export function gateSatisfied(
 ): boolean
 ```
 
-- `resolveCompatibilityProfile()` with no arg ⇒ newest Redis (**`redis-7.4` / `7.4.4`**) ⇒ identical to today.
+- `resolveCompatibilityProfile()` with no arg ⇒ newest Redis (**`redis-8.0` / `8.0.0`**) ⇒ identical to today.
 - Named presets map to `{ flavor, version }`; arbitrary versions allowed (`{ flavor:'valkey', version:'9.0.0' }`) so "valkey 9.0" works even though it post-dates real releases.
 - `versionNum` via a `parseVersion()` helper; `has()` is precomputed at resolve time from the gate table.
 - `gateSatisfied(gate, p)` = `gate[p.flavor] !== undefined && p.versionNum >= parseVersion(gate[p.flavor])`.
@@ -257,7 +258,7 @@ Add a short compatibility-profile section to the README/API docs:
 - Show `createRedisMock({ compatibility: 'redis-6.2' })` for test suites that use the mock facade.
 - Show `createRedisCluster({ compatibility: 'valkey-9.0', databasesPerNode: 16 })`
   for cluster tests.
-- State that the default is newest supported Redis (`redis-7.4`) for backward
+- State that the default is newest supported Redis (`redis-8.0`) for backward
   compatibility.
 - State the scope clearly: profiles gate implemented commands/subcommands/options and
   known behavior differences to prevent false greens; unsupported Redis commands remain
@@ -274,7 +275,7 @@ useful, but they are supporting coverage rather than the interface users should 
 Unit (`tests/compatibility/` + co-located):
 
 - `profile.test.ts`: `parseVersion`, `versionNum` ordering, `gateSatisfied` per flavor,
-  named-preset resolution, default = `redis-7.4`, Valkey 7.2 inherits Redis 7.2-era
+  named-preset resolution, default = `redis-8.0`, Valkey 7.2 inherits Redis 7.2-era
   gates, and Valkey 9.0 enables Valkey-specific gates such as `cluster.multi-db`.
 - public builder wiring: `createRedisServer({ compatibility:'redis-6.2' })`,
   `createRedisMock({ compatibility:'redis-6.2' })`, and

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import { createRedisServer } from './mock'
 import type { Logger } from './logger'
+import type { CompatibilitySpec } from './core/compatibility'
 
 type Mode = 'single' | 'cluster'
 
@@ -9,6 +10,7 @@ export type CliOptions = {
   masters: number
   slaves: number
   basePort: number
+  compatibility?: CompatibilitySpec
   help: boolean
   debug: boolean
 }
@@ -75,6 +77,15 @@ export function parseArgs(args: string[]): CliOptions {
 
     if (arg === '--slaves') {
       options.slaves = parseInteger(args[++i], '--slaves')
+      continue
+    }
+
+    if (arg === '--compat') {
+      const value = args[++i]
+      if (!value) {
+        throw new Error('Missing value for --compat')
+      }
+      options.compatibility = value as CompatibilitySpec
       continue
     }
 
@@ -146,6 +157,7 @@ Cluster options:
   --base-port <number>   Starting port for cluster nodes (default 30000)
 
 General:
+  --compat <preset>       Compatibility profile (or REDIS_COMPAT env)
   -d, --debug            Enable debug logging
   -h, --help             Show help
 `)
@@ -155,7 +167,11 @@ async function runSingle(options: CliOptions, logger: Logger) {
   validatePort(options.port, 'port')
   logger.debug('Starting single server mode', { port: options.port })
 
-  const { server } = await createRedisServer({ port: options.port, logger })
+  const { server } = await createRedisServer({
+    port: options.port,
+    compatibility: resolveCliCompatibility(options),
+    logger,
+  })
   logger.info(`Single Redis server listening at ${server.getAddress()}`)
 
   const shutdown = async () => {
@@ -178,6 +194,7 @@ async function runCluster(options: CliOptions, logger: Logger) {
   const cluster = await createRedisServer({
     cluster: { masters: options.masters, replicas: options.slaves },
     basePort: options.basePort,
+    compatibility: resolveCliCompatibility(options),
     logger,
   })
 
@@ -190,6 +207,15 @@ async function runCluster(options: CliOptions, logger: Logger) {
 
   process.once('SIGINT', shutdown)
   process.once('SIGTERM', shutdown)
+}
+
+function resolveCliCompatibility(
+  options: CliOptions,
+): CompatibilitySpec | undefined {
+  return (
+    options.compatibility ??
+    (process.env.REDIS_COMPAT as CompatibilitySpec | undefined)
+  )
 }
 
 export async function main(argv = process.argv.slice(2)) {

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -14,6 +14,11 @@ import {
 } from './state'
 import type { CommandExecutor } from './core/command-executor'
 import type { Logger } from './logger'
+import {
+  resolveCompatibilityProfile,
+  type CompatibilityProfile,
+  type CompatibilitySpec,
+} from './core/compatibility'
 
 export type RedisClusterOptions = {
   masters: number
@@ -22,6 +27,7 @@ export type RedisClusterOptions = {
   host?: string
   databasesPerNode?: number
   replicaUpdateDelayMs?: number
+  compatibility?: CompatibilitySpec
   logger?: Pick<Logger, 'error'>
 }
 
@@ -134,6 +140,7 @@ export function buildClusterNodes(options: RedisClusterOptions): ClusterNodes {
   const host = options.host ?? '127.0.0.1'
   const replicas = options.replicasPerMaster ?? 0
   const totalNodes = options.masters * (replicas + 1)
+  const profile = resolveCompatibilityProfile(options.compatibility)
 
   if (options.basePort + totalNodes - 1 > 65535) {
     throw new Error('Cluster base-port range exceeds 65535')
@@ -180,6 +187,7 @@ export function buildClusterNodes(options: RedisClusterOptions): ClusterNodes {
     topology,
     options.databasesPerNode ?? 1,
     options.replicaUpdateDelayMs ?? 0,
+    profile,
     replicationLinks,
   )
 
@@ -191,6 +199,7 @@ export function buildClusterNodes(options: RedisClusterOptions): ClusterNodes {
 
     const executor = createRedisCommandExecutor({
       extraCommands: createClusterCommands(node.id),
+      compatibility: profile,
       policies: [createClusterPolicy({ localNodeId: node.id, topology })],
     })
 
@@ -308,6 +317,7 @@ function createClusterNodeStates(
   topology: RedisClusterTopology,
   databaseCount: number,
   replicaUpdateDelayMs: number,
+  profile: CompatibilityProfile,
   replicationLinks: ReplicationLink[],
 ): Map<string, RedisServerState> {
   const states = new Map<string, RedisServerState>()
@@ -318,6 +328,7 @@ function createClusterNodeStates(
       new RedisServerState({
         databaseCount,
         clusterTopology: topology,
+        compatibility: profile,
         activeExpiryIntervalMs: node.role === 'replica' ? false : undefined,
       }),
     )

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -41,6 +41,8 @@ const SUBCOMMAND_FEATURES: Record<string, FeatureId> = {
   'command|docs': 'command.docs',
   'command|getkeysandflags': 'command.getkeysandflags',
   'client|setinfo': 'client.setinfo',
+  'pubsub|shardchannels': 'pubsub.sharded',
+  'pubsub|shardnumsub': 'pubsub.sharded',
 }
 
 const commandIntrospection: CommandIntrospection = {
@@ -112,7 +114,7 @@ export const commandCommand = defineCommand({
         }
         return commandGetKeysAndFlags(args, ctx)
       case 'help':
-        return commandHelp(args)
+        return commandHelp(args, ctx)
       default:
         throw new RedisCommandError(
           `unknown subcommand '${args.subcommand}'. Try COMMAND HELP.`,
@@ -218,35 +220,49 @@ function commandGetKeysAndFlags(
   )
 }
 
-function commandHelp(args: CommandArgs): RedisResult {
+function commandHelp(
+  args: CommandArgs,
+  ctx: RedisExecutionContext,
+): RedisResult {
   expectArgCount('command|help', args.args, 0)
-  return RedisResult.create(
-    RedisValue.array(
-      [
-        'COMMAND <subcommand> [<arg> [value] [opt] ...]. Subcommands are:',
-        '(no subcommand)',
-        '    Return details about all Redis commands.',
-        'COUNT',
-        '    Return the total number of commands in this Redis server.',
-        'LIST',
-        '    Return a list of all commands in this Redis server.',
-        'INFO [<command-name> ...]',
-        '    Return details about multiple Redis commands.',
-        '    If no command names are given, documentation details for all',
-        '    commands are returned.',
-        'DOCS [<command-name> ...]',
-        '    Return documentation details about multiple Redis commands.',
-        '    If no command names are given, documentation details for all',
-        '    commands are returned.',
-        'GETKEYS <full-command>',
-        '    Return the keys from a full Redis command.',
-        'GETKEYSANDFLAGS <full-command>',
-        '    Return the keys and the access flags from a full Redis command.',
-        'HELP',
-        '    Prints this help.',
-      ].map(bulkString),
-    ),
+  const lines = [
+    'COMMAND <subcommand> [<arg> [value] [opt] ...]. Subcommands are:',
+    '(no subcommand)',
+    '    Return details about all Redis commands.',
+    'COUNT',
+    '    Return the total number of commands in this Redis server.',
+    'LIST',
+    '    Return a list of all commands in this Redis server.',
+    'INFO [<command-name> ...]',
+    '    Return details about multiple Redis commands.',
+    '    If no command names are given, documentation details for all',
+    '    commands are returned.',
+  ]
+
+  if (ctx.server.profile.has('command.docs')) {
+    lines.push(
+      'DOCS [<command-name> ...]',
+      '    Return documentation details about multiple Redis commands.',
+      '    If no command names are given, documentation details for all',
+      '    commands are returned.',
+    )
+  }
+
+  lines.push(
+    'GETKEYS <full-command>',
+    '    Return the keys from a full Redis command.',
   )
+
+  if (ctx.server.profile.has('command.getkeysandflags')) {
+    lines.push(
+      'GETKEYSANDFLAGS <full-command>',
+      '    Return the keys and the access flags from a full Redis command.',
+    )
+  }
+
+  lines.push('HELP', '    Prints this help.')
+
+  return RedisResult.create(RedisValue.array(lines.map(bulkString)))
 }
 
 function planCommandKeys(

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -15,6 +15,7 @@ import {
 import type { RedisExecutionContext } from '../core/redis-context'
 import { RedisResult } from '../core/redis-result'
 import { RedisValue } from '../core/redis-value'
+import type { FeatureId } from '../core/compatibility'
 import { commandDocs, commandSubcommandInfo } from './introspection'
 
 type CommandArgs = {
@@ -34,6 +35,12 @@ type CommandInfo = {
   keySpecs: readonly CommandKeySpec[]
   subcommands: readonly CommandInfo[]
   docs?: CommandDocumentation
+}
+
+const SUBCOMMAND_FEATURES: Record<string, FeatureId> = {
+  'command|docs': 'command.docs',
+  'command|getkeysandflags': 'command.getkeysandflags',
+  'client|setinfo': 'client.setinfo',
 }
 
 const commandIntrospection: CommandIntrospection = {
@@ -89,10 +96,20 @@ export const commandCommand = defineCommand({
       case 'info':
         return commandInfoSubcommand(args, ctx)
       case 'docs':
+        if (!ctx.server.profile.has('command.docs')) {
+          throw new RedisCommandError(
+            `unknown subcommand '${args.subcommand}'. Try COMMAND HELP.`,
+          )
+        }
         return commandDocsSubcommand(args, ctx)
       case 'getkeys':
         return commandGetKeys(args, ctx)
       case 'getkeysandflags':
+        if (!ctx.server.profile.has('command.getkeysandflags')) {
+          throw new RedisCommandError(
+            `unknown subcommand '${args.subcommand}'. Try COMMAND HELP.`,
+          )
+        }
         return commandGetKeysAndFlags(args, ctx)
       case 'help':
         return commandHelp(args)
@@ -271,7 +288,7 @@ function planCommandKeys(
 function allRootCommandInfos(ctx: RedisExecutionContext): CommandInfo[] {
   return ctx.executor
     .getCommandDefinitions()
-    .map(definition => createCommandInfo(definition))
+    .map(definition => createCommandInfo(definition, ctx))
 }
 
 function allCommandInfos(ctx: RedisExecutionContext): CommandInfo[] {
@@ -298,12 +315,14 @@ function findCommandInfo(
 
 function createCommandInfo(
   definition: CommandDefinition<unknown>,
+  ctx: RedisExecutionContext,
 ): CommandInfo {
   const name = definition.name.toLowerCase()
   return createCommandInfoFromIntrospection(
     name,
     definition.flags,
     definition.introspection,
+    ctx,
   )
 }
 
@@ -311,6 +330,7 @@ function createCommandInfoFromIntrospection(
   name: string,
   fallbackFlags: readonly string[],
   introspection?: CommandIntrospection,
+  ctx?: RedisExecutionContext,
 ): CommandInfo {
   const keySpecs = introspection?.keySpecs ?? []
   const firstKey = introspection?.firstKey ?? firstKeyFromSpecs(keySpecs)
@@ -328,20 +348,35 @@ function createCommandInfoFromIntrospection(
     categories: introspection?.categories ?? inferCategories(flags),
     tips: introspection?.tips ?? [],
     keySpecs,
-    subcommands: (introspection?.subcommands ?? []).map(subcommand => {
-      if (!subcommand.name) {
-        throw new Error('Synthetic command introspection is missing a name')
-      }
-      return createCommandInfoFromIntrospection(
-        subcommand.name,
-        subcommand.flags ?? [],
-        subcommand,
-      )
-    }),
+    subcommands: (introspection?.subcommands ?? [])
+      .filter(subcommand => subcommandAvailable(subcommand, ctx))
+      .map(subcommand => {
+        if (!subcommand.name) {
+          throw new Error('Synthetic command introspection is missing a name')
+        }
+        return createCommandInfoFromIntrospection(
+          subcommand.name,
+          subcommand.flags ?? [],
+          subcommand,
+          ctx,
+        )
+      }),
     docs:
       introspection?.docs ??
       commandDocs(`${name.toUpperCase()} command`, 'generic'),
   }
+}
+
+function subcommandAvailable(
+  introspection: CommandIntrospection,
+  ctx?: RedisExecutionContext,
+): boolean {
+  if (!ctx || !introspection.name) {
+    return true
+  }
+
+  const feature = SUBCOMMAND_FEATURES[introspection.name.toLowerCase()]
+  return feature === undefined || ctx.server.profile.has(feature)
 }
 
 function commandInfo(

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -19,7 +19,7 @@ import { RedisValue } from '../core/redis-value'
 import { array, bulk, integer, ok, simpleString } from './helpers'
 import { commandSubcommandInfo } from './introspection'
 
-const REDIS_VERSION = '7.4.4'
+const VALKEY_REDIS_COMPAT_VERSION = '7.2.4'
 const MASTER_REPLID = '0000000000000000000000000000000000000000'
 
 // There is no persistence, so LASTSAVE reports the process/server start time.
@@ -104,7 +104,7 @@ function buildInfo(ctx: RedisExecutionContext, section?: string): string {
   const sectionBuilders: Record<string, () => string[]> = {
     server: () => [
       '# Server',
-      `redis_version:${REDIS_VERSION}`,
+      ...serverIdentityLines(ctx),
       'redis_git_sha1:00000000',
       'redis_git_dirty:0',
       `redis_mode:${redisMode(ctx)}`,
@@ -478,6 +478,12 @@ export const clientCommand = defineCommand({
     }
 
     if (subcommand === 'setinfo') {
+      if (!ctx.server.profile.has('client.setinfo')) {
+        throw new RedisCommandError(
+          `unknown subcommand '${subcommand}'. Try CLIENT HELP.`,
+        )
+      }
+
       expectArgCount('client|setinfo', args.args, 2)
       const attribute = args.args[0].toString().toLowerCase()
       if (attribute === 'lib-name') {
@@ -583,8 +589,8 @@ export const helloCommand = defineCommand({
     ctx.session.setProtocolVersion(version)
 
     const fields: [RedisValue, RedisValue][] = [
-      [value('server'), value('redis')],
-      [value('version'), value(REDIS_VERSION)],
+      [value('server'), value(ctx.server.profile.flavor)],
+      [value('version'), value(ctx.server.profile.version)],
       [value('proto'), RedisValue.integer(version)],
       [value('id'), RedisValue.integer(getClientId(ctx.session))],
       [value('mode'), value(redisMode(ctx))],
@@ -599,6 +605,19 @@ export const helloCommand = defineCommand({
     return RedisResult.create(RedisValue.array(fields.flat()))
   },
 })
+
+function serverIdentityLines(ctx: RedisExecutionContext): string[] {
+  const profile = ctx.server.profile
+  if (profile.flavor === 'redis') {
+    return [`redis_version:${profile.version}`]
+  }
+
+  return [
+    `redis_version:${VALKEY_REDIS_COMPAT_VERSION}`,
+    'server_name:valkey',
+    `valkey_version:${profile.version}`,
+  ]
+}
 
 export const authCommand = defineCommand({
   name: 'auth',
@@ -632,6 +651,7 @@ export const authCommand = defineCommand({
 
 export const resetCommand = defineCommand({
   name: 'reset',
+  since: { redis: '6.2.0', valkey: '7.2.0' },
   schema: t.object({}),
   // 'transaction' makes RESET bypass MULTI queueing and run immediately, like
   // EXEC/DISCARD/WATCH — it aborts the in-flight transaction via

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -512,7 +512,7 @@ export const clientCommand = defineCommand({
 
     if (subcommand === 'help') {
       expectArgCount('client|help', args.args, 0)
-      return array([
+      const lines = [
         value(
           'CLIENT <subcommand> [<arg> [value] [opt] ...]. Subcommands are:',
         ),
@@ -521,8 +521,11 @@ export const clientCommand = defineCommand({
         value('LIST'),
         value('GETNAME'),
         value('SETNAME <connection-name>'),
-        value('SETINFO <LIB-NAME|LIB-VER> <value>'),
-      ])
+      ]
+      if (ctx.server.profile.has('client.setinfo')) {
+        lines.push(value('SETINFO <LIB-NAME|LIB-VER> <value>'))
+      }
+      return array(lines)
     }
 
     throw new RedisCommandError(

--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -45,6 +45,10 @@ type HashExpireMode =
   | 'milliseconds'
   | 'unix-seconds'
   | 'unix-milliseconds'
+
+const HASH_FIELD_EXPIRATION_SINCE = { redis: '7.4.0', valkey: '9.0.0' } as const
+const HGETEX_SINCE = { redis: '8.0.0', valkey: '9.0.0' } as const
+const HGETDEL_SINCE = { redis: '8.0.0', valkey: '9.1.0' } as const
 type HashExpireArgs = {
   key: Buffer
   rawArgs: Buffer[]
@@ -697,6 +701,7 @@ export const hdelCommand = defineCommand({
 
 export const hgetdelCommand = defineCommand({
   name: 'hgetdel',
+  since: HGETDEL_SINCE,
   schema: createHashFieldsSchema(),
   flags: ['write', 'fast'],
   keys: args => [args.key],
@@ -726,6 +731,7 @@ export const hgetdelCommand = defineCommand({
 
 export const hgetexCommand = defineCommand({
   name: 'hgetex',
+  since: HGETEX_SINCE,
   schema: createHgetexSchema(),
   flags: ['write', 'fast'],
   keys: args => [args.key],
@@ -734,6 +740,7 @@ export const hgetexCommand = defineCommand({
 
 export const hpersistCommand = defineCommand({
   name: 'hpersist',
+  since: HASH_FIELD_EXPIRATION_SINCE,
   schema: createHashFieldsSchema(),
   flags: ['write', 'fast'],
   keys: args => [args.key],
@@ -742,6 +749,7 @@ export const hpersistCommand = defineCommand({
 
 export const hexpireCommand = defineCommand({
   name: 'hexpire',
+  since: HASH_FIELD_EXPIRATION_SINCE,
   schema: createHashExpireSchema(),
   flags: ['write', 'fast'],
   keys: args => [args.key],
@@ -750,6 +758,7 @@ export const hexpireCommand = defineCommand({
 
 export const hpexpireCommand = defineCommand({
   name: 'hpexpire',
+  since: HASH_FIELD_EXPIRATION_SINCE,
   schema: createHashExpireSchema(),
   flags: ['write', 'fast'],
   keys: args => [args.key],
@@ -758,6 +767,7 @@ export const hpexpireCommand = defineCommand({
 
 export const hexpireatCommand = defineCommand({
   name: 'hexpireat',
+  since: HASH_FIELD_EXPIRATION_SINCE,
   schema: createHashExpireSchema(),
   flags: ['write', 'fast'],
   keys: args => [args.key],
@@ -766,6 +776,7 @@ export const hexpireatCommand = defineCommand({
 
 export const hpexpireatCommand = defineCommand({
   name: 'hpexpireat',
+  since: HASH_FIELD_EXPIRATION_SINCE,
   schema: createHashExpireSchema(),
   flags: ['write', 'fast'],
   keys: args => [args.key],
@@ -774,6 +785,7 @@ export const hpexpireatCommand = defineCommand({
 
 export const httlCommand = defineCommand({
   name: 'httl',
+  since: HASH_FIELD_EXPIRATION_SINCE,
   schema: createHashFieldsSchema(),
   flags: ['readonly', 'fast'],
   keys: args => [args.key],
@@ -782,6 +794,7 @@ export const httlCommand = defineCommand({
 
 export const hpttlCommand = defineCommand({
   name: 'hpttl',
+  since: HASH_FIELD_EXPIRATION_SINCE,
   schema: createHashFieldsSchema(),
   flags: ['readonly', 'fast'],
   keys: args => [args.key],

--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -890,6 +890,7 @@ export const hvalsCommand = defineCommand({
 
 export const hrandfieldCommand = defineCommand({
   name: 'hrandfield',
+  since: { redis: '6.2.0', valkey: '7.2.0' },
   schema: createHrandfieldSchema(),
   flags: ['readonly', 'random', 'noscript'],
   keys: args => [args.key],

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,6 +1,12 @@
 import type { CommandDefinition } from '../core/command-definition'
 import { CommandExecutor } from '../core/command-executor'
 import { CommandRegistry } from '../core/command-registry'
+import {
+  gateSatisfied,
+  resolveCompatibilityProfile,
+  type CompatibilityProfile,
+  type CompatibilitySpec,
+} from '../core/compatibility'
 import type { ExecutionPolicy } from '../core/execution-policies'
 import {
   createAuthPolicy,
@@ -43,19 +49,25 @@ export const redisCommandDefinitions: readonly CommandDefinition[] = [
 
 export function createRedisCommandRegistry(
   extraCommands: readonly CommandDefinition[] = [],
+  profile: CompatibilityProfile = resolveCompatibilityProfile(),
 ): CommandRegistry {
   const registry = new CommandRegistry()
-  registry.registerAll(redisCommandDefinitions)
-  registry.registerAll(extraCommands)
+  registry.registerAll(
+    filterCompatibleCommands(redisCommandDefinitions, profile),
+  )
+  registry.registerAll(filterCompatibleCommands(extraCommands, profile))
   return registry
 }
 
 export function createRedisCommandExecutor(options?: {
   extraCommands?: readonly CommandDefinition[]
   policies?: readonly ExecutionPolicy[]
+  compatibility?: CompatibilitySpec
 }): CommandExecutor {
+  const profile = resolveCompatibilityProfile(options?.compatibility)
   return new CommandExecutor({
-    registry: createRedisCommandRegistry(options?.extraCommands),
+    registry: createRedisCommandRegistry(options?.extraCommands, profile),
+    profile,
     policies: [
       createAuthPolicy(),
       createSubscribedModePolicy(),
@@ -63,6 +75,17 @@ export function createRedisCommandExecutor(options?: {
       createTransactionPolicy(),
     ],
   })
+}
+
+function filterCompatibleCommands(
+  definitions: readonly CommandDefinition[],
+  profile: CompatibilityProfile,
+): CommandDefinition[] {
+  return definitions.filter(
+    definition =>
+      definition.since === undefined ||
+      gateSatisfied(definition.since, profile),
+  )
 }
 
 export {

--- a/src/commands/keys.ts
+++ b/src/commands/keys.ts
@@ -167,6 +167,7 @@ export const pttlCommand = defineCommand({
 
 export const expiretimeCommand = defineCommand({
   name: 'expiretime',
+  since: { redis: '7.0.0', valkey: '7.2.0' },
   schema: t.object({
     key: t.key(),
   }),
@@ -189,6 +190,7 @@ export const expiretimeCommand = defineCommand({
 
 export const pexpiretimeCommand = defineCommand({
   name: 'pexpiretime',
+  since: { redis: '7.0.0', valkey: '7.2.0' },
   schema: t.object({
     key: t.key(),
   }),
@@ -215,13 +217,23 @@ type ExpireOptions = {
   comparison?: ExpireComparison
 }
 
-const expireOptionsSchema = t.custom<ExpireOptions>((input, index) => {
+const expireOptionsSchema = t.custom<ExpireOptions>((input, index, ctx) => {
   const options: ExpireOptions = {}
   let cursor = index
 
   while (cursor < input.length) {
     const token = input[cursor]!.toString()
     const option = token.toUpperCase()
+
+    if (
+      (option === 'NX' ||
+        option === 'XX' ||
+        option === 'GT' ||
+        option === 'LT') &&
+      !ctx.profile.has('expire.conditions')
+    ) {
+      return { value: options, nextIndex: cursor }
+    }
 
     if (option === 'NX') {
       if (options.condition === 'XX' || options.comparison !== undefined) {
@@ -517,6 +529,7 @@ const copyOptionsSchema = t.custom<CopyOptions>((input, index) => {
 
 export const copyCommand = defineCommand({
   name: 'copy',
+  since: { redis: '6.2.0', valkey: '7.2.0' },
   schema: t.object({
     source: t.key(),
     destination: t.key(),
@@ -716,6 +729,7 @@ export const sortCommand = defineCommand({
 
 export const sortRoCommand = defineCommand({
   name: 'sort_ro',
+  since: { redis: '7.0.0', valkey: '7.2.0' },
   schema: sortSchema(false),
   flags: ['readonly'],
   keys: args => [args.key],

--- a/src/commands/lists/blmove.ts
+++ b/src/commands/lists/blmove.ts
@@ -71,6 +71,7 @@ async function blockingListMove(
 
 export const blmoveCommand = defineCommand({
   name: 'blmove',
+  since: { redis: '6.2.0', valkey: '7.2.0' },
   schema: t.custom<BlmoveArgs>((input, index, ctx) => {
     const source = input[index]
     const destination = input[index + 1]

--- a/src/commands/lists/lmpop.ts
+++ b/src/commands/lists/lmpop.ts
@@ -201,6 +201,7 @@ async function blockingListMultiPop(
 
 export const lmpopCommand = defineCommand({
   name: 'lmpop',
+  since: { redis: '7.0.0', valkey: '7.2.0' },
   schema: t.custom<ListMultiPopArgs>((input, index, ctx) => ({
     value: parseListMultiPopArgs(input, index, ctx, { blocking: false }),
     nextIndex: input.length,
@@ -214,6 +215,7 @@ export const lmpopCommand = defineCommand({
 
 export const blmpopCommand = defineCommand({
   name: 'blmpop',
+  since: { redis: '7.0.0', valkey: '7.2.0' },
   schema: t.custom<BlockingListMultiPopArgs>((input, index, ctx) => ({
     value: parseListMultiPopArgs(input, index, ctx, { blocking: true }),
     nextIndex: input.length,

--- a/src/commands/lists/move.ts
+++ b/src/commands/lists/move.ts
@@ -89,6 +89,7 @@ export const rpoplpushCommand = defineCommand({
 
 export const lmoveCommand = defineCommand({
   name: 'lmove',
+  since: { redis: '6.2.0', valkey: '7.2.0' },
   schema: t.object({
     source: t.key(),
     destination: t.key(),

--- a/src/commands/pubsub.ts
+++ b/src/commands/pubsub.ts
@@ -56,6 +56,7 @@ export const unsubscribeCommand = defineCommand({
 
 export const ssubscribeCommand = defineCommand({
   name: 'ssubscribe',
+  since: { redis: '7.0.0', valkey: '7.2.0' },
   schema: t.object({
     channels: t.variadic(t.key(), { min: 1 }),
   }),
@@ -75,6 +76,7 @@ export const ssubscribeCommand = defineCommand({
 
 export const sunsubscribeCommand = defineCommand({
   name: 'sunsubscribe',
+  since: { redis: '7.0.0', valkey: '7.2.0' },
   schema: t.object({
     channels: t.variadic(t.key()),
   }),
@@ -152,6 +154,7 @@ export const publishCommand = defineCommand({
 
 export const spublishCommand = defineCommand({
   name: 'spublish',
+  since: { redis: '7.0.0', valkey: '7.2.0' },
   schema: t.object({
     channel: t.key(),
     message: t.bulk(),
@@ -223,6 +226,11 @@ export const pubsubCommand = defineCommand({
     }
 
     if (subcommand === 'shardchannels') {
+      if (!ctx.server.profile.has('pubsub.sharded')) {
+        throw new RedisCommandError(
+          `unknown subcommand '${args.subcommand}'. Try PUBSUB HELP.`,
+        )
+      }
       expectPubSubSubcommandMaxArgCount(args.subcommand, args.args, 1)
       const channels = ctx.server.pubsubBroker.shardChannelsMatching(
         args.args[0],
@@ -231,6 +239,11 @@ export const pubsubCommand = defineCommand({
     }
 
     if (subcommand === 'shardnumsub') {
+      if (!ctx.server.profile.has('pubsub.sharded')) {
+        throw new RedisCommandError(
+          `unknown subcommand '${args.subcommand}'. Try PUBSUB HELP.`,
+        )
+      }
       return RedisResult.create(
         RedisValue.array(
           args.args.flatMap(channel => [
@@ -245,7 +258,7 @@ export const pubsubCommand = defineCommand({
 
     if (subcommand === 'help') {
       expectArgCount('pubsub|help', args.args, 0)
-      return pubsubHelp()
+      return pubsubHelp(ctx)
     }
 
     throw new RedisCommandError(
@@ -285,24 +298,31 @@ function pubsubNumsub(args: PubSubArgs, ctx: RedisExecutionContext) {
   )
 }
 
-function pubsubHelp(): RedisResult {
+function pubsubHelp(ctx: RedisExecutionContext): RedisResult {
+  const lines = [
+    'PUBSUB <subcommand> [<arg> [value] [opt] ...]. Subcommands are:',
+    'CHANNELS [<pattern>]',
+    '    Return the currently active channels matching a pattern.',
+    'NUMSUB [<channel> ...]',
+    '    Return the number of subscribers for the specified channels.',
+    'NUMPAT',
+    '    Return the number of pattern subscriptions.',
+  ]
+
+  if (ctx.server.profile.has('pubsub.sharded')) {
+    lines.push(
+      'SHARDCHANNELS [<pattern>]',
+      '    Return active shard channels matching a pattern.',
+      'SHARDNUMSUB [<channel> ...]',
+      '    Return the number of shard subscribers for the specified channels.',
+    )
+  }
+
+  lines.push('HELP', '    Prints this help.')
+
   return RedisResult.create(
     RedisValue.array(
-      [
-        'PUBSUB <subcommand> [<arg> [value] [opt] ...]. Subcommands are:',
-        'CHANNELS [<pattern>]',
-        '    Return the currently active channels matching a pattern.',
-        'NUMSUB [<channel> ...]',
-        '    Return the number of subscribers for the specified channels.',
-        'NUMPAT',
-        '    Return the number of pattern subscriptions.',
-        'SHARDCHANNELS [<pattern>]',
-        '    Return active shard channels matching a pattern.',
-        'SHARDNUMSUB [<channel> ...]',
-        '    Return the number of shard subscribers for the specified channels.',
-        'HELP',
-        '    Prints this help.',
-      ].map(line => RedisValue.bulkString(Buffer.from(line))),
+      lines.map(line => RedisValue.bulkString(Buffer.from(line))),
     ),
   )
 }

--- a/src/commands/sets.ts
+++ b/src/commands/sets.ts
@@ -231,6 +231,7 @@ export const sismemberCommand = defineCommand({
 
 export const smismemberCommand = defineCommand({
   name: 'smismember',
+  since: { redis: '6.2.0', valkey: '7.2.0' },
   schema: t.object({ key: t.key(), members: t.variadic(t.key(), { min: 1 }) }),
   flags: ['readonly', 'fast'],
   keys: args => [args.key],
@@ -394,6 +395,7 @@ export const sinterCommand = defineCommand({
 
 export const sintercardCommand = defineCommand({
   name: 'sintercard',
+  since: { redis: '7.0.0', valkey: '7.2.0' },
   schema: sintercardSchema,
   flags: ['readonly'],
   keys: args => args.keys,

--- a/src/commands/streams/xautoclaim.ts
+++ b/src/commands/streams/xautoclaim.ts
@@ -73,6 +73,7 @@ function createXautoclaimSchema() {
 
 export const xautoclaimCommand = defineCommand({
   name: 'xautoclaim',
+  since: { redis: '6.2.0', valkey: '7.2.0' },
   schema: t.object({ args: createXautoclaimSchema() }),
   flags: ['write'],
   keys: args => [args.args.key],

--- a/src/commands/strings.ts
+++ b/src/commands/strings.ts
@@ -285,6 +285,7 @@ export const getsetCommand = defineCommand({
 
 export const getdelCommand = defineCommand({
   name: 'getdel',
+  since: { redis: '6.2.0', valkey: '7.2.0' },
   schema: t.object({ key: t.key() }),
   flags: ['write', 'fast'],
   keys: args => [args.key],
@@ -451,6 +452,7 @@ export const setrangeCommand = defineCommand({
 
 export const getexCommand = defineCommand({
   name: 'getex',
+  since: { redis: '6.2.0', valkey: '7.2.0' },
   schema: createGetexSchema(),
   flags: ['write', 'fast'],
   keys: args => [args.key],
@@ -523,6 +525,10 @@ function createSetSchema(): CommandSchema<SetArgs> {
         }
 
         if (option === 'GET') {
+          if (!ctx.profile.has('set.get')) {
+            throw new RedisSyntaxError()
+          }
+
           if (args.get) {
             throw new RedisSyntaxError()
           }
@@ -548,6 +554,13 @@ function createSetSchema(): CommandSchema<SetArgs> {
           option === 'EXAT' ||
           option === 'PXAT'
         ) {
+          if (
+            (option === 'EXAT' || option === 'PXAT') &&
+            !ctx.profile.has('set.exat-pxat')
+          ) {
+            throw new RedisSyntaxError()
+          }
+
           if (args.expiresAt !== undefined || args.keepTtl) {
             throw new RedisSyntaxError()
           }

--- a/src/commands/zsets/zmpop.ts
+++ b/src/commands/zsets/zmpop.ts
@@ -232,6 +232,7 @@ async function blockingZsetMultiPop(
 
 export const zmpopCommand = defineCommand({
   name: 'zmpop',
+  since: { redis: '7.0.0', valkey: '7.2.0' },
   schema: t.custom<ZsetMultiPopArgs>((input, index, ctx) => ({
     value: parseZsetMultiPopArgs(input, index, ctx, { blocking: false }),
     nextIndex: input.length,
@@ -245,6 +246,7 @@ export const zmpopCommand = defineCommand({
 
 export const bzmpopCommand = defineCommand({
   name: 'bzmpop',
+  since: { redis: '7.0.0', valkey: '7.2.0' },
   schema: t.custom<BlockingZsetMultiPopArgs>((input, index, ctx) => ({
     value: parseZsetMultiPopArgs(input, index, ctx, { blocking: true }),
     nextIndex: input.length,

--- a/src/commands/zsets/zscore.ts
+++ b/src/commands/zsets/zscore.ts
@@ -20,6 +20,7 @@ export const zscoreCommand = defineCommand({
 
 export const zmscoreCommand = defineCommand({
   name: 'zmscore',
+  since: { redis: '6.2.0', valkey: '7.2.0' },
   schema: t.object({ key: t.key(), members: t.variadic(t.key(), { min: 1 }) }),
   flags: ['readonly', 'fast'],
   keys: args => [args.key],

--- a/src/commands/zsets/zsetops.ts
+++ b/src/commands/zsets/zsetops.ts
@@ -382,6 +382,7 @@ const zintercardSchema = t.custom<ZintercardArgs>((input, index, ctx) => {
 
 export const zintercardCommand = defineCommand({
   name: 'zintercard',
+  since: { redis: '7.0.0', valkey: '7.2.0' },
   schema: zintercardSchema,
   flags: ['readonly'],
   keys: args => args.keys,

--- a/src/core/command-definition.ts
+++ b/src/core/command-definition.ts
@@ -2,6 +2,7 @@ import type { CommandSchema } from './command-schema'
 import type { RedisExecutionContext } from './redis-context'
 import type { RedisResult } from './redis-result'
 import type { ResponseStream } from './response-stream'
+import type { VersionGate } from './compatibility'
 
 export type CommandFlag =
   | 'readonly'
@@ -87,6 +88,7 @@ export type CommandExecutionResult =
 
 export interface CommandDefinition<TArgs = unknown> {
   readonly name: string
+  readonly since?: VersionGate
   readonly schema: CommandSchema<TArgs>
   readonly flags: readonly CommandFlag[]
   readonly capabilities?: CommandCapabilities

--- a/src/core/command-executor.ts
+++ b/src/core/command-executor.ts
@@ -12,6 +12,10 @@ import type { RedisExecutionContext } from './redis-context'
 import { RedisResult } from './redis-result'
 import { isResponseStream, ResponseStream } from './response-stream'
 import type { RedisMonitorCommandEvent } from '../state/monitor-feed'
+import {
+  resolveCompatibilityProfile,
+  type CompatibilityProfile,
+} from './compatibility'
 
 /**
  * The result of running a command: either a finished {@link RedisResult} or a
@@ -28,6 +32,7 @@ export type RawExecutionResult = {
 export type CommandExecutorOptions = {
   registry: CommandRegistry
   policies?: readonly ExecutionPolicy[]
+  profile?: CompatibilityProfile
 }
 
 /**
@@ -54,10 +59,12 @@ export type CommandExecutorOptions = {
 export class CommandExecutor {
   private readonly registry: CommandRegistry
   private readonly policies: readonly ExecutionPolicy[]
+  readonly profile: CompatibilityProfile
 
   constructor(options: CommandExecutorOptions) {
     this.registry = options.registry
     this.policies = options.policies ?? []
+    this.profile = options.profile ?? resolveCompatibilityProfile()
   }
 
   getCommandDefinition(name: string): CommandDefinition<unknown> | undefined {
@@ -326,7 +333,12 @@ export class CommandExecutor {
     rawCommand: Buffer | string,
     rawArgs: readonly Buffer[],
   ): CommandPlan<TArgs> {
-    const args = parseCommandArgs(definition.schema, rawArgs, definition.name)
+    const args = parseCommandArgs(
+      definition.schema,
+      rawArgs,
+      definition.name,
+      this.profile,
+    )
     const keys = definition.keys(args)
 
     return {

--- a/src/core/command-schema.ts
+++ b/src/core/command-schema.ts
@@ -5,9 +5,14 @@ import {
   RedisSyntaxError,
   WrongNumberOfArgumentsError,
 } from './redis-error'
+import {
+  resolveCompatibilityProfile,
+  type CompatibilityProfile,
+} from './compatibility'
 
 export type ParseContext = {
   commandName: string
+  profile: CompatibilityProfile
 }
 
 export type ParseNodeResult<TValue> = {
@@ -52,9 +57,10 @@ export function parseCommandArgs<TArgs>(
   schema: CommandSchema<TArgs>,
   input: readonly Buffer[],
   commandName: string,
+  profile: CompatibilityProfile = resolveCompatibilityProfile(),
 ): TArgs {
   try {
-    const result = schema.parse(input, 0, { commandName })
+    const result = schema.parse(input, 0, { commandName, profile })
     if (result.nextIndex !== input.length) {
       throw new WrongNumberOfArgumentsError(commandName)
     }

--- a/src/core/compatibility/feature-gates.ts
+++ b/src/core/compatibility/feature-gates.ts
@@ -1,0 +1,11 @@
+import type { FeatureId, VersionGate } from './profile'
+
+export const FEATURE_GATES: Record<FeatureId, VersionGate> = {
+  'expire.conditions': { redis: '7.0.0', valkey: '7.2.0' },
+  'set.get': { redis: '6.2.0', valkey: '7.2.0' },
+  'set.exat-pxat': { redis: '6.2.0', valkey: '7.2.0' },
+  'command.docs': { redis: '7.0.0', valkey: '7.2.0' },
+  'command.getkeysandflags': { redis: '7.0.0', valkey: '7.2.0' },
+  'client.setinfo': { redis: '7.2.0', valkey: '7.2.0' },
+  'cluster.multi-db': { valkey: '9.0.0' },
+}

--- a/src/core/compatibility/feature-gates.ts
+++ b/src/core/compatibility/feature-gates.ts
@@ -7,5 +7,6 @@ export const FEATURE_GATES: Record<FeatureId, VersionGate> = {
   'command.docs': { redis: '7.0.0', valkey: '7.2.0' },
   'command.getkeysandflags': { redis: '7.0.0', valkey: '7.2.0' },
   'client.setinfo': { redis: '7.2.0', valkey: '7.2.0' },
+  'pubsub.sharded': { redis: '7.0.0', valkey: '7.2.0' },
   'cluster.multi-db': { valkey: '9.0.0' },
 }

--- a/src/core/compatibility/index.ts
+++ b/src/core/compatibility/index.ts
@@ -1,0 +1,11 @@
+export { FEATURE_GATES } from './feature-gates'
+export {
+  gateSatisfied,
+  parseVersion,
+  resolveCompatibilityProfile,
+  type CompatibilityProfile,
+  type CompatibilitySpec,
+  type FeatureId,
+  type RedisFlavor,
+  type VersionGate,
+} from './profile'

--- a/src/core/compatibility/profile.ts
+++ b/src/core/compatibility/profile.ts
@@ -11,6 +11,7 @@ export type FeatureId =
   | 'command.docs'
   | 'command.getkeysandflags'
   | 'client.setinfo'
+  | 'pubsub.sharded'
   | 'cluster.multi-db'
 
 export interface CompatibilityProfile {
@@ -27,6 +28,7 @@ export type CompatibilitySpec =
   | 'redis-7.0'
   | 'redis-7.2'
   | 'redis-7.4'
+  | 'redis-8.0'
   | 'valkey-8.0'
   | 'valkey-9.0'
 
@@ -41,11 +43,12 @@ const PRESETS: Record<
   'redis-7.0': { flavor: 'redis', version: '7.0.15' },
   'redis-7.2': { flavor: 'redis', version: '7.2.4' },
   'redis-7.4': { flavor: 'redis', version: '7.4.4' },
+  'redis-8.0': { flavor: 'redis', version: '8.0.0' },
   'valkey-8.0': { flavor: 'valkey', version: '8.0.0' },
   'valkey-9.0': { flavor: 'valkey', version: '9.0.0' },
 }
 
-const DEFAULT_SPEC = 'redis-7.4'
+const DEFAULT_SPEC = 'redis-8.0'
 
 export function parseVersion(version: string): number {
   const [majorRaw, minorRaw = '0', patchRaw = '0'] = version.split('.')

--- a/src/core/compatibility/profile.ts
+++ b/src/core/compatibility/profile.ts
@@ -1,0 +1,99 @@
+import { FEATURE_GATES } from './feature-gates'
+
+export type RedisFlavor = 'redis' | 'valkey'
+
+export type VersionGate = { redis?: string; valkey?: string }
+
+export type FeatureId =
+  | 'expire.conditions'
+  | 'set.get'
+  | 'set.exat-pxat'
+  | 'command.docs'
+  | 'command.getkeysandflags'
+  | 'client.setinfo'
+  | 'cluster.multi-db'
+
+export interface CompatibilityProfile {
+  readonly flavor: RedisFlavor
+  readonly version: string
+  readonly versionNum: number
+  has(feature: FeatureId): boolean
+}
+
+export type CompatibilitySpec =
+  | CompatibilityProfile
+  | { flavor?: RedisFlavor; version?: string }
+  | 'redis-6.2'
+  | 'redis-7.0'
+  | 'redis-7.2'
+  | 'redis-7.4'
+  | 'valkey-8.0'
+  | 'valkey-9.0'
+
+const PRESETS: Record<
+  Exclude<
+    CompatibilitySpec,
+    CompatibilityProfile | { flavor?: RedisFlavor; version?: string }
+  >,
+  { flavor: RedisFlavor; version: string }
+> = {
+  'redis-6.2': { flavor: 'redis', version: '6.2.14' },
+  'redis-7.0': { flavor: 'redis', version: '7.0.15' },
+  'redis-7.2': { flavor: 'redis', version: '7.2.4' },
+  'redis-7.4': { flavor: 'redis', version: '7.4.4' },
+  'valkey-8.0': { flavor: 'valkey', version: '8.0.0' },
+  'valkey-9.0': { flavor: 'valkey', version: '9.0.0' },
+}
+
+const DEFAULT_SPEC = 'redis-7.4'
+
+export function parseVersion(version: string): number {
+  const [majorRaw, minorRaw = '0', patchRaw = '0'] = version.split('.')
+  const major = parseVersionPart(majorRaw, version)
+  const minor = parseVersionPart(minorRaw, version)
+  const patch = parseVersionPart(patchRaw, version)
+  return major * 10000 + minor * 100 + patch
+}
+
+export function resolveCompatibilityProfile(
+  spec: CompatibilitySpec = DEFAULT_SPEC,
+): CompatibilityProfile {
+  if (typeof spec === 'object' && 'has' in spec) {
+    return spec
+  }
+
+  if (typeof spec === 'string' && !(spec in PRESETS)) {
+    throw new Error(`Unknown compatibility profile ${spec}`)
+  }
+
+  const resolved = typeof spec === 'string' ? PRESETS[spec] : spec
+  const flavor = resolved.flavor ?? 'redis'
+  const version = resolved.version ?? PRESETS[DEFAULT_SPEC].version
+  const versionNum = parseVersion(version)
+
+  return {
+    flavor,
+    version,
+    versionNum,
+    has: feature =>
+      gateSatisfied(FEATURE_GATES[feature], { flavor, versionNum }),
+  }
+}
+
+export function gateSatisfied(
+  gate: VersionGate,
+  profile: Pick<CompatibilityProfile, 'flavor' | 'versionNum'>,
+): boolean {
+  const minimumVersion = gate[profile.flavor]
+  return (
+    minimumVersion !== undefined &&
+    profile.versionNum >= parseVersion(minimumVersion)
+  )
+}
+
+function parseVersionPart(raw: string | undefined, version: string): number {
+  if (raw === undefined || !/^\d+$/.test(raw)) {
+    throw new Error(`Invalid compatibility version ${version}`)
+  }
+  return Number(raw)
+}

--- a/src/core/execution-policies/cluster-policy.ts
+++ b/src/core/execution-policies/cluster-policy.ts
@@ -43,9 +43,10 @@ export function createClusterPolicy(
 
       if (capabilities?.clusterMode === 'singleDb') {
         // Cluster mode has a single logical database (0). DB 0 is a no-op and
-        // accepted; any non-zero index is rejected like real Redis.
+        // accepted; any non-zero index is rejected like real Redis unless the
+        // selected profile models Valkey's cluster multi-DB support.
         const index = (plan.args as { database: number }).database
-        if (index !== 0) {
+        if (index !== 0 && !ctx.server.profile.has('cluster.multi-db')) {
           throw new RedisCommandError(
             `${plan.definition.name.toUpperCase()} is not allowed in cluster mode`,
           )

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,17 @@ export {
 } from './cluster'
 
 export type { Logger } from './logger'
+export type {
+  CompatibilityProfile,
+  CompatibilitySpec,
+  FeatureId,
+  RedisFlavor,
+  VersionGate,
+} from './core/compatibility'
+export {
+  gateSatisfied,
+  resolveCompatibilityProfile,
+} from './core/compatibility'
 
 // Client-visible error classes
 export {

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -56,6 +56,13 @@ export type { RedisResultOptions } from './core/redis-result'
 export type { RespEncodeOptions, RespVersion } from './core/resp-encoder'
 export type { ResponseStream } from './core/response-stream'
 export type { RedisTurnHandle, RedisTurnQueue } from './core/turn-queue'
+export type {
+  CompatibilityProfile,
+  CompatibilitySpec,
+  FeatureId,
+  RedisFlavor,
+  VersionGate,
+} from './core/compatibility'
 export type { ClientSessionOptions } from './core/client-session'
 export type {
   ConnectionTransport,
@@ -74,6 +81,12 @@ export { CommandExecutor, type ExecutorResult } from './core/command-executor'
 export { CommandRegistry } from './core/command-registry'
 export { defineCommand } from './core/command-definition'
 export { t, parseCommandArgs } from './core/command-schema'
+export {
+  FEATURE_GATES,
+  gateSatisfied,
+  parseVersion,
+  resolveCompatibilityProfile,
+} from './core/compatibility'
 export {
   createAuthPolicy,
   createClusterPolicy,

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -9,6 +9,10 @@ import { Resp2Server } from './core/transports/resp2/server'
 import { RedisServerState } from './state'
 import { seedCluster, seedStandalone, type SeedEntry } from './seed'
 import type { Logger } from './logger'
+import {
+  resolveCompatibilityProfile,
+  type CompatibilitySpec,
+} from './core/compatibility'
 
 const DEFAULT_HOST = '127.0.0.1'
 const DEFAULT_DATABASE_COUNT = 16
@@ -20,6 +24,7 @@ export type CreateRedisServerOptions = {
   port?: number
   /** Logical database count. Defaults to 16, matching real Redis. */
   databaseCount?: number
+  compatibility?: CompatibilitySpec
   logger?: Pick<Logger, 'error'>
 }
 
@@ -30,6 +35,7 @@ export type CreateRedisServerClusterOptions = {
   basePort?: number
   /** Databases per cluster node. Defaults to 1. */
   databasesPerNode?: number
+  compatibility?: CompatibilitySpec
   logger?: Pick<Logger, 'error'>
 }
 
@@ -42,14 +48,22 @@ export type RedisServerHandle = {
 }
 
 /** Build a standalone keyspace + command pipeline (no transport). */
-function createStandalonePipeline(databaseCount?: number): {
+function createStandalonePipeline(
+  databaseCount?: number,
+  compatibility?: CompatibilitySpec,
+): {
   state: RedisServerState
   executor: CommandExecutor
 } {
+  const profile = resolveCompatibilityProfile(compatibility)
   const state = new RedisServerState({
     databaseCount: databaseCount ?? DEFAULT_DATABASE_COUNT,
+    compatibility: profile,
   })
-  return { state, executor: createRedisCommandExecutor() }
+  return {
+    state,
+    executor: createRedisCommandExecutor({ compatibility: profile }),
+  }
 }
 
 /**
@@ -79,13 +93,17 @@ export async function createRedisServer(
       replicasPerMaster: options.cluster.replicas ?? 0,
       basePort: options.basePort ?? 0,
       databasesPerNode: options.databasesPerNode,
+      compatibility: options.compatibility,
       logger: options.logger,
     })
     await cluster.listen()
     return cluster
   }
 
-  const { state, executor } = createStandalonePipeline(options.databaseCount)
+  const { state, executor } = createStandalonePipeline(
+    options.databaseCount,
+    options.compatibility,
+  )
   const server = new Resp2Server({
     server: state,
     executor,
@@ -117,6 +135,7 @@ export type CreateRedisMockOptions = {
   port?: number
   /** Cluster base port. Defaults to `0` (each node OS-assigned). */
   basePort?: number
+  compatibility?: CompatibilitySpec
   logger?: Pick<Logger, 'error'>
 }
 
@@ -175,7 +194,10 @@ export async function createRedisMock(
 async function createTcpStandaloneMock(
   options: CreateRedisMockOptions,
 ): Promise<RedisMock> {
-  const { state, executor } = createStandalonePipeline(options.databaseCount)
+  const { state, executor } = createStandalonePipeline(
+    options.databaseCount,
+    options.compatibility,
+  )
   const server = new Resp2Server({
     server: state,
     executor,
@@ -208,6 +230,7 @@ async function createClusterMock(
     masters: cluster.masters,
     replicasPerMaster: cluster.replicas ?? 0,
     basePort: options.basePort ?? 0,
+    compatibility: options.compatibility,
     logger: options.logger,
   })
 

--- a/src/state/server-state.ts
+++ b/src/state/server-state.ts
@@ -10,6 +10,11 @@ import {
   createRedisLuaRuntime,
   type RedisLuaRuntime,
 } from '../core/lua-runtime'
+import {
+  resolveCompatibilityProfile,
+  type CompatibilityProfile,
+  type CompatibilitySpec,
+} from '../core/compatibility'
 
 export type RedisServerStateOptions = {
   databaseCount?: number
@@ -28,6 +33,7 @@ export type RedisServerStateOptions = {
    * the default user is `nopass` and no authentication is enforced.
    */
   requirepass?: string
+  compatibility?: CompatibilitySpec
 }
 
 const DEFAULT_ACTIVE_EXPIRY_INTERVAL_MS = 100
@@ -39,6 +45,7 @@ export class RedisServerState {
   readonly pubsubBroker: RedisPubSubBroker
   readonly clusterTopology: RedisClusterTopology
   readonly requirepass?: string
+  readonly profile: CompatibilityProfile
   /**
    * Normalized `notify-keyspace-events` flag string (Redis canonical form, e.g.
    * `"AKE"`). Empty string disables keyspace notifications. Managed via
@@ -52,6 +59,7 @@ export class RedisServerState {
 
   constructor(options?: RedisServerStateOptions) {
     this.requirepass = options?.requirepass
+    this.profile = resolveCompatibilityProfile(options?.compatibility)
     const databaseCount = options?.databaseCount ?? 1
     if (!Number.isInteger(databaseCount) || databaseCount < 1) {
       throw new Error(`Invalid database count ${databaseCount}`)

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -46,8 +46,14 @@ describe('CLI argument parsing', () => {
     assert.strictEqual(options.masters, 5)
   })
 
+  test('parses compatibility profile', () => {
+    const options = parseArgs(['--compat', 'redis-6.2'])
+    assert.strictEqual(options.compatibility, 'redis-6.2')
+  })
+
   test('rejects invalid values', () => {
     assert.throws(() => parseArgs(['--port', 'abc']), /Invalid value/)
     assert.throws(() => parseArgs(['--mode', 'bad']), /Invalid mode/)
+    assert.throws(() => parseArgs(['--compat']), /Missing value/)
   })
 })

--- a/tests/compatibility/behavior.test.ts
+++ b/tests/compatibility/behavior.test.ts
@@ -125,6 +125,78 @@ describe('compatibility behavior gates', () => {
     )
   })
 
+  test('PUBSUB sharded subcommands follow their feature gate', async () => {
+    const redis62 = createSession('redis-6.2')
+    assertError(
+      (await redis62.execute('pubsub', buf('shardchannels'))) as RedisResult,
+      /unknown subcommand/i,
+    )
+
+    const redis70 = createSession('redis-7.0')
+    const result = (await redis70.execute(
+      'pubsub',
+      buf('shardchannels'),
+    )) as RedisResult
+    assert.strictEqual(result.value.kind, 'array')
+  })
+
+  test('HELP output hides gated subcommands', async () => {
+    const redis62 = createSession('redis-6.2')
+    const commandHelp62 = arrayTexts(
+      (await redis62.execute('command', buf('help'))) as RedisResult,
+    )
+    assert.strictEqual(
+      commandHelp62.some(line => line.includes('DOCS')),
+      false,
+    )
+    assert.strictEqual(
+      commandHelp62.some(line => line.includes('GETKEYSANDFLAGS')),
+      false,
+    )
+
+    const pubsubHelp62 = arrayTexts(
+      (await redis62.execute('pubsub', buf('help'))) as RedisResult,
+    )
+    assert.strictEqual(
+      pubsubHelp62.some(line => line.includes('SHARDCHANNELS')),
+      false,
+    )
+    assert.strictEqual(
+      pubsubHelp62.some(line => line.includes('SHARDNUMSUB')),
+      false,
+    )
+
+    const redis70 = createSession('redis-7.0')
+    const commandHelp70 = arrayTexts(
+      (await redis70.execute('command', buf('help'))) as RedisResult,
+    )
+    assert.strictEqual(
+      commandHelp70.some(line => line.includes('DOCS')),
+      true,
+    )
+    assert.strictEqual(
+      commandHelp70.some(line => line.includes('GETKEYSANDFLAGS')),
+      true,
+    )
+
+    const clientHelp70 = arrayTexts(
+      (await redis70.execute('client', buf('help'))) as RedisResult,
+    )
+    assert.strictEqual(
+      clientHelp70.some(line => line.includes('SETINFO')),
+      false,
+    )
+
+    const redis72 = createSession('redis-7.2')
+    const clientHelp72 = arrayTexts(
+      (await redis72.execute('client', buf('help'))) as RedisResult,
+    )
+    assert.strictEqual(
+      clientHelp72.some(line => line.includes('SETINFO')),
+      true,
+    )
+  })
+
   test('CLIENT SETINFO follows its feature gate', async () => {
     const redis70 = createSession('redis-7.0')
     assertError(
@@ -196,6 +268,11 @@ function commandSubcommandNames(result: RedisResult): string[] {
     assert.ok(name.value)
     return name.value.toString()
   })
+}
+
+function arrayTexts(result: RedisResult): string[] {
+  assert.strictEqual(result.value.kind, 'array')
+  return result.value.items.map(bulkStringText)
 }
 
 function helloField(result: RedisResult, key: string): string {

--- a/tests/compatibility/behavior.test.ts
+++ b/tests/compatibility/behavior.test.ts
@@ -1,0 +1,217 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+
+import {
+  ClientSession,
+  REDIS_CLUSTER_SLOT_COUNT,
+  RedisClusterTopology,
+  RedisResult,
+  RedisServerState,
+  RedisValue,
+  createClusterCommands,
+  createClusterPolicy,
+  createRedisCommandExecutor,
+  type CompatibilitySpec,
+} from '../../src/internal'
+
+function createSession(compatibility: CompatibilitySpec): ClientSession {
+  const server = new RedisServerState({ compatibility, databaseCount: 16 })
+  const executor = createRedisCommandExecutor({ compatibility: server.profile })
+  return new ClientSession({ server, executor })
+}
+
+function createClusterSession(compatibility: CompatibilitySpec): ClientSession {
+  const topology = new RedisClusterTopology([
+    {
+      id: 'local',
+      role: 'master',
+      host: '127.0.0.1',
+      port: 7000,
+      slots: [[0, REDIS_CLUSTER_SLOT_COUNT - 1]],
+    },
+  ])
+  const server = new RedisServerState({
+    compatibility,
+    clusterTopology: topology,
+    databaseCount: 16,
+  })
+  const executor = createRedisCommandExecutor({
+    compatibility: server.profile,
+    extraCommands: createClusterCommands('local'),
+    policies: [createClusterPolicy({ localNodeId: 'local', topology })],
+  })
+  return new ClientSession({ server, executor })
+}
+
+function buf(...values: string[]): Buffer[] {
+  return values.map(value => Buffer.from(value))
+}
+
+function assertError(result: RedisResult, pattern: RegExp): void {
+  assert.strictEqual(result.value.kind, 'error')
+  assert.match(result.value.message, pattern)
+}
+
+describe('compatibility behavior gates', () => {
+  test('EXPIRE conditions are rejected before Redis 7.0', async () => {
+    const redis62 = createSession('redis-6.2')
+    await redis62.execute('set', buf('k', 'v'))
+    assertError(
+      (await redis62.execute('expire', buf('k', '10', 'NX'))) as RedisResult,
+      /wrong number of arguments/i,
+    )
+
+    const redis70 = createSession('redis-7.0')
+    await redis70.execute('set', buf('k', 'v'))
+    const result = (await redis70.execute(
+      'expire',
+      buf('k', '10', 'NX'),
+    )) as RedisResult
+    assert.deepStrictEqual(result.value, { kind: 'integer', value: 1 })
+  })
+
+  test('SET newer options follow their feature gates', async () => {
+    const redis60 = createSession({ flavor: 'redis', version: '6.0.0' })
+    assertError(
+      (await redis60.execute('set', buf('k', 'v', 'GET'))) as RedisResult,
+      /syntax/i,
+    )
+
+    const redis62 = createSession('redis-6.2')
+    const result = (await redis62.execute(
+      'set',
+      buf('k', 'v', 'GET'),
+    )) as RedisResult
+    assert.deepStrictEqual(result.value, { kind: 'bulk-string', value: null })
+  })
+
+  test('COMMAND subcommands follow their feature gates', async () => {
+    const redis62 = createSession('redis-6.2')
+    assertError(
+      (await redis62.execute('command', buf('docs'))) as RedisResult,
+      /unknown subcommand/i,
+    )
+
+    const redis70 = createSession('redis-7.0')
+    const result = (await redis70.execute(
+      'command',
+      buf('docs'),
+    )) as RedisResult
+    assert.strictEqual(result.value.kind, 'map')
+  })
+
+  test('COMMAND introspection hides gated subcommands', async () => {
+    const redis62 = createSession('redis-6.2')
+    const redis62Info = (await redis62.execute(
+      'command',
+      buf('info', 'command'),
+    )) as RedisResult
+    assert.deepStrictEqual(commandSubcommandNames(redis62Info), [
+      'command|getkeys',
+      'command|info',
+      'command|count',
+      'command|list',
+      'command|help',
+    ])
+
+    const redis70 = createSession('redis-7.0')
+    const redis70Info = (await redis70.execute(
+      'command',
+      buf('info', 'command'),
+    )) as RedisResult
+    assert.ok(commandSubcommandNames(redis70Info).includes('command|docs'))
+    assert.ok(
+      commandSubcommandNames(redis70Info).includes('command|getkeysandflags'),
+    )
+  })
+
+  test('CLIENT SETINFO follows its feature gate', async () => {
+    const redis70 = createSession('redis-7.0')
+    assertError(
+      (await redis70.execute(
+        'client',
+        buf('setinfo', 'lib-name', 'test'),
+      )) as RedisResult,
+      /unknown subcommand/i,
+    )
+
+    const redis72 = createSession('redis-7.2')
+    assert.deepStrictEqual(
+      await redis72.execute('client', buf('setinfo', 'lib-name', 'test')),
+      RedisResult.ok(),
+    )
+  })
+
+  test('Valkey cluster profile allows non-zero SELECT', async () => {
+    const redis = createClusterSession('redis-7.4')
+    assert.deepStrictEqual(
+      await redis.execute('select', buf('1')),
+      RedisResult.error('SELECT is not allowed in cluster mode', 'ERR'),
+    )
+
+    const valkey = createClusterSession('valkey-9.0')
+    assert.deepStrictEqual(
+      await valkey.execute('select', buf('1')),
+      RedisResult.ok(),
+    )
+  })
+
+  test('INFO and HELLO report the selected profile', async () => {
+    const redis62 = createSession('redis-6.2')
+    const info = (await redis62.execute('info', buf('server'))) as RedisResult
+    assert.strictEqual(info.value.kind, 'bulk-string')
+    assert.ok(info.value.value)
+    assert.match(info.value.value.toString(), /^redis_version:6\.2\.14$/m)
+
+    const redisHello = (await redis62.execute('hello', buf('2'))) as RedisResult
+    assert.strictEqual(helloField(redisHello, 'server'), 'redis')
+    assert.strictEqual(helloField(redisHello, 'version'), '6.2.14')
+
+    const valkey = createSession('valkey-9.0')
+    const valkeyInfo = (await valkey.execute(
+      'info',
+      buf('server'),
+    )) as RedisResult
+    assert.strictEqual(valkeyInfo.value.kind, 'bulk-string')
+    assert.ok(valkeyInfo.value.value)
+    assert.match(valkeyInfo.value.value.toString(), /^server_name:valkey$/m)
+    assert.match(valkeyInfo.value.value.toString(), /^valkey_version:9\.0\.0$/m)
+
+    const valkeyHello = (await valkey.execute('hello', buf('2'))) as RedisResult
+    assert.strictEqual(helloField(valkeyHello, 'server'), 'valkey')
+    assert.strictEqual(helloField(valkeyHello, 'version'), '9.0.0')
+  })
+})
+
+function commandSubcommandNames(result: RedisResult): string[] {
+  assert.strictEqual(result.value.kind, 'array')
+  const [commandInfo] = result.value.items
+  assert.strictEqual(commandInfo.kind, 'array')
+  const subcommands = commandInfo.items[9]
+  assert.strictEqual(subcommands.kind, 'array')
+  return subcommands.items.map(subcommand => {
+    assert.strictEqual(subcommand.kind, 'array')
+    const name = subcommand.items[0]
+    assert.strictEqual(name.kind, 'bulk-string')
+    assert.ok(name.value)
+    return name.value.toString()
+  })
+}
+
+function helloField(result: RedisResult, key: string): string {
+  assert.strictEqual(result.value.kind, 'array')
+  for (let index = 0; index < result.value.items.length; index += 2) {
+    const field = result.value.items[index]
+    const value = result.value.items[index + 1]
+    if (bulkStringText(field) === key) {
+      return bulkStringText(value)
+    }
+  }
+  throw new Error(`Missing HELLO field ${key}`)
+}
+
+function bulkStringText(value: RedisValue): string {
+  assert.strictEqual(value.kind, 'bulk-string')
+  assert.ok(value.value)
+  return value.value.toString()
+}

--- a/tests/compatibility/builders.test.ts
+++ b/tests/compatibility/builders.test.ts
@@ -1,0 +1,45 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+
+import {
+  createRedisCluster,
+  createRedisMock,
+  createRedisServer,
+} from '../../src'
+
+describe('compatibility builder wiring', () => {
+  test('createRedisServer applies compatibility to standalone state', async () => {
+    const handle = await createRedisServer({ compatibility: 'redis-6.2' })
+    try {
+      assert.strictEqual(handle.state.profile.version, '6.2.14')
+    } finally {
+      await handle.close()
+    }
+  })
+
+  test('createRedisMock applies compatibility to standalone mocks', async () => {
+    const mock = await createRedisMock({ compatibility: 'redis-6.2' })
+    try {
+      assert.strictEqual(mock.state?.profile.version, '6.2.14')
+    } finally {
+      await mock.close()
+    }
+  })
+
+  test('createRedisCluster applies compatibility to every node', async () => {
+    const cluster = createRedisCluster({
+      masters: 2,
+      replicasPerMaster: 1,
+      basePort: 0,
+      compatibility: 'valkey-9.0',
+    })
+    try {
+      for (const node of cluster.nodes) {
+        assert.strictEqual(node.server.profile.flavor, 'valkey')
+        assert.strictEqual(node.server.profile.version, '9.0.0')
+      }
+    } finally {
+      await cluster.close()
+    }
+  })
+})

--- a/tests/compatibility/plumbing.test.ts
+++ b/tests/compatibility/plumbing.test.ts
@@ -1,0 +1,40 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+
+import { defineCommand } from '../../src/core/command-definition'
+import { CommandExecutor } from '../../src/core/command-executor'
+import { CommandRegistry } from '../../src/core/command-registry'
+import { t } from '../../src/core/command-schema'
+import { RedisResult } from '../../src/core/redis-result'
+import { RedisServerState } from '../../src/state'
+
+describe('compatibility profile plumbing', () => {
+  test('RedisServerState stores a resolved compatibility profile', () => {
+    const server = new RedisServerState({ compatibility: 'redis-6.2' })
+    assert.strictEqual(server.profile.flavor, 'redis')
+    assert.strictEqual(server.profile.version, '6.2.14')
+  })
+
+  test('CommandExecutor passes its profile into argument parsing', () => {
+    const registry = new CommandRegistry()
+    registry.register(
+      defineCommand({
+        name: 'probe',
+        schema: t.custom((_input, index, ctx) => ({
+          value: ctx.profile.has('expire.conditions'),
+          nextIndex: index,
+        })),
+        flags: ['readonly'],
+        keys: () => [],
+        execute: () => RedisResult.ok(),
+      }),
+    )
+
+    const executor = new CommandExecutor({
+      registry,
+      profile: new RedisServerState({ compatibility: 'redis-6.2' }).profile,
+    })
+
+    assert.deepStrictEqual(executor.plan('probe', []).args, false)
+  })
+})

--- a/tests/compatibility/profile.test.ts
+++ b/tests/compatibility/profile.test.ts
@@ -17,8 +17,8 @@ describe('compatibility profiles', () => {
   test('resolves the default and named presets', () => {
     const defaultProfile = resolveCompatibilityProfile()
     assert.strictEqual(defaultProfile.flavor, 'redis')
-    assert.strictEqual(defaultProfile.version, '7.4.4')
-    assert.strictEqual(defaultProfile.versionNum, 70404)
+    assert.strictEqual(defaultProfile.version, '8.0.0')
+    assert.strictEqual(defaultProfile.versionNum, 80000)
 
     const redis62 = resolveCompatibilityProfile('redis-6.2')
     assert.strictEqual(redis62.flavor, 'redis')
@@ -27,6 +27,10 @@ describe('compatibility profiles', () => {
     const valkey9 = resolveCompatibilityProfile('valkey-9.0')
     assert.strictEqual(valkey9.flavor, 'valkey')
     assert.strictEqual(valkey9.version, '9.0.0')
+
+    const redis80 = resolveCompatibilityProfile('redis-8.0')
+    assert.strictEqual(redis80.flavor, 'redis')
+    assert.strictEqual(redis80.version, '8.0.0')
   })
 
   test('rejects unknown preset strings at runtime', () => {

--- a/tests/compatibility/profile.test.ts
+++ b/tests/compatibility/profile.test.ts
@@ -1,0 +1,82 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+
+import {
+  gateSatisfied,
+  parseVersion,
+  resolveCompatibilityProfile,
+} from '../../src/core/compatibility'
+
+describe('compatibility profiles', () => {
+  test('parses semantic versions into comparable numbers', () => {
+    assert.strictEqual(parseVersion('6.2'), 60200)
+    assert.strictEqual(parseVersion('7.4.4'), 70404)
+    assert.strictEqual(parseVersion('10.0.1'), 100001)
+  })
+
+  test('resolves the default and named presets', () => {
+    const defaultProfile = resolveCompatibilityProfile()
+    assert.strictEqual(defaultProfile.flavor, 'redis')
+    assert.strictEqual(defaultProfile.version, '7.4.4')
+    assert.strictEqual(defaultProfile.versionNum, 70404)
+
+    const redis62 = resolveCompatibilityProfile('redis-6.2')
+    assert.strictEqual(redis62.flavor, 'redis')
+    assert.strictEqual(redis62.version, '6.2.14')
+
+    const valkey9 = resolveCompatibilityProfile('valkey-9.0')
+    assert.strictEqual(valkey9.flavor, 'valkey')
+    assert.strictEqual(valkey9.version, '9.0.0')
+  })
+
+  test('rejects unknown preset strings at runtime', () => {
+    assert.throws(
+      () =>
+        resolveCompatibilityProfile(
+          'redis-9.9' as Parameters<typeof resolveCompatibilityProfile>[0],
+        ),
+      /Unknown compatibility profile redis-9\.9/,
+    )
+  })
+
+  test('evaluates gates per flavor', () => {
+    assert.strictEqual(
+      gateSatisfied(
+        { redis: '7.0.0' },
+        resolveCompatibilityProfile('redis-6.2'),
+      ),
+      false,
+    )
+    assert.strictEqual(
+      gateSatisfied(
+        { redis: '7.0.0' },
+        resolveCompatibilityProfile('redis-7.0'),
+      ),
+      true,
+    )
+    assert.strictEqual(
+      gateSatisfied(
+        { valkey: '9.0.0' },
+        resolveCompatibilityProfile('redis-7.4'),
+      ),
+      false,
+    )
+  })
+
+  test('precomputes feature support from the profile', () => {
+    const redis62 = resolveCompatibilityProfile('redis-6.2')
+    assert.strictEqual(redis62.has('expire.conditions'), false)
+    assert.strictEqual(redis62.has('set.get'), true)
+    assert.strictEqual(redis62.has('client.setinfo'), false)
+
+    const valkey72 = resolveCompatibilityProfile({
+      flavor: 'valkey',
+      version: '7.2.4',
+    })
+    assert.strictEqual(valkey72.has('command.docs'), true)
+    assert.strictEqual(valkey72.has('cluster.multi-db'), false)
+
+    const valkey9 = resolveCompatibilityProfile('valkey-9.0')
+    assert.strictEqual(valkey9.has('cluster.multi-db'), true)
+  })
+})

--- a/tests/compatibility/registry.test.ts
+++ b/tests/compatibility/registry.test.ts
@@ -1,0 +1,101 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+
+import {
+  createRedisCommandExecutor,
+  createRedisCommandRegistry,
+} from '../../src/commands'
+import { defineCommand } from '../../src/core/command-definition'
+import { t } from '../../src/core/command-schema'
+import { RedisResult } from '../../src/core/redis-result'
+import { resolveCompatibilityProfile } from '../../src/core/compatibility'
+
+const futureCommand = defineCommand({
+  name: 'future',
+  since: { redis: '7.0.0' },
+  schema: t.object({}),
+  flags: ['readonly'],
+  keys: () => [],
+  execute: () => RedisResult.ok(),
+})
+
+describe('compatibility registry filtering', () => {
+  test('filters command definitions whose version gate is not satisfied', () => {
+    const redis62 = createRedisCommandRegistry(
+      [futureCommand],
+      resolveCompatibilityProfile('redis-6.2'),
+    )
+    assert.strictEqual(redis62.has('future'), false)
+
+    const redis70 = createRedisCommandRegistry(
+      [futureCommand],
+      resolveCompatibilityProfile('redis-7.0'),
+    )
+    assert.strictEqual(redis70.has('future'), true)
+  })
+
+  test('passes one resolved profile to the registry and executor', () => {
+    const executor = createRedisCommandExecutor({
+      extraCommands: [futureCommand],
+      compatibility: 'redis-6.2',
+    })
+
+    assert.strictEqual(executor.profile.version, '6.2.14')
+    assert.strictEqual(executor.getCommandDefinition('future'), undefined)
+  })
+
+  test('filters implemented root commands by Redis version', () => {
+    const redis60 = createRedisCommandRegistry(
+      [],
+      resolveCompatibilityProfile({ flavor: 'redis', version: '6.0.0' }),
+    )
+    for (const command of [
+      'getex',
+      'getdel',
+      'copy',
+      'hrandfield',
+      'lmove',
+      'blmove',
+      'smismember',
+      'xautoclaim',
+      'zmscore',
+      'reset',
+    ]) {
+      assert.strictEqual(redis60.has(command), false, command)
+    }
+
+    const redis62 = createRedisCommandRegistry(
+      [],
+      resolveCompatibilityProfile('redis-6.2'),
+    )
+    for (const command of ['getex', 'copy', 'hrandfield', 'lmove', 'zmscore']) {
+      assert.strictEqual(redis62.has(command), true, command)
+    }
+    for (const command of [
+      'expiretime',
+      'pexpiretime',
+      'lmpop',
+      'blmpop',
+      'zmpop',
+      'bzmpop',
+      'sintercard',
+      'sort_ro',
+    ]) {
+      assert.strictEqual(redis62.has(command), false, command)
+    }
+
+    const redis70 = createRedisCommandRegistry(
+      [],
+      resolveCompatibilityProfile('redis-7.0'),
+    )
+    for (const command of [
+      'expiretime',
+      'lmpop',
+      'zmpop',
+      'sintercard',
+      'sort_ro',
+    ]) {
+      assert.strictEqual(redis70.has(command), true, command)
+    }
+  })
+})

--- a/tests/compatibility/registry.test.ts
+++ b/tests/compatibility/registry.test.ts
@@ -79,6 +79,10 @@ describe('compatibility registry filtering', () => {
       'zmpop',
       'bzmpop',
       'sintercard',
+      'spublish',
+      'ssubscribe',
+      'sunsubscribe',
+      'zintercard',
       'sort_ro',
     ]) {
       assert.strictEqual(redis62.has(command), false, command)
@@ -93,9 +97,40 @@ describe('compatibility registry filtering', () => {
       'lmpop',
       'zmpop',
       'sintercard',
+      'spublish',
+      'ssubscribe',
+      'sunsubscribe',
+      'zintercard',
       'sort_ro',
     ]) {
       assert.strictEqual(redis70.has(command), true, command)
+    }
+
+    const redis74 = createRedisCommandRegistry(
+      [],
+      resolveCompatibilityProfile('redis-7.4'),
+    )
+    for (const command of [
+      'hpersist',
+      'hexpire',
+      'hpexpire',
+      'hexpireat',
+      'hpexpireat',
+      'httl',
+      'hpttl',
+    ]) {
+      assert.strictEqual(redis74.has(command), true, command)
+    }
+    for (const command of ['hgetdel', 'hgetex']) {
+      assert.strictEqual(redis74.has(command), false, command)
+    }
+
+    const redis80 = createRedisCommandRegistry(
+      [],
+      resolveCompatibilityProfile('redis-8.0'),
+    )
+    for (const command of ['hgetdel', 'hgetex']) {
+      assert.strictEqual(redis80.has(command), true, command)
     }
   })
 })


### PR DESCRIPTION
## Summary
- add Redis / Valkey compatibility profiles and feature gates
- wire profiles through state, executor, parser, registry, public builders, cluster builder, and CLI
- gate implemented commands/options/subcommands plus Valkey cluster multi-DB behavior
- document profile usage in README/API docs and add compatibility tests

## Validation
- npm run build
- npm run lint
- npm test
- npm run test:package
- prettier --check changed files
- git diff --check
- npm run test:integration:mock
- npm run test:integration:real

Note: the first combined integration verification hung in the mock runner after completed output; rerunning mock and real integration separately passed.