### PR TITLE
Document compatibility profile gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ const valkeyCluster = await createRedisMock({
 Profiles gate implemented commands, subcommands, options, and known behavioral
 differences. For example, `EXPIRETIME key` is unavailable under `redis-6.2` but
 available under newer Redis profiles. Unsupported commands remain unsupported
-regardless of profile.
+regardless of profile. See the current gate matrix in
+[Compatibility Profiles](docs/API.md#compatibility-profiles).
 
 Supported presets: `redis-6.2`, `redis-7.0`, `redis-7.2`, `redis-7.4`,
 `redis-8.0`, `valkey-8.0`, and `valkey-9.0`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -131,6 +131,23 @@ Valkey profiles model the Redis 7.0-era gates as enabled:
 | `valkey-8.0` | enabled | cluster multi-DB disabled |
 | `valkey-9.0` | enabled | cluster multi-DB enabled |
 
+Current profile gates:
+
+| Surface | Redis profiles | Valkey profiles |
+| --- | --- | --- |
+| Redis 6.2 root commands: `BLMOVE`, `COPY`, `GETDEL`, `GETEX`, `HRANDFIELD`, `LMOVE`, `RESET`, `SMISMEMBER`, `XAUTOCLAIM`, `ZMSCORE` | `redis-6.2+` | `valkey-8.0+` |
+| Redis 7.0 root commands: `BLMPOP`, `BZMPOP`, `EXPIRETIME`, `LMPOP`, `PEXPIRETIME`, `SINTERCARD`, `SORT_RO`, `SPUBLISH`, `SSUBSCRIBE`, `SUNSUBSCRIBE`, `ZINTERCARD`, `ZMPOP` | `redis-7.0+` | `valkey-8.0+` |
+| Redis 7.4 hash-field expiration commands: `HEXPIRE`, `HEXPIREAT`, `HPERSIST`, `HPEXPIRE`, `HPEXPIREAT`, `HPTTL`, `HTTL` | `redis-7.4+` | `valkey-9.0+` |
+| Redis 8.0 hash-field read commands: `HGETDEL`, `HGETEX` | `redis-8.0+` | `HGETEX` in `valkey-9.0`; `HGETDEL` is not modeled for Valkey |
+| `COMMAND DOCS` and `COMMAND GETKEYSANDFLAGS` | `redis-7.0+` | `valkey-8.0+` |
+| `EXPIRE`/`PEXPIRE`/`EXPIREAT`/`PEXPIREAT` `NX`, `XX`, `GT`, `LT` options | `redis-7.0+` | `valkey-8.0+` |
+| `SET GET`, `SET EXAT`, `SET PXAT` | `redis-6.2+` | `valkey-8.0+` |
+| `SET NX GET` | `redis-7.0+` | `valkey-8.0+` |
+| `CLIENT SETINFO` | `redis-7.2+` | `valkey-8.0+` |
+| Sharded Pub/Sub: `SSUBSCRIBE`, `SUNSUBSCRIBE`, `SPUBLISH`, `PUBSUB SHARDCHANNELS`, `PUBSUB SHARDNUMSUB` | `redis-7.0+` | `valkey-8.0+` |
+| `XAUTOCLAIM` deleted-entry ID reply shape | `redis-7.0+` | `valkey-8.0+` |
+| Cluster `SELECT` for non-zero databases | unsupported | `valkey-9.0` |
+
 ## Package Entry Points
 
 The package ships dual ESM + CJS builds with two import surfaces:

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -6,6 +6,10 @@ This document provides a detailed overview of Redis commands and their implement
 only a subset of the real Redis syntax, the supported syntax is shown and a
 **Note** lists the gaps.
 
+Command rows describe the newest implemented profile. Older compatibility
+profiles can hide newer implemented commands, subcommands, options, or reply
+shapes; see the gate matrix in [Compatibility Profiles](API.md#compatibility-profiles).
+
 ## 1. Connection Commands
 
 - [x] `PING [message]` - Return PONG, or echo `message`


### PR DESCRIPTION
## Summary
- add the current compatibility profile gate matrix to `docs/API.md`
- link `docs/COMMANDS.md` and `README.md` to the gate matrix so command support docs do not drift

## Root cause
#308 tracks the remaining Redis 7.0 audit documentation gap: profile docs described gates generically, but there was no compact matrix tying implemented root commands, subcommands, options, and reply-shape gates to Redis/Valkey presets.

## Scope
- This is docs-only.
- #304 remains covered by PR #303.
- Refs #296.

## Validation
- `node --enable-source-maps --import tsx --no-warnings --test ./tests/compatibility/profile.test.ts ./tests/compatibility/registry.test.ts`
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/compatibility/profile-gates.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`
- `git diff --check`

Fixes #308
