### PR TITLE
feat(browser-demo): multi-server picker, compat profiles, terminal UX

### DIFF
--- a/examples/browser-demo/backend.ts
+++ b/examples/browser-demo/backend.ts
@@ -9,6 +9,7 @@ import {
   type RedisNativeReply,
 } from '../../src/in-memory-client'
 import { buildClusterNodes } from '../../src/cluster'
+import type { CompatibilitySpec } from '../../src/core/compatibility'
 import { formatReply, type Reply } from './format'
 
 export interface NodeInfo {
@@ -80,17 +81,22 @@ const MOVED = /^MOVED (\d+) (\S+):(\d+)/
 
 class ClusterConnection implements DemoConnection {
   private streamingNodes: { id: string; conn: InMemoryRedisClient }[] = []
+  // Sticky current node, like `redis-cli -c`: stay on whatever node last served
+  // a command and only redirect (and print MOVED) when the key lives elsewhere.
+  private currentNode: string
 
   constructor(
     private readonly conns: Map<string, InMemoryRedisClient>,
     private readonly byAddr: Map<string, string>,
-    private readonly defaultNode: string,
+    defaultNode: string,
     private readonly onServed: (nodeId: string) => void,
-  ) {}
+  ) {
+    this.currentNode = defaultNode
+  }
 
   async send(name: string, args: string[]): Promise<SendResult> {
     const hops: string[] = []
-    let nodeId = this.defaultNode
+    let nodeId = this.currentNode
 
     for (let i = 0; i < 6; i++) {
       const conn = this.conns.get(nodeId)!
@@ -104,6 +110,7 @@ class ClusterConnection implements DemoConnection {
           return { ok: true, reply, route: '→ all nodes', streaming: true }
         }
 
+        this.currentNode = nodeId
         this.onServed(nodeId)
         const route = [...hops, nodeId].join(' ')
         return { ok: true, reply, route: `→ ${route}`, streaming: false }
@@ -183,8 +190,13 @@ class ClusterConnection implements DemoConnection {
 
 // --- factories --------------------------------------------------------------
 
-export async function createSingleBackend(): Promise<DemoBackend> {
-  const instance = await createInMemoryRedis({ databaseCount: 16 })
+export async function createSingleBackend(
+  compatibility?: CompatibilitySpec,
+): Promise<DemoBackend> {
+  const instance = await createInMemoryRedis({
+    databaseCount: 16,
+    compatibility,
+  })
   return {
     mode: 'single',
     topology: () => [],
@@ -194,8 +206,15 @@ export async function createSingleBackend(): Promise<DemoBackend> {
   }
 }
 
-export function createClusterBackend(masters = 3): DemoBackend {
-  const { topology, nodes } = buildClusterNodes({ masters, basePort: 7000 })
+export function createClusterBackend(
+  masters = 3,
+  compatibility?: CompatibilitySpec,
+): DemoBackend {
+  const { topology, nodes } = buildClusterNodes({
+    masters,
+    basePort: 7000,
+    compatibility,
+  })
   const byAddr = new Map<string, string>()
   for (const node of nodes) {
     byAddr.set(`${node.host}:${node.port}`, node.id)

--- a/examples/browser-demo/index.html
+++ b/examples/browser-demo/index.html
@@ -48,6 +48,15 @@
         font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em;
         color: var(--muted); margin: 0 0 0.5rem;
       }
+      .field-label {
+        font-size: 0.7rem; color: var(--muted); margin-bottom: 0.25rem;
+      }
+      .server-select {
+        width: 100%; background: var(--bg); color: var(--fg);
+        border: 1px solid var(--border); border-radius: 6px;
+        padding: 0.35rem; margin-bottom: 0.5rem; font-size: 0.8rem;
+        font-family: ui-monospace, monospace;
+      }
       .toggle { display: flex; gap: 4px; }
       .toggle button {
         flex: 1; background: var(--bg); color: var(--fg);

--- a/examples/browser-demo/main.ts
+++ b/examples/browser-demo/main.ts
@@ -9,10 +9,12 @@ import { TabManager } from './tabs'
 
 // Load the Lua WASM + Emscripten glue from jsDelivr instead of bundling the
 // ~260 kB of assets into the GitHub Pages deploy. lua-redis-wasm's browser
-// loader fetches these URLs directly (EVAL works on first use).
-const LUA_WASM_VERSION = '1.4.0'
+// loader fetches these URLs directly (EVAL works on first use). The version is
+// injected by vite.config from the installed package, so the CDN assets always
+// match the bundled loader.
+declare const __LUA_WASM_VERSION__: string
 const cdn = (file: string) =>
-  `https://cdn.jsdelivr.net/npm/lua-redis-wasm@${LUA_WASM_VERSION}/dist/${file}`
+  `https://cdn.jsdelivr.net/npm/lua-redis-wasm@${__LUA_WASM_VERSION__}/dist/${file}`
 setLuaWasmLoadOptions({
   modulePath: cdn('redis_lua.mjs'),
   wasmPath: cdn('redis_lua.wasm'),
@@ -23,43 +25,115 @@ const tabbar = $('tabbar')
 const terminals = $('terminals')
 const panel = $('panel')
 
-let backend: DemoBackend
-let tabs: TabManager
-let mode: 'single' | 'cluster' = 'single'
+// Supported compatibility presets (see src/core/compatibility). Default first.
+const PROFILES = [
+  'redis-8.0',
+  'redis-7.4',
+  'redis-7.2',
+  'redis-7.0',
+  'redis-6.2',
+  'valkey-9.0',
+  'valkey-8.0',
+] as const
+type Profile = (typeof PROFILES)[number]
 
-async function buildBackend(next: 'single' | 'cluster'): Promise<DemoBackend> {
-  return next === 'single' ? createSingleBackend() : createClusterBackend(3)
+interface Server {
+  name: string
+  profile: Profile
+  backend: DemoBackend
+  tabs: TabManager
+  host: HTMLDivElement
 }
 
-async function setMode(next: 'single' | 'cluster'): Promise<void> {
-  tabs?.dispose()
-  backend?.close()
-  mode = next
-  backend = await buildBackend(next)
-  tabs = new TabManager(backend, tabbar, terminals, renderPanel)
-  renderPanel()
+const servers: Server[] = []
+let active = -1
+let newProfile: Profile = 'redis-8.0'
+const counts = { single: 0, cluster: 0 }
+
+async function addServer(
+  kind: 'single' | 'cluster',
+  profile: Profile,
+): Promise<void> {
+  const backend =
+    kind === 'single'
+      ? await createSingleBackend(profile)
+      : createClusterBackend(3, profile)
+  const host = document.createElement('div')
+  host.className = 'terminal-host'
+  terminals.appendChild(host)
+  const name = `${kind} ${++counts[kind]} · ${profile}`
+  const tabs = new TabManager(backend, tabbar, host, renderPanel)
+  servers.push({ name, profile, backend, tabs, host })
   await tabs.boot()
+  selectServer(servers.length - 1)
+}
+
+function selectServer(index: number): void {
+  active = index
+  servers.forEach((s, i) => {
+    s.host.style.display = i === index ? 'block' : 'none'
+  })
+  servers[index]?.tabs.activate()
+  renderPanel()
 }
 
 function renderPanel(): void {
   panel.replaceChildren()
-
-  const modeBox = document.createElement('div')
-  modeBox.className = 'panel-section'
-  modeBox.appendChild(heading('Mode'))
-  const toggle = document.createElement('div')
-  toggle.className = 'toggle'
-  for (const m of ['single', 'cluster'] as const) {
-    const btn = document.createElement('button')
-    btn.textContent = m
-    btn.className = m === mode ? 'active' : ''
-    btn.onclick = () => {
-      if (m !== mode) void setMode(m)
-    }
-    toggle.appendChild(btn)
+  const backend = servers[active]?.backend
+  if (!backend) {
+    return
   }
-  modeBox.appendChild(toggle)
-  panel.appendChild(modeBox)
+
+  // Active-server switcher.
+  const serverBox = document.createElement('div')
+  serverBox.className = 'panel-section'
+  serverBox.appendChild(heading('Active server'))
+  const select = document.createElement('select')
+  select.className = 'server-select'
+  servers.forEach((s, i) => {
+    const opt = document.createElement('option')
+    opt.value = String(i)
+    opt.textContent = s.name
+    opt.selected = i === active
+    select.appendChild(opt)
+  })
+  select.onchange = () => selectServer(Number(select.value))
+  serverBox.appendChild(select)
+  panel.appendChild(serverBox)
+
+  // Create a new server — profile applies to whichever button is clicked.
+  const newBox = document.createElement('div')
+  newBox.className = 'panel-section'
+  newBox.appendChild(heading('New server'))
+  const profileSelect = document.createElement('select')
+  profileSelect.className = 'server-select'
+  profileSelect.setAttribute(
+    'aria-label',
+    'Compatibility profile for new server',
+  )
+  for (const p of PROFILES) {
+    const opt = document.createElement('option')
+    opt.value = p
+    opt.textContent = p
+    opt.selected = p === newProfile
+    profileSelect.appendChild(opt)
+  }
+  profileSelect.onchange = () => {
+    newProfile = profileSelect.value as Profile
+  }
+  newBox.appendChild(fieldLabel('Compatibility'))
+  newBox.appendChild(profileSelect)
+
+  const addRow = document.createElement('div')
+  addRow.className = 'toggle'
+  for (const kind of ['single', 'cluster'] as const) {
+    const btn = document.createElement('button')
+    btn.textContent = `+ ${kind === 'single' ? 'instance' : 'cluster'}`
+    btn.onclick = () => void addServer(kind, newProfile)
+    addRow.appendChild(btn)
+  }
+  newBox.appendChild(addRow)
+  panel.appendChild(newBox)
 
   if (backend.mode === 'cluster') {
     const nodesBox = document.createElement('div')
@@ -116,4 +190,11 @@ function heading(text: string): HTMLElement {
   return h
 }
 
-void setMode('single')
+function fieldLabel(text: string): HTMLElement {
+  const l = document.createElement('div')
+  l.className = 'field-label'
+  l.textContent = text
+  return l
+}
+
+void addServer('single', 'redis-8.0')

--- a/examples/browser-demo/tabs.ts
+++ b/examples/browser-demo/tabs.ts
@@ -10,6 +10,37 @@ const DIM = (s: string) => `\x1b[2m${s}\x1b[0m`
 const RED = (s: string) => `\x1b[31m${s}\x1b[0m`
 const GREEN = (s: string) => `\x1b[32m${s}\x1b[0m`
 const CYAN = (s: string) => `\x1b[36m${s}\x1b[0m`
+const HINT = (s: string) => `\x1b[90m${s}\x1b[0m` // grey, like redis-cli
+
+// Argument syntax shown dimly after the cursor once a command is recognised,
+// mirroring redis-cli. Demo-scoped — covers the commands the Try panel suggests.
+// ponytail: static map, not COMMAND DOCS — the mock's docs metadata omits most
+// optional args, so it can't produce these. Extend the map as the demo grows.
+const HINTS: Record<string, string> = {
+  set: 'key value [NX|XX] [GET] [EX seconds|PX ms|EXAT ts|PXAT ts|KEEPTTL]',
+  get: 'key',
+  getset: 'key value',
+  mset: 'key value [key value ...]',
+  mget: 'key [key ...]',
+  append: 'key value',
+  incr: 'key',
+  decr: 'key',
+  incrby: 'key increment',
+  del: 'key [key ...]',
+  exists: 'key [key ...]',
+  expire: 'key seconds [NX|XX|GT|LT]',
+  ttl: 'key',
+  type: 'key',
+  hset: 'key field value [field value ...]',
+  hget: 'key field',
+  hgetall: 'key',
+  lpush: 'key element [element ...]',
+  rpush: 'key element [element ...]',
+  blpop: 'key [key ...] timeout',
+  subscribe: 'channel [channel ...]',
+  publish: 'channel message',
+  eval: 'script numkeys [key ...] [arg ...]',
+}
 
 interface TabOptions {
   title: string
@@ -56,10 +87,12 @@ class Tab {
           `try SET/GET, HSET, EVAL, SUBSCRIBE, MONITOR, BLPOP.`,
       ),
     )
+    this.term.write(this.promptText())
   }
 
   async runAuto(command: string): Promise<void> {
-    this.term.writeln(this.promptText() + command)
+    // open() has already drawn the prompt; echo the command onto it.
+    this.term.writeln(command)
     await this.execute(command)
   }
 
@@ -85,18 +118,20 @@ class Tab {
 
     switch (data) {
       case '\r':
-        this.term.write('\r\n')
+        // Redraw without the inline hint (\x1b[K erases it), then commit.
+        this.term.write('\r' + this.promptText() + this.line + '\x1b[K\r\n')
         await this.submit()
         return
       case '\x7f': // backspace
         if (this.cursor > 0) {
-          this.line = this.line.slice(0, -1)
+          this.line =
+            this.line.slice(0, this.cursor - 1) + this.line.slice(this.cursor)
           this.cursor--
-          this.term.write('\b \b')
+          this.render()
         }
         return
       case '\x03': // Ctrl-C
-        this.term.write('^C')
+        this.term.write('\r' + this.promptText() + this.line + '\x1b[K^C')
         this.prompt()
         return
       case '\x1b[A': // up
@@ -105,13 +140,47 @@ class Tab {
       case '\x1b[B': // down
         this.recall(1)
         return
+      case '\x1b[C': // right
+        if (this.cursor < this.line.length) {
+          this.cursor++
+          this.term.write('\x1b[C')
+        }
+        return
+      case '\x1b[D': // left
+        if (this.cursor > 0) {
+          this.cursor--
+          this.term.write('\x1b[D')
+        }
+        return
       default:
         if (data >= ' ') {
-          this.line += data
+          this.line =
+            this.line.slice(0, this.cursor) +
+            data +
+            this.line.slice(this.cursor)
           this.cursor += data.length
-          this.term.write(data)
+          this.render()
         }
     }
+  }
+
+  // ponytail: full-line redraw per keystroke, O(line length) — fine for a REPL.
+  private render(): void {
+    // Hint only when the cursor sits at the end of the line, like redis-cli.
+    const hint = this.cursor === this.line.length ? this.hintFor(this.line) : ''
+    this.term.write(
+      '\r' + this.promptText() + '\x1b[K' + this.line + (hint && HINT(hint)),
+    )
+    const back = this.line.length - this.cursor + hint.length
+    if (back > 0) {
+      this.term.write(`\x1b[${back}D`)
+    }
+  }
+
+  private hintFor(line: string): string {
+    const cmd = /^\s*(\S+)/.exec(line)?.[1].toLowerCase()
+    const syntax = cmd && HINTS[cmd]
+    return syntax ? ` ${syntax}` : ''
   }
 
   private recall(dir: number): void {
@@ -123,10 +192,9 @@ class Tab {
       Math.min(this.history.length, this.histPos + dir),
     )
     const next = this.history[this.histPos] ?? ''
-    // clear current line
-    this.term.write('\r' + this.promptText() + '\x1b[K' + next)
     this.line = next
     this.cursor = next.length
+    this.render()
   }
 
   private async submit(): Promise<void> {
@@ -204,9 +272,14 @@ export class TabManager {
   ) {}
 
   async boot(): Promise<void> {
-    this.addTab({ title: 'commands' })
-    await this.addTab({ title: 'monitor', autoRun: 'MONITOR' })
+    await this.addTab({ title: 'commands' })
     this.select(0)
+  }
+
+  // Show this manager's tabs again after another server was active: redraw the
+  // shared tab bar and re-focus the current tab.
+  activate(): void {
+    this.select(this.active < 0 ? 0 : this.active)
   }
 
   async addTab(options: TabOptions): Promise<void> {

--- a/examples/browser-demo/vite.config.ts
+++ b/examples/browser-demo/vite.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
@@ -17,6 +18,13 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills'
 // where the shim isn't installed. Alias the three shims to absolute paths in the
 // demo's own node_modules so they resolve regardless of importer location.
 const abs = (rel: string) => fileURLToPath(new URL(rel, import.meta.url))
+
+// Pin the CDN-loaded WASM + glue to the SAME version we bundle the JS loader
+// from, so a root-level `lua-redis-wasm` bump can't leave the loader and the
+// jsDelivr assets on mismatched (ABI-incompatible) versions.
+const luaWasmVersion = JSON.parse(
+  readFileSync(abs('./node_modules/lua-redis-wasm/package.json'), 'utf8'),
+).version as string
 
 const shim = (name: string) =>
   abs(`./node_modules/vite-plugin-node-polyfills/shims/${name}/dist/index.js`)
@@ -50,6 +58,7 @@ const stripBundledLuaAssets = {
 
 export default defineConfig({
   base: '/js-redis-server/',
+  define: { __LUA_WASM_VERSION__: JSON.stringify(luaWasmVersion) },
   plugins: [stripBundledLuaAssets, nodePolyfills()],
   resolve: {
     alias: {

--- a/src/in-memory-client.ts
+++ b/src/in-memory-client.ts
@@ -1,5 +1,6 @@
 import { createRedisCommandExecutor } from './commands'
 import { ClientSession } from './core/client-session'
+import type { CompatibilitySpec } from './core/compatibility'
 import type { CommandExecutor } from './core/command-executor'
 import { RedisCommandError } from './core/redis-error'
 import type { RedisValue } from './core/redis-value'
@@ -273,6 +274,8 @@ export type CreateInMemoryRedisOptions = {
   databaseCount?: number
   /** Pre-populate the keyspace before any connection is opened. */
   seed?: readonly SeedEntry[]
+  /** Redis/Valkey version to emulate (defaults to `redis-8.0`). */
+  compatibility?: CompatibilitySpec
 }
 
 /** Per-connection options for {@link InMemoryRedis.connect}. */
@@ -321,8 +324,11 @@ export async function createInMemoryRedis(
 ): Promise<InMemoryRedis> {
   const state = new RedisServerState({
     databaseCount: options.databaseCount ?? DEFAULT_DATABASE_COUNT,
+    compatibility: options.compatibility,
   })
-  const executor = createRedisCommandExecutor()
+  const executor = createRedisCommandExecutor({
+    compatibility: options.compatibility,
+  })
 
   if (options.seed) {
     await seedStandalone(state, options.seed)

--- a/tests/in-memory-client.test.ts
+++ b/tests/in-memory-client.test.ts
@@ -81,4 +81,18 @@ describe('createInMemoryClient', () => {
     client.close()
     await assert.rejects(client.command('PING'), /closed/)
   })
+
+  test('compatibility option gates commands by version', async () => {
+    // LMPOP arrived in Redis 7.0, so it is unknown under a 6.2 profile but
+    // available on the default (redis-8.0).
+    client = await createInMemoryClient({ compatibility: 'redis-6.2' })
+    await assert.rejects(
+      client.command('LMPOP', '1', 'k', 'LEFT'),
+      /unknown command 'LMPOP'/,
+    )
+    client.close()
+
+    client = await createInMemoryClient()
+    assert.strictEqual(await client.command('LMPOP', '1', 'k', 'LEFT'), null)
+  })
 })


### PR DESCRIPTION
## Summary

Browser-demo overhaul plus the one lib change that enables it.

### Demo
- **Cluster routing like `redis-cli -c`** — the terminal now keeps a sticky current node that follows the last redirect, instead of restarting from node 0 on every command. A key on the current node no longer shows a spurious `MOVED` hop.
- **Terminal line editor** — left/right arrows + cursor-aware insert/backspace, a prompt drawn immediately on open, and redis-cli-style dim argument hints as you type a recognized command.
- **Multiple servers** — create any number of instances/clusters and switch between them via a dropdown; each keeps its own keyspace and tabs. Removed the default monitor tab.
- **Compatibility profile per new server** (default `redis-8.0`), in a clearly-scoped "New server" panel section.
- **Pinned Lua WASM version** — the CDN-loaded WASM/glue version is injected by `vite.config` from the installed `lua-redis-wasm`, so the bundled loader and CDN assets can't drift.

### Lib
- `createInMemoryRedis` now accepts a `compatibility` option (forwarded to state + executor), matching what the cluster builder already supported. `createInMemoryClient` inherits it.

## Test
- New unit test: `createInMemoryClient({ compatibility: 'redis-6.2' })` rejects `LMPOP` (7.0+) while the default profile runs it.
- `npm test` (306 pass), `npm run lint`, demo `vite build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)