### PR TITLE
[codex] Gate Redis 7.2 RESP3 publish order

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -146,6 +146,7 @@ Current profile gates:
 | `SET NX GET` | `redis-7.0+` | `valkey-8.0+` |
 | `CLIENT SETINFO` | `redis-7.2+` | `valkey-8.0+` |
 | Sharded Pub/Sub: `SSUBSCRIBE`, `SUNSUBSCRIBE`, `SPUBLISH`, `PUBSUB SHARDCHANNELS`, `PUBSUB SHARDNUMSUB` | `redis-7.0+` | `valkey-8.0+` |
+| RESP3 subscribed `PUBLISH` self-reply before pushed message | `redis-7.2+` | `valkey-8.0+` |
 | `XAUTOCLAIM` deleted-entry ID reply shape | `redis-7.0+` | `valkey-8.0+` |
 | Cluster `SELECT` for non-zero databases | unsupported | `valkey-9.0` |
 

--- a/src/commands/pubsub.ts
+++ b/src/commands/pubsub.ts
@@ -148,8 +148,26 @@ export const publishCommand = defineCommand({
     categories: ['@pubsub', '@fast'],
   },
   keys: () => [],
-  execute: (args, ctx) =>
-    integer(ctx.server.pubsubBroker.publish(args.channel, args.message)),
+  execute: (args, ctx) => {
+    if (
+      ctx.session.mode !== 'subscribed' ||
+      ctx.session.protocolVersion !== 3 ||
+      !ctx.server.profile.has('pubsub.resp3-publish-reply-first')
+    ) {
+      return integer(
+        ctx.server.pubsubBroker.publish(args.channel, args.message),
+      )
+    }
+
+    const flushPushes = ctx.session.deferPushesUntilAfterReply()
+    const delivered = ctx.server.pubsubBroker.publish(
+      args.channel,
+      args.message,
+    )
+    return RedisResult.create(RedisValue.integer(delivered), {
+      afterReply: flushPushes,
+    })
+  },
 })
 
 export const spublishCommand = defineCommand({

--- a/src/core/client-session.ts
+++ b/src/core/client-session.ts
@@ -109,6 +109,7 @@ export class ClientSession implements RedisClientSession {
   private readonly pubsubPatterns = new Map<string, PubSubRegistration>()
   private readonly pushQueue: RedisResult[] = []
   private readonly pushWaiters = new Set<() => void>()
+  private deferredPushes: RedisResult[] | null = null
   private pushQueueClosed = false
   private readonly responseStreamCleanups = new Set<() => void>()
   private unregisterClientSession?: Unsubscribe
@@ -688,6 +689,17 @@ export class ClientSession implements RedisClientSession {
     this.refreshPubSubMode()
   }
 
+  deferPushesUntilAfterReply(): () => void {
+    const deferred: RedisResult[] = []
+    this.deferredPushes = deferred
+    return () => {
+      this.deferredPushes = null
+      for (const result of deferred) {
+        this.enqueuePush(result)
+      }
+    }
+  }
+
   registerResponseStreamCleanup(cleanup: () => void): Unsubscribe {
     this.responseStreamCleanups.add(cleanup)
     return () => {
@@ -706,6 +718,11 @@ export class ClientSession implements RedisClientSession {
 
   enqueuePush(result: RedisResult): void {
     if (this.pushQueueClosed || this.signal.aborted) {
+      return
+    }
+
+    if (this.deferredPushes) {
+      this.deferredPushes.push(result)
       return
     }
 

--- a/src/core/compatibility/feature-gates.ts
+++ b/src/core/compatibility/feature-gates.ts
@@ -17,6 +17,7 @@ export const FEATURE_GATES: Record<FeatureId, VersionGate> = {
   'info.multi-section': { redis: '7.0.0', valkey: '7.2.0' },
   'shutdown.now-force-abort': { redis: '7.0.0', valkey: '7.2.0' },
   'pubsub.sharded': { redis: '7.0.0', valkey: '7.2.0' },
+  'pubsub.resp3-publish-reply-first': { redis: '7.2.0', valkey: '8.0.0' },
   'stream.xautoclaim-deleted-ids': { redis: '7.0.0', valkey: '7.2.0' },
   'cluster.multi-db': { valkey: '9.0.0' },
 }

--- a/src/core/compatibility/profile.ts
+++ b/src/core/compatibility/profile.ts
@@ -18,6 +18,7 @@ export type FeatureId =
   | 'info.multi-section'
   | 'shutdown.now-force-abort'
   | 'pubsub.sharded'
+  | 'pubsub.resp3-publish-reply-first'
   | 'stream.xautoclaim-deleted-ids'
   | 'cluster.multi-db'
 

--- a/src/core/redis-context.ts
+++ b/src/core/redis-context.ts
@@ -60,6 +60,7 @@ export interface RedisClientSession {
   subscribePubSubPatterns(patterns: readonly Buffer[]): RedisResult[]
   unsubscribePubSubPatterns(patterns: readonly Buffer[]): RedisResult[]
   resetPubSub(): void
+  deferPushesUntilAfterReply(): () => void
   registerResponseStreamCleanup(cleanup: () => void): () => void
   resetResponseStreams(): void
 }

--- a/src/core/redis-result.ts
+++ b/src/core/redis-result.ts
@@ -4,6 +4,7 @@ export type RedisResultOptions = {
   close?: boolean
   disconnect?: boolean
   omitReply?: boolean
+  afterReply?: () => void
 }
 
 export class RedisResult {

--- a/src/core/transports/resp2/session-adapter.ts
+++ b/src/core/transports/resp2/session-adapter.ts
@@ -129,6 +129,8 @@ export class Resp2SessionAdapter {
         )
       }
 
+      result.options?.afterReply?.()
+
       if (result.options?.close || result.options?.disconnect) {
         this.transport.close('command requested close')
       }

--- a/tests-integration/compatibility/profile-gates.test.ts
+++ b/tests-integration/compatibility/profile-gates.test.ts
@@ -3,7 +3,12 @@ import assert from 'node:assert'
 
 import { TestRunner } from '../test-config'
 import { commandFrame } from '../utils'
-import { RawRedisConnection } from '../raw-tcp/raw-connection'
+import {
+  RawRedisConnection,
+  respMapGet,
+  respNumber,
+  type RespWireValue,
+} from '../raw-tcp/raw-connection'
 
 type ProfileName =
   | 'redis-6.2'
@@ -242,6 +247,45 @@ describe(
       }
     })
 
+    test('RESP3 subscribed PUBLISH self-reply order matches the profile', async () => {
+      const channel = `compat:${profile}:self-publish`
+
+      connection.write(commandFrame('HELLO', '3'))
+      const hello = await connection.readFrame()
+      assert.ok(hello instanceof Map)
+      assert.strictEqual(respNumber(respMapGet(hello, 'proto')), 3)
+
+      connection.write(commandFrame('SUBSCRIBE', channel))
+      assert.deepStrictEqual(normalizeFrame(await connection.readFrame()), [
+        'subscribe',
+        channel,
+        1,
+      ])
+
+      connection.write(commandFrame('PUBLISH', channel, 'self'))
+      const first = await connection.readFrame()
+      const second = await connection.readFrame()
+      const message = ['message', channel, 'self']
+
+      if (supportsResp3PublishReplyBeforeSelfMessage()) {
+        assert.strictEqual(first, 1)
+        assert.deepStrictEqual(normalizeFrame(second), message)
+      } else {
+        assert.deepStrictEqual(normalizeFrame(first), message)
+        assert.strictEqual(second, 1)
+      }
+
+      connection.write(commandFrame('UNSUBSCRIBE', channel))
+      assert.deepStrictEqual(normalizeFrame(await connection.readFrame()), [
+        'unsubscribe',
+        channel,
+        0,
+      ])
+
+      connection.write(commandFrame('HELLO', '2'))
+      await connection.readFrame()
+    })
+
     async function send(...args: string[]): Promise<string> {
       connection.write(commandFrame(...args))
       return (await connection.readRawFrame()).toString()
@@ -296,6 +340,10 @@ function supportsLuaOsLib(): boolean {
   )
 }
 
+function supportsResp3PublishReplyBeforeSelfMessage(): boolean {
+  return !['redis-6.2', 'redis-7.0'].includes(profile)
+}
+
 function supportsExpireConditions(): boolean {
   return profile !== 'redis-6.2'
 }
@@ -344,4 +392,16 @@ function bulkStringFrame(value: string): RegExp {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function normalizeFrame(value: RespWireValue): RespWireValue {
+  if (Buffer.isBuffer(value)) {
+    return value.toString()
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeFrame)
+  }
+
+  return value
 }

--- a/tests/compatibility/profile.test.ts
+++ b/tests/compatibility/profile.test.ts
@@ -87,15 +87,21 @@ describe('compatibility profiles', () => {
       redis70.has('client.setinfo.unknown-subcommand-error'),
       true,
     )
+    assert.strictEqual(redis70.has('pubsub.resp3-publish-reply-first'), false)
+
+    const redis72 = resolveCompatibilityProfile('redis-7.2')
+    assert.strictEqual(redis72.has('pubsub.resp3-publish-reply-first'), true)
 
     const valkey72 = resolveCompatibilityProfile({
       flavor: 'valkey',
       version: '7.2.4',
     })
     assert.strictEqual(valkey72.has('command.docs'), true)
+    assert.strictEqual(valkey72.has('pubsub.resp3-publish-reply-first'), false)
     assert.strictEqual(valkey72.has('cluster.multi-db'), false)
 
     const valkey9 = resolveCompatibilityProfile('valkey-9.0')
+    assert.strictEqual(valkey9.has('pubsub.resp3-publish-reply-first'), true)
     assert.strictEqual(valkey9.has('cluster.multi-db'), true)
   })
 })

--- a/tests/compatibility/registry.test.ts
+++ b/tests/compatibility/registry.test.ts
@@ -115,6 +115,20 @@ describe('compatibility registry filtering', () => {
       assert.strictEqual(redis70.has(command), true, command)
     }
 
+    const redis72 = createRedisCommandRegistry(
+      [],
+      resolveCompatibilityProfile('redis-7.2'),
+    )
+    for (const command of redis70Commands) {
+      assert.strictEqual(redis72.has(command), true, command)
+    }
+    for (const command of hashFieldExpirationCommands) {
+      assert.strictEqual(redis72.has(command), false, command)
+    }
+    for (const command of ['hgetdel', 'hgetex']) {
+      assert.strictEqual(redis72.has(command), false, command)
+    }
+
     const redis74 = createRedisCommandRegistry(
       [],
       resolveCompatibilityProfile('redis-7.4'),


### PR DESCRIPTION
## Summary
- Add a `pubsub.resp3-publish-reply-first` compatibility feature gate for Redis 7.2+ and Valkey 8.0+.
- Defer same-session Pub/Sub pushes until after the command reply for RESP3 subscribed `PUBLISH` when that profile gate is enabled.
- Keep Redis 6.2/7.0 on the older message-first ordering, document the API matrix, and retain explicit Redis 7.2 registry coverage.

## Root cause
`PUBLISH` delivered broker messages synchronously while the command was still executing. For a RESP3 client subscribed to the same channel, that queued the pushed message before the integer command reply, so every profile behaved like pre-Redis 7.2. Redis changed this ordering in 7.2 for RESP3 clients.

## Validation
- `TEST_BACKEND=mock REDIS_COMPAT=redis-7.2 node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/compatibility/profile-gates.test.ts`
- `TEST_BACKEND=mock REDIS_COMPAT=redis-7.0 node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/compatibility/profile-gates.test.ts`
- `node --enable-source-maps --import tsx --no-warnings --test ./tests/compatibility/profile.test.ts`
- `npm run test:integration:compatibility:mock`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run lint`
- `npm run test:integration:real`

Refs #297
