### PR TITLE
Gate SET NX GET by Redis profile

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -197,6 +197,7 @@ with `GT` or `LT`.
 
 - [x] `GET key` - Returns the string value of a key.
 - [x] `SET key value [NX | XX] [GET] [KEEPTTL | EX seconds | PX milliseconds | EXAT unix-time-seconds | PXAT unix-time-milliseconds]` - Set the string value of a key
+  - Compatibility profiles: `GET` is available in `redis-6.2`; combining `NX` with `GET` is available in `redis-7.0+`.
 - [x] `SETNX key value` - Set the value of a key, only if it does not exist
 - [x] `SETEX key seconds value` - Set the value and expiration in seconds
 - [x] `PSETEX key milliseconds value` - Set the value and expiration in milliseconds

--- a/src/commands/strings.ts
+++ b/src/commands/strings.ts
@@ -574,6 +574,14 @@ function createSetSchema(): CommandSchema<SetArgs> {
         throw new RedisSyntaxError()
       }
 
+      if (
+        args.condition === 'NX' &&
+        args.get &&
+        !ctx.profile.has('set.nx-get')
+      ) {
+        throw new RedisSyntaxError()
+      }
+
       return { value: args, nextIndex: input.length }
     },
   )

--- a/src/core/compatibility/feature-gates.ts
+++ b/src/core/compatibility/feature-gates.ts
@@ -3,6 +3,7 @@ import type { FeatureId, VersionGate } from './profile'
 export const FEATURE_GATES: Record<FeatureId, VersionGate> = {
   'expire.conditions': { redis: '7.0.0', valkey: '7.2.0' },
   'set.get': { redis: '6.2.0', valkey: '7.2.0' },
+  'set.nx-get': { redis: '7.0.0', valkey: '7.2.0' },
   'set.exat-pxat': { redis: '6.2.0', valkey: '7.2.0' },
   'command.docs': { redis: '7.0.0', valkey: '7.2.0' },
   'command.getkeysandflags': { redis: '7.0.0', valkey: '7.2.0' },

--- a/src/core/compatibility/profile.ts
+++ b/src/core/compatibility/profile.ts
@@ -7,6 +7,7 @@ export type VersionGate = { redis?: string; valkey?: string }
 export type FeatureId =
   | 'expire.conditions'
   | 'set.get'
+  | 'set.nx-get'
   | 'set.exat-pxat'
   | 'command.docs'
   | 'command.getkeysandflags'

--- a/tests-integration/compatibility/profile-gates.test.ts
+++ b/tests-integration/compatibility/profile-gates.test.ts
@@ -127,6 +127,7 @@ describe(
       await send('SET', key, 'v')
       await expectGate(supportsExpireConditions(), 'EXPIRE', key, '10', 'NX')
       await expectGate(true, 'SET', key, 'next', 'GET')
+      await expectGate(supportsSetNxGet(), 'SET', key, 'guarded', 'NX', 'GET')
       await expectGate(true, 'SET', key, 'expires', 'EXAT', '4102444800')
 
       await expectGate(supportsCommandDocs(), 'COMMAND', 'DOCS')
@@ -240,6 +241,10 @@ function supportsExpireConditions(): boolean {
 }
 
 function supportsRedis70Commands(): boolean {
+  return profile !== 'redis-6.2'
+}
+
+function supportsSetNxGet(): boolean {
   return profile !== 'redis-6.2'
 }
 

--- a/tests/compatibility/behavior.test.ts
+++ b/tests/compatibility/behavior.test.ts
@@ -83,6 +83,26 @@ describe('compatibility behavior gates', () => {
       buf('k', 'v', 'GET'),
     )) as RedisResult
     assert.deepStrictEqual(result.value, { kind: 'bulk-string', value: null })
+
+    assertError(
+      (await redis62.execute('set', buf('k', 'v', 'NX', 'GET'))) as RedisResult,
+      /syntax/i,
+    )
+    assertError(
+      (await redis62.execute('set', buf('k', 'v', 'GET', 'NX'))) as RedisResult,
+      /syntax/i,
+    )
+
+    const redis70 = createSession('redis-7.0')
+    await redis70.execute('set', buf('k', 'old'))
+    const nxGet = (await redis70.execute(
+      'set',
+      buf('k', 'new', 'NX', 'GET'),
+    )) as RedisResult
+    assert.deepStrictEqual(nxGet.value, {
+      kind: 'bulk-string',
+      value: Buffer.from('old'),
+    })
   })
 
   test('COMMAND subcommands follow their feature gates', async () => {


### PR DESCRIPTION
## Summary
- add a dedicated `set.nx-get` compatibility gate for the Redis 7.0 `SET NX GET` combination
- reject `SET NX GET` and `SET GET NX` under `redis-6.2` while keeping plain `SET GET` available there
- cover the gate in unit behavior tests and the mock compatibility profile integration matrix

## Root Cause
`SET GET` was correctly gated as Redis 6.2+, but the parser treated `GET` as globally combinable with `NX`. Redis 7.0 introduced the `NX` + `GET` combination, so `redis-6.2` profiles were accepting it too early.

## Real Redis Check
Verified against `redis:6.2-alpine` (`redis_version:6.2.22`):
- `SET k v NX GET` returns `ERR syntax error`
- `SET k v GET` succeeds and returns nil

## Validation
- `node --enable-source-maps --import tsx --no-warnings --test ./tests/compatibility/behavior.test.ts`
- `REDIS_COMPAT=redis-6.2 TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/compatibility/profile-gates.test.ts`
- `REDIS_COMPAT=redis-7.0 TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/compatibility/profile-gates.test.ts`
- `npm run build`
- `npm test`
- `npm run lint`
- `npm run test:integration:compatibility:mock`
- `npm run test:integration:mock`
- `npm run test:integration:real`

Fixes #305
Refs #296
