### PR TITLE
[codex] match compatibility gate error wording

### DIFF
--- a/docs/COMPATIBILITY-PROFILES-PLAN.md
+++ b/docs/COMPATIBILITY-PROFILES-PLAN.md
@@ -113,6 +113,8 @@ export type FeatureId =
   | 'command.docs' // COMMAND DOCS                                    (subcommand)
   | 'command.getkeysandflags' // COMMAND GETKEYSANDFLAGS                     (subcommand)
   | 'client.setinfo' // CLIENT SETINFO                                  (subcommand)
+  | 'client.setinfo.unknown-subcommand-error' // CLIENT SETINFO old-profile error shape
+  | 'pubsub.sharded' // PUBSUB SHARD* / SSUBSCRIBE / SPUBLISH           (subcommand/root)
   | 'cluster.multi-db' // SELECT non-zero db / multi-DB in cluster mode   (policy)
 
 export interface CompatibilityProfile {
@@ -199,11 +201,14 @@ Side benefit: `COMMAND COUNT/DOCS/INFO` read `registry.getAll()`, so introspecti
   gated-off subcommands.
 - `src/commands/connection.ts`: gate `CLIENT SETINFO` behind Redis 7.2 / Valkey 7.2.
   This matters for package users running clients that probe `CLIENT SETINFO` during
-  connection setup; an older profile must behave like the older real server.
+  connection setup; an older profile must behave like the older real server. Its
+  missing-feature error is version-specific: Redis 6.2 says `Unknown subcommand
+  or wrong number of arguments`, while Redis 7.0 says `unknown subcommand`; model
+  that with a named compatibility gate, not an inline version comparison.
 - EXPIRE family in `src/commands/keys.ts`: the existing `expireOptionsSchema` custom parser, when it sees `NX|XX|GT|LT` but `!ctx.profile.has('expire.conditions')`, **does not consume** the token and returns `undefined`. The trailing arg then trips `parseCommandArgs`' length check → `WrongNumberOfArgumentsError` — which is exactly what real 6.2 (fixed arity 3) returns. When the feature is on, behavior is unchanged.
 - SET option loop in `src/commands/strings.ts` (`createSetSchema`): when the loop encounters `GET` and `!ctx.profile.has('set.get')`, or `EXAT|PXAT` and `!ctx.profile.has('set.exat-pxat')`, throw `RedisSyntaxError` (SET is variadic arity, so an unknown option is `ERR syntax error` on the real server — matches).
 
-Rule of thumb for any future option gate: replicate what the real old server does — fixed-arity commands surface a trailing unsupported option as `WrongNumberOfArgumentsError` (don't consume), variadic commands as `RedisSyntaxError` (throw).
+Rule of thumb for any future option gate: verify the exact missing-feature behavior against the real old server before choosing the mock error. Do not infer it from parser shape alone; Redis varies by command and option, so record the observed error/result shape with the gate.
 
 ### Policy / semantic gating (execute-time, no new wiring)
 

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -99,18 +99,14 @@ export const commandCommand = defineCommand({
         return commandInfoSubcommand(args, ctx)
       case 'docs':
         if (!ctx.server.profile.has('command.docs')) {
-          throw new RedisCommandError(
-            `unknown subcommand '${args.subcommand}'. Try COMMAND HELP.`,
-          )
+          throw commandSubcommandError(args.subcommand)
         }
         return commandDocsSubcommand(args, ctx)
       case 'getkeys':
         return commandGetKeys(args, ctx)
       case 'getkeysandflags':
         if (!ctx.server.profile.has('command.getkeysandflags')) {
-          throw new RedisCommandError(
-            `unknown subcommand '${args.subcommand}'. Try COMMAND HELP.`,
-          )
+          throw commandSubcommandError(args.subcommand)
         }
         return commandGetKeysAndFlags(args, ctx)
       case 'help':
@@ -122,6 +118,12 @@ export const commandCommand = defineCommand({
     }
   },
 })
+
+function commandSubcommandError(subcommand: string): RedisCommandError {
+  return new RedisCommandError(
+    `Unknown subcommand or wrong number of arguments for '${subcommand}'. Try COMMAND HELP.`,
+  )
+}
 
 function commandCount(
   args: CommandArgs,

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -479,9 +479,7 @@ export const clientCommand = defineCommand({
 
     if (subcommand === 'setinfo') {
       if (!ctx.server.profile.has('client.setinfo')) {
-        throw new RedisCommandError(
-          `unknown subcommand '${subcommand}'. Try CLIENT HELP.`,
-        )
+        throw clientSetInfoUnavailableError(ctx, args.subcommand)
       }
 
       expectArgCount('client|setinfo', args.args, 2)
@@ -529,10 +527,25 @@ export const clientCommand = defineCommand({
     }
 
     throw new RedisCommandError(
-      `unknown subcommand '${subcommand}'. Try CLIENT HELP.`,
+      `unknown subcommand '${args.subcommand}'. Try CLIENT HELP.`,
     )
   },
 })
+
+function clientSetInfoUnavailableError(
+  ctx: RedisExecutionContext,
+  subcommand: string,
+): RedisCommandError {
+  if (!ctx.server.profile.has('client.setinfo.unknown-subcommand-error')) {
+    return new RedisCommandError(
+      `Unknown subcommand or wrong number of arguments for '${subcommand}'. Try CLIENT HELP.`,
+    )
+  }
+
+  return new RedisCommandError(
+    `unknown subcommand '${subcommand}'. Try CLIENT HELP.`,
+  )
+}
 
 /**
  * Parse HELLO's protocol-version token. Unlike a generic `t.integer()` field,

--- a/src/commands/pubsub.ts
+++ b/src/commands/pubsub.ts
@@ -227,9 +227,7 @@ export const pubsubCommand = defineCommand({
 
     if (subcommand === 'shardchannels') {
       if (!ctx.server.profile.has('pubsub.sharded')) {
-        throw new RedisCommandError(
-          `unknown subcommand '${args.subcommand}'. Try PUBSUB HELP.`,
-        )
+        throw pubsubUnavailableSubcommandError(args.subcommand)
       }
       expectPubSubSubcommandMaxArgCount(args.subcommand, args.args, 1)
       const channels = ctx.server.pubsubBroker.shardChannelsMatching(
@@ -240,9 +238,7 @@ export const pubsubCommand = defineCommand({
 
     if (subcommand === 'shardnumsub') {
       if (!ctx.server.profile.has('pubsub.sharded')) {
-        throw new RedisCommandError(
-          `unknown subcommand '${args.subcommand}'. Try PUBSUB HELP.`,
-        )
+        throw pubsubUnavailableSubcommandError(args.subcommand)
       }
       return RedisResult.create(
         RedisValue.array(
@@ -367,5 +363,13 @@ function expectPubSubSubcommandMaxArgCount(
 function pubsubSubcommandError(subcommand: string): RedisCommandError {
   return new RedisCommandError(
     `unknown subcommand or wrong number of arguments for '${subcommand}'. Try PUBSUB HELP.`,
+  )
+}
+
+function pubsubUnavailableSubcommandError(
+  subcommand: string,
+): RedisCommandError {
+  return new RedisCommandError(
+    `Unknown subcommand or wrong number of arguments for '${subcommand}'. Try PUBSUB HELP.`,
   )
 }

--- a/src/core/compatibility/feature-gates.ts
+++ b/src/core/compatibility/feature-gates.ts
@@ -7,6 +7,10 @@ export const FEATURE_GATES: Record<FeatureId, VersionGate> = {
   'command.docs': { redis: '7.0.0', valkey: '7.2.0' },
   'command.getkeysandflags': { redis: '7.0.0', valkey: '7.2.0' },
   'client.setinfo': { redis: '7.2.0', valkey: '7.2.0' },
+  'client.setinfo.unknown-subcommand-error': {
+    redis: '7.0.0',
+    valkey: '7.2.0',
+  },
   'pubsub.sharded': { redis: '7.0.0', valkey: '7.2.0' },
   'cluster.multi-db': { valkey: '9.0.0' },
 }

--- a/src/core/compatibility/profile.ts
+++ b/src/core/compatibility/profile.ts
@@ -11,6 +11,7 @@ export type FeatureId =
   | 'command.docs'
   | 'command.getkeysandflags'
   | 'client.setinfo'
+  | 'client.setinfo.unknown-subcommand-error'
   | 'pubsub.sharded'
   | 'cluster.multi-db'
 

--- a/tests/compatibility/behavior.test.ts
+++ b/tests/compatibility/behavior.test.ts
@@ -52,6 +52,11 @@ function assertError(result: RedisResult, pattern: RegExp): void {
   assert.match(result.value.message, pattern)
 }
 
+function assertErrorMessage(result: RedisResult, message: string): void {
+  assert.strictEqual(result.value.kind, 'error')
+  assert.strictEqual(result.value.message, message)
+}
+
 describe('compatibility behavior gates', () => {
   test('EXPIRE conditions are rejected before Redis 7.0', async () => {
     const redis62 = createSession('redis-6.2')
@@ -87,9 +92,16 @@ describe('compatibility behavior gates', () => {
 
   test('COMMAND subcommands follow their feature gates', async () => {
     const redis62 = createSession('redis-6.2')
-    assertError(
+    assertErrorMessage(
       (await redis62.execute('command', buf('docs'))) as RedisResult,
-      /unknown subcommand/i,
+      "Unknown subcommand or wrong number of arguments for 'docs'. Try COMMAND HELP.",
+    )
+    assertErrorMessage(
+      (await redis62.execute(
+        'command',
+        buf('GETKEYSANDFLAGS', 'get', 'k'),
+      )) as RedisResult,
+      "Unknown subcommand or wrong number of arguments for 'GETKEYSANDFLAGS'. Try COMMAND HELP.",
     )
 
     const redis70 = createSession('redis-7.0')
@@ -127,9 +139,13 @@ describe('compatibility behavior gates', () => {
 
   test('PUBSUB sharded subcommands follow their feature gate', async () => {
     const redis62 = createSession('redis-6.2')
-    assertError(
+    assertErrorMessage(
       (await redis62.execute('pubsub', buf('shardchannels'))) as RedisResult,
-      /unknown subcommand/i,
+      "Unknown subcommand or wrong number of arguments for 'shardchannels'. Try PUBSUB HELP.",
+    )
+    assertErrorMessage(
+      (await redis62.execute('pubsub', buf('SHARDNUMSUB'))) as RedisResult,
+      "Unknown subcommand or wrong number of arguments for 'SHARDNUMSUB'. Try PUBSUB HELP.",
     )
 
     const redis70 = createSession('redis-7.0')
@@ -198,13 +214,22 @@ describe('compatibility behavior gates', () => {
   })
 
   test('CLIENT SETINFO follows its feature gate', async () => {
+    const redis62 = createSession('redis-6.2')
+    assertErrorMessage(
+      (await redis62.execute(
+        'client',
+        buf('SETINFO', 'lib-name', 'test'),
+      )) as RedisResult,
+      "Unknown subcommand or wrong number of arguments for 'SETINFO'. Try CLIENT HELP.",
+    )
+
     const redis70 = createSession('redis-7.0')
-    assertError(
+    assertErrorMessage(
       (await redis70.execute(
         'client',
-        buf('setinfo', 'lib-name', 'test'),
+        buf('SETINFO', 'lib-name', 'test'),
       )) as RedisResult,
-      /unknown subcommand/i,
+      "unknown subcommand 'SETINFO'. Try CLIENT HELP.",
     )
 
     const redis72 = createSession('redis-7.2')

--- a/tests/compatibility/profile.test.ts
+++ b/tests/compatibility/profile.test.ts
@@ -76,6 +76,17 @@ describe('compatibility profiles', () => {
     assert.strictEqual(redis62.has('expire.conditions'), false)
     assert.strictEqual(redis62.has('set.get'), true)
     assert.strictEqual(redis62.has('client.setinfo'), false)
+    assert.strictEqual(
+      redis62.has('client.setinfo.unknown-subcommand-error'),
+      false,
+    )
+
+    const redis70 = resolveCompatibilityProfile('redis-7.0')
+    assert.strictEqual(redis70.has('client.setinfo'), false)
+    assert.strictEqual(
+      redis70.has('client.setinfo.unknown-subcommand-error'),
+      true,
+    )
 
     const valkey72 = resolveCompatibilityProfile({
       flavor: 'valkey',


### PR DESCRIPTION
## Summary
- match missing-feature subcommand gate errors to the real older Redis wording for COMMAND and PUBSUB gates
- make CLIENT SETINFO's unsupported-profile error version-aware because Redis 6.2 and Redis 7.0 differ
- tighten compatibility behavior tests to assert exact error messages and update the internal gating note to require real Redis checks

## Real Redis checks
- Redis 6.2: COMMAND DOCS / GETKEYSANDFLAGS and PUBSUB SHARDCHANNELS / SHARDNUMSUB return `Unknown subcommand or wrong number of arguments ...`
- Redis 7.0: CLIENT SETINFO returns `unknown subcommand 'SETINFO'. Try CLIENT HELP.`
- Redis 8: truly unknown COMMAND/PUBSUB/CLIENT subcommands still use the simpler `unknown subcommand ...` form

## Validation
- `node --enable-source-maps --import tsx --no-warnings --test ./tests/compatibility/behavior.test.ts`
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/command-integration.test.ts ./tests-integration/raw-tcp/pubsub-protocol.test.ts`
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/compatibility/profile-gates.test.ts`
- `npm run build`
- `npm test`
- `npm run lint`