### PR TITLE
Gate XAUTOCLAIM deleted IDs by Redis profile

### DIFF
--- a/src/commands/streams/xautoclaim.ts
+++ b/src/commands/streams/xautoclaim.ts
@@ -80,6 +80,9 @@ export const xautoclaimCommand = defineCommand({
   execute: (args, ctx) => {
     const command = args.args
     const now = Date.now()
+    const includeDeletedIds = ctx.server.profile.has(
+      'stream.xautoclaim-deleted-ids',
+    )
     requireStreamGroup(
       ctx.db.getStream(command.key),
       command.key,
@@ -95,6 +98,7 @@ export const xautoclaimCommand = defineCommand({
           start: command.start,
           count: command.count,
           justId: command.justId,
+          cleanDeletedEntries: includeDeletedIds,
         },
         now,
       )
@@ -103,14 +107,16 @@ export const xautoclaimCommand = defineCommand({
     const claimed = result.claimed.map(entry =>
       command.justId
         ? streamIdValue(entry.id)
-        : entryToReply(entry.id, entry.fields),
+        : entry.fields === null
+          ? RedisValue.bulkString(null)
+          : entryToReply(entry.id, entry.fields),
     )
     const deleted = result.deleted.map(id => streamIdValue(id))
 
-    return array([
-      streamIdValue(result.nextStartId),
-      RedisValue.array(claimed),
-      RedisValue.array(deleted),
-    ])
+    const reply = [streamIdValue(result.nextStartId), RedisValue.array(claimed)]
+    if (includeDeletedIds) {
+      reply.push(RedisValue.array(deleted))
+    }
+    return array(reply)
   },
 })

--- a/src/core/compatibility/feature-gates.ts
+++ b/src/core/compatibility/feature-gates.ts
@@ -8,5 +8,6 @@ export const FEATURE_GATES: Record<FeatureId, VersionGate> = {
   'command.getkeysandflags': { redis: '7.0.0', valkey: '7.2.0' },
   'client.setinfo': { redis: '7.2.0', valkey: '7.2.0' },
   'pubsub.sharded': { redis: '7.0.0', valkey: '7.2.0' },
+  'stream.xautoclaim-deleted-ids': { redis: '7.0.0', valkey: '7.2.0' },
   'cluster.multi-db': { valkey: '9.0.0' },
 }

--- a/src/core/compatibility/profile.ts
+++ b/src/core/compatibility/profile.ts
@@ -12,6 +12,7 @@ export type FeatureId =
   | 'command.getkeysandflags'
   | 'client.setinfo'
   | 'pubsub.sharded'
+  | 'stream.xautoclaim-deleted-ids'
   | 'cluster.multi-db'
 
 export interface CompatibilityProfile {

--- a/src/state/tracked-values.ts
+++ b/src/state/tracked-values.ts
@@ -418,9 +418,10 @@ export class TrackedSortedSetData {
 // entry that has since been deleted carries fields === null.
 export type StreamDelivery = { id: StreamId; fields: Buffer[] | null }
 export type ClaimedEntry = { id: StreamId; fields: Buffer[] }
+export type AutoClaimedEntry = { id: StreamId; fields: Buffer[] | null }
 export type AutoClaimResult = {
   nextStartId: StreamId
-  claimed: ClaimedEntry[]
+  claimed: AutoClaimedEntry[]
   deleted: StreamId[]
 }
 
@@ -641,12 +642,13 @@ export class TrackedStreamData {
       start: StreamId
       count: number
       justId: boolean
+      cleanDeletedEntries: boolean
     },
     now: number,
   ): AutoClaimResult {
     ensureConsumer(group, consumerName, now).activeAt = now
     const consumerId = consumerName.toString('hex')
-    const claimed: ClaimedEntry[] = []
+    const claimed: AutoClaimedEntry[] = []
     const deleted: StreamId[] = []
     let nextStartId: StreamId = MIN_ID
 
@@ -655,8 +657,26 @@ export class TrackedStreamData {
 
       const entry = findEntry(this.stream, pending.id)
       if (!entry) {
-        group.pending.delete(streamIdKey(pending.id))
-        deleted.push(pending.id)
+        if (options.cleanDeletedEntries) {
+          group.pending.delete(streamIdKey(pending.id))
+          deleted.push(pending.id)
+          continue
+        }
+
+        const idleTime = Math.max(0, now - pending.deliveredAt)
+        if (idleTime < options.minIdleMs) continue
+
+        pending.consumerId = consumerId
+        pending.deliveredAt = now
+        if (!options.justId) pending.deliveryCount++
+        claimed.push({ id: pending.id, fields: null })
+
+        if (claimed.length >= options.count) {
+          const next = pendingEntriesSorted(group).find(
+            item => compareStreamId(item.id, pending.id) > 0,
+          )
+          nextStartId = next ? cloneStreamId(next.id) : MIN_ID
+        }
         continue
       }
 

--- a/tests/compatibility/behavior.test.ts
+++ b/tests/compatibility/behavior.test.ts
@@ -214,6 +214,57 @@ describe('compatibility behavior gates', () => {
     )
   })
 
+  test('LPOP and RPOP count on missing keys return nil arrays', async () => {
+    for (const profile of ['redis-6.2', 'redis-7.0'] as const) {
+      const session = createSession(profile)
+      assert.deepStrictEqual(
+        (await session.execute('lpop', buf('missing-list', '1'))).value,
+        RedisValue.nullArray(),
+        profile,
+      )
+      assert.deepStrictEqual(
+        (await session.execute('rpop', buf('missing-list', '1'))).value,
+        RedisValue.nullArray(),
+        profile,
+      )
+    }
+  })
+
+  test('XAUTOCLAIM deleted-id reply element follows Redis 7 profile', async () => {
+    const redis62 = createSession('redis-6.2')
+    await createDeletedPendingStreamEntry(redis62)
+    assert.deepStrictEqual(
+      (
+        await redis62.execute(
+          'xautoclaim',
+          buf('stream', 'workers', 'bob', '0', '0-0', 'COUNT', '10'),
+        )
+      ).value,
+      RedisValue.array([
+        RedisValue.bulkString(Buffer.from('0-0')),
+        RedisValue.array([RedisValue.bulkString(null)]),
+      ]),
+    )
+    assert.strictEqual(await pendingCount(redis62), 1)
+
+    const redis70 = createSession('redis-7.0')
+    await createDeletedPendingStreamEntry(redis70)
+    assert.deepStrictEqual(
+      (
+        await redis70.execute(
+          'xautoclaim',
+          buf('stream', 'workers', 'bob', '0', '0-0', 'COUNT', '10'),
+        )
+      ).value,
+      RedisValue.array([
+        RedisValue.bulkString(Buffer.from('0-0')),
+        RedisValue.array([]),
+        RedisValue.array([RedisValue.bulkString(Buffer.from('1-0'))]),
+      ]),
+    )
+    assert.strictEqual(await pendingCount(redis70), 0)
+  })
+
   test('Valkey cluster profile allows non-zero SELECT', async () => {
     for (const profile of [
       'redis-6.2',
@@ -263,6 +314,29 @@ describe('compatibility behavior gates', () => {
     assert.strictEqual(helloField(valkeyHello, 'version'), '9.0.0')
   })
 })
+
+async function createDeletedPendingStreamEntry(
+  session: ClientSession,
+): Promise<void> {
+  await session.execute('xadd', buf('stream', '1-0', 'field', 'value'))
+  await session.execute('xgroup', buf('create', 'stream', 'workers', '0'))
+  await session.execute(
+    'xreadgroup',
+    buf('GROUP', 'workers', 'alice', 'STREAMS', 'stream', '>'),
+  )
+  await session.execute('xdel', buf('stream', '1-0'))
+}
+
+async function pendingCount(session: ClientSession): Promise<number | bigint> {
+  const pending = (await session.execute(
+    'xpending',
+    buf('stream', 'workers'),
+  )) as RedisResult
+  assert.strictEqual(pending.value.kind, 'array')
+  const count = pending.value.items[0]
+  assert.strictEqual(count.kind, 'integer')
+  return count.value
+}
 
 function commandSubcommandNames(result: RedisResult): string[] {
   assert.strictEqual(result.value.kind, 'array')


### PR DESCRIPTION
## Summary
- add a Redis 7.0 feature gate for XAUTOCLAIM deleted pending-entry cleanup/reply shape
- keep Redis 6.2 XAUTOCLAIM on the two-element reply with a nil claimed-entry placeholder for deleted PEL entries
- add compatibility coverage for LPOP/RPOP count nil-array shape and XAUTOCLAIM deleted-id behavior

## Real Redis Check
Verified against Docker Redis images:
- `redis:6.2-alpine` (`redis_version:6.2.22`): deleted pending entries return as a nil item in the claimed entries array; XPENDING keeps the entry and moves it to the claiming consumer
- `redis:7.0-alpine` (`redis_version:7.0.15`): deleted pending entries are omitted from claimed entries, returned in the third deleted-ids array, and removed from XPENDING

Redis reference: https://redis.io/docs/latest/commands/xautoclaim/

Refs #306
Refs #296

## Tests
- `node --enable-source-maps --import tsx --no-warnings --test ./tests/compatibility/behavior.test.ts`
- `node --enable-source-maps --import tsx --no-warnings --test ./tests/commands-streams.test.ts`
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/stream/group.test.ts ./tests-integration/node-redis/stream/group.test.ts`
- `npm run build`
- `npm test`
- `npm run lint`
- `npm run test:integration:mock`
- `npm run test:integration:real` (fails in unrelated real-backend DBSIZE workflow: tests-integration/ioredis/key/workflow.test.ts expected +32 keys, observed +31)
- `npm run clean:redis && TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/key/workflow.test.ts`
