### PR TITLE
Fix SCRIPT DEBUG transaction replay behavior

### DIFF
--- a/src/commands/scripts.ts
+++ b/src/commands/scripts.ts
@@ -81,7 +81,7 @@ export const scriptCommand = defineCommand({
       case 'kill':
         return scriptKill(args)
       case 'debug':
-        return scriptDebug(args)
+        return scriptDebug(args, ctx)
       case 'help':
         return scriptHelp(args)
       default:
@@ -174,11 +174,20 @@ function scriptKill(args: ScriptArgs): RedisResult {
   return RedisResult.error('No scripts in execution right now.', 'NOTBUSY')
 }
 
-function scriptDebug(args: ScriptArgs): RedisResult {
+function scriptDebug(
+  args: ScriptArgs,
+  ctx: RedisExecutionContext,
+): RedisResult {
   expectRestLength(args, 'script|debug', 1)
   const mode = args.rest[0].toString().toUpperCase()
   if (mode !== 'YES' && mode !== 'SYNC' && mode !== 'NO') {
     throw new ScriptDebugModeError()
+  }
+
+  if (ctx.transactionReplay) {
+    throw new RedisCommandError(
+      'SCRIPT DEBUG must be called outside a pipeline',
+    )
   }
 
   return ok()

--- a/src/core/client-session.ts
+++ b/src/core/client-session.ts
@@ -289,6 +289,8 @@ export class ClientSession implements RedisClientSession {
     const noBlockCtx = this.createExecutionContext(
       undefined,
       createNonBlockingParkHandler(),
+      undefined,
+      true,
     )
     let currentDbId = this.selectedDatabaseId
 
@@ -774,6 +776,7 @@ export class ClientSession implements RedisClientSession {
     turnAccess?: TurnAccess,
     parkOverride?: ParkHandler,
     monitor?: RedisMonitorContext,
+    transactionReplay = false,
   ): RedisExecutionContext {
     // `db` is a live getter, not a snapshot: a queued `SELECT N` runs mid-EXEC
     // and updates `selectedDatabaseId`, so every command must resolve the
@@ -787,6 +790,7 @@ export class ClientSession implements RedisClientSession {
       server: this.server,
       session: this,
       executor: this.executor,
+      ...(transactionReplay ? { transactionReplay } : {}),
       ...(this.nodeRole ? { nodeRole: this.nodeRole } : {}),
       ...(monitor ? { monitor } : {}),
       signal: this.signal,

--- a/src/core/command-executor.ts
+++ b/src/core/command-executor.ts
@@ -396,6 +396,9 @@ function createMonitorDeferredContext(
     server: ctx.server,
     session: ctx.session,
     executor: ctx.executor,
+    ...(ctx.transactionReplay
+      ? { transactionReplay: ctx.transactionReplay }
+      : {}),
     ...(ctx.nodeRole ? { nodeRole: ctx.nodeRole } : {}),
     monitor: {
       ...ctx.monitor,

--- a/src/core/lua-runtime.ts
+++ b/src/core/lua-runtime.ts
@@ -102,6 +102,9 @@ function createLuaMonitorContext(
     server: ctx.server,
     session: ctx.session,
     executor: ctx.executor,
+    ...(ctx.transactionReplay
+      ? { transactionReplay: ctx.transactionReplay }
+      : {}),
     ...(ctx.nodeRole ? { nodeRole: ctx.nodeRole } : {}),
     monitor: {
       ...ctx.monitor,

--- a/src/core/redis-context.ts
+++ b/src/core/redis-context.ts
@@ -69,6 +69,7 @@ export interface RedisExecutionContext {
   readonly server: RedisServerState
   readonly session: RedisClientSession
   readonly executor: CommandExecutor
+  readonly transactionReplay?: boolean
   readonly nodeRole?: RedisClusterNodeRole
   readonly monitor?: RedisMonitorContext
   readonly signal: AbortSignal

--- a/tests-integration/raw-tcp/protocol.test.ts
+++ b/tests-integration/raw-tcp/protocol.test.ts
@@ -176,6 +176,30 @@ describe(`Raw TCP protocol integration (${testRunner.getBackendName()})`, () => 
     )
   })
 
+  test('returns SCRIPT DEBUG pipeline errors from EXEC replies', async () => {
+    const conn = await connect()
+
+    conn.write(
+      Buffer.concat([
+        commandFrame('MULTI'),
+        commandFrame('SCRIPT', 'DEBUG', 'YES'),
+        commandFrame('EXEC'),
+      ]),
+    )
+
+    assert.deepStrictEqual(await conn.readRawFrame(), Buffer.from('+OK\r\n'))
+    assert.deepStrictEqual(
+      await conn.readRawFrame(),
+      Buffer.from('+QUEUED\r\n'),
+    )
+    assert.deepStrictEqual(
+      await conn.readRawFrame(),
+      Buffer.from(
+        '*1\r\n-ERR SCRIPT DEBUG must be called outside a pipeline\r\n',
+      ),
+    )
+  })
+
   // #80: RESET must execute immediately inside MULTI (like EXEC/DISCARD/WATCH),
   // aborting the transaction — it must not be queued.
   test('RESET inside MULTI executes immediately and aborts the transaction', async () => {

--- a/tests/compatibility/behavior.test.ts
+++ b/tests/compatibility/behavior.test.ts
@@ -310,6 +310,32 @@ describe('compatibility behavior gates', () => {
     assert.strictEqual(await pendingCount(redis70), 0)
   })
 
+  test('SCRIPT DEBUG inside MULTI returns the Redis pipeline error', async () => {
+    for (const profile of ['redis-6.2', 'redis-7.0'] as const) {
+      const session = createSession(profile)
+      assert.deepStrictEqual(
+        await session.execute('multi', []),
+        RedisResult.ok(),
+      )
+      assert.deepStrictEqual(
+        await session.execute('script', buf('debug', 'YES')),
+        RedisResult.create(RedisValue.simpleString('QUEUED')),
+      )
+      assert.deepStrictEqual(
+        await session.execute('exec', []),
+        RedisResult.create(
+          RedisValue.array([
+            RedisValue.error(
+              'SCRIPT DEBUG must be called outside a pipeline',
+              'ERR',
+            ),
+          ]),
+        ),
+        profile,
+      )
+    }
+  })
+
   test('Valkey cluster profile allows non-zero SELECT', async () => {
     for (const profile of [
       'redis-6.2',


### PR DESCRIPTION
## Summary
- match Redis behavior for `SCRIPT DEBUG YES|SYNC|NO` when replayed from `EXEC`
- carry a transaction-replay marker through execution contexts so commands can distinguish queued replay from normal execution
- add compatibility and raw TCP coverage for the exact `EXEC` error reply

## Root cause
`SCRIPT DEBUG` validated its mode and returned `OK` even when the command was queued by `MULTI` and replayed by `EXEC`. Real Redis queues the command, then returns `ERR SCRIPT DEBUG must be called outside a pipeline` as the `EXEC` array element.

## Validation
- `node --enable-source-maps --import tsx --no-warnings --test ./tests/compatibility/behavior.test.ts`
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/raw-tcp/protocol.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/raw-tcp/protocol.test.ts`
- `npm run build`
- `git diff --check`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`
- `npm run test:integration:compatibility:mock`

Fixes #306
Refs #296