### PR TITLE
feat: implement Bitmap commands (SETBIT/GETBIT/BITCOUNT/BITPOS/BITOP/BITFIELD) (#322)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -148,6 +148,7 @@ Current profile gates:
 | Sharded Pub/Sub: `SSUBSCRIBE`, `SUNSUBSCRIBE`, `SPUBLISH`, `PUBSUB SHARDCHANNELS`, `PUBSUB SHARDNUMSUB` | `redis-7.0+` | `valkey-8.0+` |
 | RESP3 subscribed `PUBLISH` self-reply before pushed message | `redis-7.2+` | `valkey-8.0+` |
 | `XAUTOCLAIM` deleted-entry ID reply shape | `redis-7.0+` | `valkey-8.0+` |
+| `BITCOUNT`/`BITPOS` `BYTE`\|`BIT` range modifier | `redis-7.0+` | `valkey-8.0+` |
 | Cluster `SELECT` for non-zero databases | unsupported | `valkey-9.0` |
 
 ## Package Entry Points

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -506,6 +506,41 @@ The auth system (`requirepass` / `AUTH`) is functional for the built-in
 - [ ] `ACL LOAD` - Reload ACL rules from the `aclfile`
 - [x] `ACL HELP`
 
+## 17. Bitmap Commands
+
+Bitmaps are not a distinct type — they operate on the String value stored at a
+key. None of these are implemented yet.
+
+- [x] `SETBIT key offset value` - Set or clear the bit at `offset`
+- [x] `GETBIT key offset` - Return the bit value at `offset`
+- [x] `BITCOUNT key [start end [BYTE | BIT]]` - Count set bits, optionally within a byte or bit range
+- [x] `BITPOS key bit [start [end [BYTE | BIT]]]` - Find the first bit set to `bit`
+- [x] `BITOP AND | OR | XOR | NOT destkey key [key ...]` - Bitwise operation across keys, storing the result
+- [x] `BITFIELD key [GET type offset] [SET type offset value] [INCRBY type offset increment] [OVERFLOW WRAP | SAT | FAIL]` - Operate on arbitrary-width integer fields
+- [x] `BITFIELD_RO key [GET type offset ...]` - Read-only variant of `BITFIELD`
+
+## 18. HyperLogLog Commands
+
+HyperLogLogs are stored in the String type. None of these are implemented yet.
+
+- [ ] `PFADD key [element ...]` - Add elements to the HyperLogLog
+- [ ] `PFCOUNT key [key ...]` - Return the approximated cardinality
+- [ ] `PFMERGE destkey [sourcekey ...]` - Merge multiple HyperLogLogs into one
+- [ ] `PFDEBUG`, `PFSELFTEST` - Internal/debug subcommands
+
+## 19. Geo Commands
+
+Geo commands are stored in the Sorted Set type (members scored by geohash).
+None of these are implemented yet.
+
+- [ ] `GEOADD key [NX | XX] [CH] longitude latitude member [longitude latitude member ...]` - Add geospatial members
+- [ ] `GEOPOS key member [member ...]` - Return longitude/latitude of members
+- [ ] `GEODIST key member1 member2 [m | km | ft | mi]` - Distance between two members
+- [ ] `GEOHASH key member [member ...]` - Return Geohash strings for members
+- [ ] `GEOSEARCH key <FROMMEMBER member | FROMLONLAT longitude latitude> <BYRADIUS radius unit | BYBOX width height unit> [ASC | DESC] [COUNT count [ANY]] [WITHCOORD] [WITHDIST] [WITHHASH]` - Search within a radius or box
+- [ ] `GEOSEARCHSTORE destination source <FROMMEMBER ... | FROMLONLAT ...> <BYRADIUS ... | BYBOX ...> [STOREDIST]` - Store a `GEOSEARCH` result
+- [ ] `GEORADIUS` / `GEORADIUSBYMEMBER` (and `_RO` variants) - Deprecated radius queries
+
 ## Implementation Notes
 
 - `[x]` indicates implemented commands; `[ ]` indicates planned or

--- a/src/commands/bitmaps.ts
+++ b/src/commands/bitmaps.ts
@@ -1,0 +1,686 @@
+import { defineCommand } from '../core/command-definition'
+import type { RedisExecutionContext } from '../core/redis-context'
+import {
+  isIntegerToken,
+  t,
+  type CommandSchema,
+  type ParseContext,
+} from '../core/command-schema'
+import {
+  BitOffsetError,
+  BitOpNotSingleKeyError,
+  BitPosBitError,
+  BitValueError,
+  BitfieldOverflowTypeError,
+  BitfieldRoGetOnlyError,
+  BitfieldTypeError,
+  ExpectedIntegerError,
+  RedisSyntaxError,
+  WrongNumberOfArgumentsError,
+} from '../core/redis-error'
+import { RedisResult } from '../core/redis-result'
+import { RedisValue } from '../core/redis-value'
+import { ensureStringOrMissing, INT64_MAX, INT64_MIN, integer } from './helpers'
+
+// The highest addressable bit. Redis caps a bit offset's *start byte* at
+// proto-max-bulk-len (512MB) — i.e. the offset itself must be < 2^32 bits.
+// A field may still spill one type-width past this, growing the buffer.
+const MAX_BIT_OFFSET = 0x1_0000_0000
+
+const EMPTY = Buffer.alloc(0)
+
+// --- shared bit helpers ----------------------------------------------------
+
+function getBit(buf: Buffer, bitIndex: number): number {
+  const byteIndex = bitIndex >>> 3
+  if (byteIndex >= buf.length) {
+    return 0
+  }
+  return (buf[byteIndex]! >> (7 - (bitIndex & 7))) & 1
+}
+
+function byteAt(buf: Buffer, index: number): number {
+  return index < buf.length ? buf[index]! : 0
+}
+
+function parseBitOffset(token: Buffer | undefined): number {
+  if (!token) {
+    throw new BitOffsetError()
+  }
+  const raw = token.toString()
+  if (!isIntegerToken(raw)) {
+    throw new BitOffsetError()
+  }
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value < 0 || value >= MAX_BIT_OFFSET) {
+    throw new BitOffsetError()
+  }
+  return value
+}
+
+function parseRangeIndex(token: Buffer): number {
+  const raw = token.toString()
+  if (!isIntegerToken(raw)) {
+    throw new ExpectedIntegerError()
+  }
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value)) {
+    throw new ExpectedIntegerError()
+  }
+  return value
+}
+
+// Normalize a [start, end] range (Redis semantics, shared by BITCOUNT/BITPOS).
+// `size` is the number of addressable units (bytes for BYTE mode, bits for BIT
+// mode). Returns null when the range is empty.
+function resolveRange(
+  start: number,
+  end: number,
+  size: number,
+): [first: number, last: number] | null {
+  if (start < 0 && end < 0 && start > end) {
+    return null
+  }
+  if (start < 0) start = size + start
+  if (end < 0) end = size + end
+  if (start < 0) start = 0
+  if (end < 0) end = 0
+  if (end >= size) end = size - 1
+  if (start > end) {
+    return null
+  }
+  return [start, end]
+}
+
+// Count set bits within the inclusive bit range [firstBit, lastBit].
+// ponytail: naive per-bit scan, O(bits). A byte-wise popcount table would be
+// faster for multi-MB bitmaps, but this mock isn't sized for those.
+function countBits(buf: Buffer, firstBit: number, lastBit: number): number {
+  let count = 0
+  for (let i = firstBit; i <= lastBit; i++) {
+    count += getBit(buf, i)
+  }
+  return count
+}
+
+// --- SETBIT / GETBIT -------------------------------------------------------
+
+type SetBitArgs = { key: Buffer; offset: number; value: number }
+
+export const setbitCommand = defineCommand({
+  name: 'setbit',
+  schema: t.custom(
+    (input, index, ctx): { value: SetBitArgs; nextIndex: number } => {
+      if (input.length - index !== 3) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+      const offset = parseBitOffset(input[index + 1])
+      const valueRaw = input[index + 2]!.toString()
+      if (valueRaw !== '0' && valueRaw !== '1') {
+        throw new BitValueError()
+      }
+      return {
+        value: { key: input[index]!, offset, value: Number(valueRaw) },
+        nextIndex: index + 3,
+      }
+    },
+  ),
+  flags: ['write', 'denyoom'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const existing = ensureStringOrMissing(ctx.db, args.key)
+    const byteIndex = args.offset >>> 3
+    const bitMask = 1 << (7 - (args.offset & 7))
+
+    const current = existing ?? EMPTY
+    const requiredSize = byteIndex + 1
+    const target =
+      requiredSize > current.length ? Buffer.alloc(requiredSize) : current
+    if (target !== current) {
+      current.copy(target, 0)
+    }
+
+    const oldBit = (target[byteIndex]! & bitMask) === 0 ? 0 : 1
+    if (args.value === 1) {
+      target[byteIndex]! |= bitMask
+    } else {
+      target[byteIndex]! &= ~bitMask
+    }
+
+    ctx.db.setString(args.key, target, { keepTtl: true })
+    return integer(oldBit)
+  },
+})
+
+type GetBitArgs = { key: Buffer; offset: number }
+
+export const getbitCommand = defineCommand({
+  name: 'getbit',
+  schema: t.custom(
+    (input, index, ctx): { value: GetBitArgs; nextIndex: number } => {
+      if (input.length - index !== 2) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+      return {
+        value: { key: input[index]!, offset: parseBitOffset(input[index + 1]) },
+        nextIndex: index + 2,
+      }
+    },
+  ),
+  flags: ['readonly', 'fast'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const existing = ensureStringOrMissing(ctx.db, args.key)
+    if (!existing) {
+      return integer(0)
+    }
+    return integer(getBit(existing, args.offset))
+  },
+})
+
+// --- BITCOUNT --------------------------------------------------------------
+
+type BitRange = { start: number; end: number; bit: boolean }
+type BitCountArgs = { key: Buffer; range?: BitRange }
+
+export const bitcountCommand = defineCommand({
+  name: 'bitcount',
+  schema: t.custom(
+    (input, index, ctx): { value: BitCountArgs; nextIndex: number } => {
+      const key = input[index]
+      if (!key) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+      const extra = input.length - index - 1
+      if (extra === 0) {
+        return { value: { key }, nextIndex: input.length }
+      }
+      if (extra !== 2 && extra !== 3) {
+        throw new RedisSyntaxError()
+      }
+      const start = parseRangeIndex(input[index + 1]!)
+      const end = parseRangeIndex(input[index + 2]!)
+      const bit = parseRangeUnit(input[index + 3], extra === 3, ctx)
+      return {
+        value: { key, range: { start, end, bit } },
+        nextIndex: input.length,
+      }
+    },
+  ),
+  flags: ['readonly'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const existing = ensureStringOrMissing(ctx.db, args.key)
+    if (!existing || existing.length === 0) {
+      return integer(0)
+    }
+    if (!args.range) {
+      return integer(countBits(existing, 0, existing.length * 8 - 1))
+    }
+
+    const { start, end, bit } = args.range
+    const size = bit ? existing.length * 8 : existing.length
+    const resolved = resolveRange(start, end, size)
+    if (!resolved) {
+      return integer(0)
+    }
+    const [first, last] = resolved
+    const firstBit = bit ? first : first * 8
+    const lastBit = bit ? last : last * 8 + 7
+    return integer(countBits(existing, firstBit, lastBit))
+  },
+})
+
+// --- BITPOS ----------------------------------------------------------------
+
+type BitPosArgs = {
+  key: Buffer
+  bit: number
+  start?: number
+  end?: number
+  endGiven: boolean
+  bitMode: boolean
+}
+
+export const bitposCommand = defineCommand({
+  name: 'bitpos',
+  schema: t.custom(
+    (input, index, ctx): { value: BitPosArgs; nextIndex: number } => {
+      const key = input[index]
+      const bitToken = input[index + 1]
+      if (!key || !bitToken) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+      const bitRaw = bitToken.toString()
+      if (bitRaw !== '0' && bitRaw !== '1') {
+        throw new BitPosBitError()
+      }
+      const extra = input.length - index - 2
+      if (extra > 3) {
+        throw new RedisSyntaxError()
+      }
+      const args: BitPosArgs = {
+        key,
+        bit: Number(bitRaw),
+        endGiven: extra >= 2,
+        bitMode: false,
+      }
+      if (extra >= 1) {
+        args.start = parseRangeIndex(input[index + 2]!)
+      }
+      if (extra >= 2) {
+        args.end = parseRangeIndex(input[index + 3]!)
+      }
+      args.bitMode = parseRangeUnit(input[index + 4], extra === 3, ctx)
+      return { value: args, nextIndex: input.length }
+    },
+  ),
+  flags: ['readonly'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const existing = ensureStringOrMissing(ctx.db, args.key)
+    if (!existing || existing.length === 0) {
+      // Missing/empty key reads as all-zero: a clear bit is at position 0, a
+      // set bit is never found.
+      return integer(args.bit === 0 ? 0 : -1)
+    }
+
+    const totalBits = existing.length * 8
+    let firstBit: number
+    let lastBit: number
+    if (args.start === undefined) {
+      firstBit = 0
+      lastBit = totalBits - 1
+    } else {
+      const size = args.bitMode ? totalBits : existing.length
+      const end = args.end ?? -1
+      const resolved = resolveRange(args.start, end, size)
+      if (!resolved) {
+        return integer(-1)
+      }
+      const [first, last] = resolved
+      firstBit = args.bitMode ? first : first * 8
+      lastBit = args.bitMode ? last : last * 8 + 7
+    }
+
+    for (let i = firstBit; i <= lastBit; i++) {
+      if (getBit(existing, i) === args.bit) {
+        return integer(i)
+      }
+    }
+    // Not found. When looking for a clear bit without an explicit end, the
+    // string is treated as zero-padded on the right, so the answer is the
+    // first bit past the searched range.
+    if (args.bit === 0 && !args.endGiven) {
+      return integer(lastBit + 1)
+    }
+    return integer(-1)
+  },
+})
+
+// Parse the optional BYTE|BIT modifier shared by BITCOUNT/BITPOS. Returns true
+// for BIT mode, false for BYTE mode. The modifier is gated to Redis 7.0+; on
+// older profiles an unrecognized trailing token is a plain syntax error.
+function parseRangeUnit(
+  token: Buffer | undefined,
+  present: boolean,
+  ctx: ParseContext,
+): boolean {
+  if (!present) {
+    return false
+  }
+  if (!ctx.profile.has('bit.byte-bit-range')) {
+    throw new RedisSyntaxError()
+  }
+  const unit = token!.toString().toUpperCase()
+  if (unit === 'BYTE') return false
+  if (unit === 'BIT') return true
+  throw new RedisSyntaxError()
+}
+
+// --- BITOP -----------------------------------------------------------------
+
+type BitOp = 'AND' | 'OR' | 'XOR' | 'NOT'
+type BitOpArgs = { op: BitOp; destKey: Buffer; sourceKeys: Buffer[] }
+
+export const bitopCommand = defineCommand({
+  name: 'bitop',
+  schema: t.custom(
+    (input, index, ctx): { value: BitOpArgs; nextIndex: number } => {
+      const opToken = input[index]
+      const destKey = input[index + 1]
+      const sourceKeys = input.slice(index + 2)
+      if (!opToken || !destKey || sourceKeys.length === 0) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+      const op = opToken.toString().toUpperCase()
+      if (op !== 'AND' && op !== 'OR' && op !== 'XOR' && op !== 'NOT') {
+        throw new RedisSyntaxError()
+      }
+      if (op === 'NOT' && sourceKeys.length !== 1) {
+        throw new BitOpNotSingleKeyError()
+      }
+      return {
+        value: { op, destKey, sourceKeys },
+        nextIndex: input.length,
+      }
+    },
+  ),
+  flags: ['write', 'denyoom'],
+  keys: args => [args.destKey, ...args.sourceKeys],
+  execute: (args, ctx) => {
+    const sources = args.sourceKeys.map(
+      key => ensureStringOrMissing(ctx.db, key) ?? EMPTY,
+    )
+    const maxLen = sources.reduce((max, buf) => Math.max(max, buf.length), 0)
+
+    if (maxLen === 0) {
+      ctx.db.delete(args.destKey)
+      return integer(0)
+    }
+
+    const result = Buffer.alloc(maxLen)
+    if (args.op === 'NOT') {
+      const src = sources[0]!
+      for (let i = 0; i < maxLen; i++) {
+        result[i] = ~byteAt(src, i) & 0xff
+      }
+    } else {
+      for (let i = 0; i < maxLen; i++) {
+        let acc = byteAt(sources[0]!, i)
+        for (let j = 1; j < sources.length; j++) {
+          const value = byteAt(sources[j]!, i)
+          if (args.op === 'AND') acc &= value
+          else if (args.op === 'OR') acc |= value
+          else acc ^= value
+        }
+        result[i] = acc
+      }
+    }
+
+    ctx.db.setString(args.destKey, result)
+    return integer(maxLen)
+  },
+})
+
+// --- BITFIELD / BITFIELD_RO ------------------------------------------------
+
+type FieldType = { signed: boolean; bits: number }
+type Overflow = 'WRAP' | 'SAT' | 'FAIL'
+type BitFieldOp =
+  | { kind: 'GET'; type: FieldType; offset: number }
+  | {
+      kind: 'SET'
+      type: FieldType
+      offset: number
+      operand: bigint
+      overflow: Overflow
+    }
+  | {
+      kind: 'INCRBY'
+      type: FieldType
+      offset: number
+      operand: bigint
+      overflow: Overflow
+    }
+type BitFieldArgs = { key: Buffer; ops: BitFieldOp[] }
+
+function parseFieldType(token: Buffer | undefined): FieldType {
+  if (!token) {
+    throw new RedisSyntaxError()
+  }
+  const match = /^([iu])(\d+)$/.exec(token.toString())
+  if (!match) {
+    throw new BitfieldTypeError()
+  }
+  const signed = match[1] === 'i'
+  const bits = Number(match[2])
+  const maxBits = signed ? 64 : 63
+  if (bits < 1 || bits > maxBits) {
+    throw new BitfieldTypeError()
+  }
+  return { signed, bits }
+}
+
+function parseFieldOffset(token: Buffer | undefined, bits: number): number {
+  if (!token) {
+    throw new RedisSyntaxError()
+  }
+  let raw = token.toString()
+  const useWidth = raw.startsWith('#')
+  if (useWidth) {
+    raw = raw.slice(1)
+  }
+  if (!isIntegerToken(raw)) {
+    throw new BitOffsetError()
+  }
+  const n = Number(raw)
+  if (!Number.isSafeInteger(n) || n < 0) {
+    throw new BitOffsetError()
+  }
+  const offset = useWidth ? n * bits : n
+  if (offset >= MAX_BIT_OFFSET) {
+    throw new BitOffsetError()
+  }
+  return offset
+}
+
+function parseFieldValue(token: Buffer | undefined): bigint {
+  if (!token) {
+    throw new RedisSyntaxError()
+  }
+  const raw = token.toString()
+  if (!isIntegerToken(raw)) {
+    throw new ExpectedIntegerError()
+  }
+  const value = BigInt(raw)
+  if (value < INT64_MIN || value > INT64_MAX) {
+    throw new ExpectedIntegerError()
+  }
+  return value
+}
+
+function parseBitFieldOps(
+  input: readonly Buffer[],
+  index: number,
+  ctx: ParseContext,
+  readonly: boolean,
+): { value: BitFieldArgs; nextIndex: number } {
+  const key = input[index]
+  if (!key) {
+    throw new WrongNumberOfArgumentsError(ctx.commandName)
+  }
+  const ops: BitFieldOp[] = []
+  let overflow: Overflow = 'WRAP'
+  let cursor = index + 1
+
+  while (cursor < input.length) {
+    const sub = input[cursor]!.toString().toUpperCase()
+
+    if (sub === 'OVERFLOW') {
+      const modeToken = input[cursor + 1]
+      if (!modeToken) {
+        throw new RedisSyntaxError()
+      }
+      const mode = modeToken.toString().toUpperCase()
+      if (mode !== 'WRAP' && mode !== 'SAT' && mode !== 'FAIL') {
+        throw new BitfieldOverflowTypeError()
+      }
+      overflow = mode
+      cursor += 2
+      continue
+    }
+
+    if (sub === 'GET') {
+      const type = parseFieldType(input[cursor + 1])
+      const offset = parseFieldOffset(input[cursor + 2], type.bits)
+      ops.push({ kind: 'GET', type, offset })
+      cursor += 3
+      continue
+    }
+
+    if (sub === 'SET' || sub === 'INCRBY') {
+      if (readonly) {
+        throw new BitfieldRoGetOnlyError()
+      }
+      const type = parseFieldType(input[cursor + 1])
+      const offset = parseFieldOffset(input[cursor + 2], type.bits)
+      const operand = parseFieldValue(input[cursor + 3])
+      ops.push({ kind: sub, type, offset, operand, overflow })
+      cursor += 4
+      continue
+    }
+
+    if (readonly) {
+      throw new BitfieldRoGetOnlyError()
+    }
+    throw new RedisSyntaxError()
+  }
+
+  return { value: { key, ops }, nextIndex: input.length }
+}
+
+function readField(buf: Buffer, offset: number, type: FieldType): bigint {
+  let value = 0n
+  for (let i = 0; i < type.bits; i++) {
+    value = (value << 1n) | BigInt(getBit(buf, offset + i))
+  }
+  if (type.signed && value & (1n << BigInt(type.bits - 1))) {
+    value -= 1n << BigInt(type.bits)
+  }
+  return value
+}
+
+function writeField(
+  buf: Buffer,
+  offset: number,
+  type: FieldType,
+  value: bigint,
+): void {
+  const stored = value & ((1n << BigInt(type.bits)) - 1n)
+  for (let i = 0; i < type.bits; i++) {
+    const bit = Number((stored >> BigInt(type.bits - 1 - i)) & 1n)
+    const bitIndex = offset + i
+    const byteIndex = bitIndex >>> 3
+    const mask = 1 << (7 - (bitIndex & 7))
+    if (bit) {
+      buf[byteIndex]! |= mask
+    } else {
+      buf[byteIndex]! &= ~mask
+    }
+  }
+}
+
+// Apply the overflow policy. Returns the value to store (and reply with), or
+// null when an overflow occurs under FAIL.
+function applyOverflow(
+  value: bigint,
+  type: FieldType,
+  mode: Overflow,
+): bigint | null {
+  const min = type.signed ? -(1n << BigInt(type.bits - 1)) : 0n
+  const max = type.signed
+    ? (1n << BigInt(type.bits - 1)) - 1n
+    : (1n << BigInt(type.bits)) - 1n
+
+  if (value >= min && value <= max) {
+    return value
+  }
+  if (mode === 'FAIL') {
+    return null
+  }
+  if (mode === 'SAT') {
+    return value > max ? max : min
+  }
+  // WRAP: modular reduction into [min, max].
+  const range = 1n << BigInt(type.bits)
+  return ((((value - min) % range) + range) % range) + min
+}
+
+function executeBitField(
+  args: BitFieldArgs,
+  ctx: RedisExecutionContext,
+): RedisResult {
+  const existing = ensureStringOrMissing(ctx.db, args.key)
+  const hasWrite = args.ops.some(op => op.kind !== 'GET')
+
+  let buf = existing ? Buffer.from(existing) : Buffer.alloc(0)
+  // Pre-grow once to fit every write op — Redis grows the key even for an op
+  // that ultimately FAILs its overflow check.
+  let maxBytes = buf.length
+  for (const op of args.ops) {
+    if (op.kind === 'GET') continue
+    const need = Math.ceil((op.offset + op.type.bits) / 8)
+    if (need > maxBytes) maxBytes = need
+  }
+  if (maxBytes > buf.length) {
+    const grown = Buffer.alloc(maxBytes)
+    buf.copy(grown, 0)
+    buf = grown
+  }
+
+  const results: RedisValue[] = []
+  for (const op of args.ops) {
+    if (op.kind === 'GET') {
+      results.push(RedisValue.integer(readField(buf, op.offset, op.type)))
+      continue
+    }
+    if (op.kind === 'SET') {
+      const old = readField(buf, op.offset, op.type)
+      const next = applyOverflow(op.operand, op.type, op.overflow)
+      if (next === null) {
+        results.push(RedisValue.null())
+        continue
+      }
+      writeField(buf, op.offset, op.type, next)
+      results.push(RedisValue.integer(old))
+    } else {
+      const current = readField(buf, op.offset, op.type)
+      const next = applyOverflow(current + op.operand, op.type, op.overflow)
+      if (next === null) {
+        results.push(RedisValue.null())
+        continue
+      }
+      writeField(buf, op.offset, op.type, next)
+      results.push(RedisValue.integer(next))
+    }
+  }
+
+  if (hasWrite) {
+    ctx.db.setString(args.key, buf, { keepTtl: true })
+  }
+  return RedisResult.create(RedisValue.array(results))
+}
+
+function bitFieldSchema(readonly: boolean): CommandSchema<BitFieldArgs> {
+  return t.custom((input, index, ctx) =>
+    parseBitFieldOps(input, index, ctx, readonly),
+  )
+}
+
+export const bitfieldCommand = defineCommand({
+  name: 'bitfield',
+  schema: bitFieldSchema(false),
+  flags: ['write', 'denyoom'],
+  keys: args => [args.key],
+  execute: executeBitField,
+})
+
+export const bitfieldRoCommand = defineCommand({
+  name: 'bitfield_ro',
+  since: { redis: '6.2.0', valkey: '7.2.0' },
+  schema: bitFieldSchema(true),
+  flags: ['readonly', 'fast'],
+  keys: args => [args.key],
+  execute: executeBitField,
+})
+
+export const bitmapsCommands = [
+  setbitCommand,
+  getbitCommand,
+  bitcountCommand,
+  bitposCommand,
+  bitopCommand,
+  bitfieldCommand,
+  bitfieldRoCommand,
+]

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -13,6 +13,7 @@ import {
   createSubscribedModePolicy,
   createTransactionPolicy,
 } from '../core/execution-policies'
+import { bitmapsCommands } from './bitmaps'
 import { commandCommand } from './command'
 import { configCommands } from './config'
 import { connectionCommands } from './connection'
@@ -36,6 +37,7 @@ export const redisCommandDefinitions: readonly CommandDefinition[] = [
   ...transactionCommands,
   ...monitorCommands,
   ...stringsCommands,
+  ...bitmapsCommands,
   ...keysCommands,
   ...scanCommands,
   ...hashesCommands,
@@ -130,6 +132,16 @@ export {
   getexCommand,
   stringsCommands,
 } from './strings'
+export {
+  bitmapsCommands,
+  setbitCommand,
+  getbitCommand,
+  bitcountCommand,
+  bitposCommand,
+  bitopCommand,
+  bitfieldCommand,
+  bitfieldRoCommand,
+} from './bitmaps'
 export {
   discardCommand,
   execCommand,

--- a/src/core/compatibility/feature-gates.ts
+++ b/src/core/compatibility/feature-gates.ts
@@ -19,5 +19,7 @@ export const FEATURE_GATES: Record<FeatureId, VersionGate> = {
   'pubsub.sharded': { redis: '7.0.0', valkey: '7.2.0' },
   'pubsub.resp3-publish-reply-first': { redis: '7.2.0', valkey: '8.0.0' },
   'stream.xautoclaim-deleted-ids': { redis: '7.0.0', valkey: '7.2.0' },
+  // BITCOUNT/BITPOS BYTE|BIT range modifier — Redis 7.0 / Valkey 7.2.
+  'bit.byte-bit-range': { redis: '7.0.0', valkey: '7.2.0' },
   'cluster.multi-db': { valkey: '9.0.0' },
 }

--- a/src/core/compatibility/profile.ts
+++ b/src/core/compatibility/profile.ts
@@ -20,6 +20,7 @@ export type FeatureId =
   | 'pubsub.sharded'
   | 'pubsub.resp3-publish-reply-first'
   | 'stream.xautoclaim-deleted-ids'
+  | 'bit.byte-bit-range'
   | 'cluster.multi-db'
 
 export interface CompatibilityProfile {

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -180,6 +180,57 @@ export class OffsetOutOfRangeError extends RedisCommandError {
   }
 }
 
+/** SETBIT/GETBIT/BITFIELD offset that is negative, non-integer, or >= 2^32. */
+export class BitOffsetError extends RedisCommandError {
+  constructor() {
+    super('bit offset is not an integer or out of range')
+  }
+}
+
+/** SETBIT value that is not exactly 0 or 1. */
+export class BitValueError extends RedisCommandError {
+  constructor() {
+    super('bit is not an integer or out of range')
+  }
+}
+
+/** BITPOS bit argument that is not 0 or 1. */
+export class BitPosBitError extends RedisCommandError {
+  constructor() {
+    super('The bit argument must be 1 or 0.')
+  }
+}
+
+/** BITOP NOT invoked with more than one source key. */
+export class BitOpNotSingleKeyError extends RedisCommandError {
+  constructor() {
+    super('BITOP NOT must be called with a single source key.')
+  }
+}
+
+/** BITFIELD type token that is malformed or u64 (only i64 is allowed at 64 bits). */
+export class BitfieldTypeError extends RedisCommandError {
+  constructor() {
+    super(
+      'Invalid bitfield type. Use something like i16 u8. Note that u64 is not supported but i64 is.',
+    )
+  }
+}
+
+/** BITFIELD OVERFLOW with a mode other than WRAP/SAT/FAIL. */
+export class BitfieldOverflowTypeError extends RedisCommandError {
+  constructor() {
+    super('Invalid OVERFLOW type specified')
+  }
+}
+
+/** A non-GET subcommand passed to BITFIELD_RO. */
+export class BitfieldRoGetOnlyError extends RedisCommandError {
+  constructor() {
+    super('BITFIELD_RO only supports the GET subcommand')
+  }
+}
+
 export class WrongTypeRedisError extends RedisCommandError {
   constructor() {
     super(

--- a/tests-integration/compatibility/profile-gates.test.ts
+++ b/tests-integration/compatibility/profile-gates.test.ts
@@ -137,6 +137,25 @@ describe(
       await expectGate(true, 'SET', key, 'expires', 'EXAT', '4102444800')
       await expectGate(true, 'SLOWLOG', 'GET', '-1')
 
+      // BITCOUNT/BITPOS BYTE|BIT range modifier is Redis 7.0+ (Valkey 7.2+).
+      await expectGate(
+        supportsBitByteBitRange(),
+        'BITCOUNT',
+        key,
+        '0',
+        '0',
+        'BYTE',
+      )
+      await expectGate(
+        supportsBitByteBitRange(),
+        'BITPOS',
+        key,
+        '1',
+        '0',
+        '-1',
+        'BIT',
+      )
+
       await expectGate(supportsCommandDocs(), 'COMMAND', 'DOCS')
       await expectGate(
         supportsCommandDocs(),
@@ -369,6 +388,10 @@ function supportsShardedPubSub(): boolean {
 }
 
 function supportsZintercard(): boolean {
+  return profile !== 'redis-6.2'
+}
+
+function supportsBitByteBitRange(): boolean {
   return profile !== 'redis-6.2'
 }
 

--- a/tests-integration/ioredis/string/bitmap.test.ts
+++ b/tests-integration/ioredis/string/bitmap.test.ts
@@ -1,0 +1,435 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster, Redis } from 'ioredis'
+import { TestRunner } from '../../test-config'
+import { connectToSlotOwner, errorWithMessage, randomKey } from '../../utils'
+
+const testRunner = new TestRunner()
+
+// Every key shares one hashtag so the whole suite runs over a single direct
+// (unprefixed) connection to one slot owner — multi-key BITOP stays same-slot,
+// `.call()` gives exact arg control for arity/error assertions, and we avoid
+// churning a fresh connection per test against the shared real cluster.
+const TAG = '{bitmap}'
+
+describe(`Bitmap Commands Integration (${testRunner.getBackendName()})`, () => {
+  let redisClient: Cluster | undefined
+  let client: Redis
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster('bitmap-integration')
+    client = await connectToSlotOwner(redisClient, TAG)
+  })
+
+  after(async () => {
+    client?.disconnect()
+    await testRunner.cleanup()
+  })
+
+  // Per-test key namespace (unique suffix) under the shared hashtag.
+  const ns = (): string => `${TAG}:${randomKey()}`
+
+  test('SETBIT / GETBIT set, return old bit, and auto-grow', async () => {
+    const key = `${ns()}:sb`
+
+    assert.strictEqual(await client.call('SETBIT', key, '7', '1'), 0)
+    assert.strictEqual(await client.call('GETBIT', key, '7'), 1)
+    // SETBIT returns the previous bit value.
+    assert.strictEqual(await client.call('SETBIT', key, '7', '0'), 1)
+    assert.strictEqual(await client.call('GETBIT', key, '7'), 0)
+
+    // Auto-grow: setting a high bit extends the underlying string.
+    assert.strictEqual(await client.call('SETBIT', key, '100', '1'), 0)
+    assert.strictEqual(await client.call('STRLEN', key), 13)
+
+    // GETBIT past the end and on a missing key reads 0.
+    assert.strictEqual(await client.call('GETBIT', key, '100000'), 0)
+    assert.strictEqual(await client.call('GETBIT', `${ns()}:missing`, '5'), 0)
+  })
+
+  test('SETBIT / GETBIT argument errors match Redis', async () => {
+    const key = `${ns()}:sb`
+
+    await assert.rejects(
+      () => client.call('SETBIT', key, '4294967296', '1'),
+      errorWithMessage('ERR bit offset is not an integer or out of range'),
+    )
+    await assert.rejects(
+      () => client.call('SETBIT', key, '-1', '1'),
+      errorWithMessage('ERR bit offset is not an integer or out of range'),
+    )
+    await assert.rejects(
+      () => client.call('SETBIT', key, 'abc', '1'),
+      errorWithMessage('ERR bit offset is not an integer or out of range'),
+    )
+    await assert.rejects(
+      () => client.call('SETBIT', key, '7', '2'),
+      errorWithMessage('ERR bit is not an integer or out of range'),
+    )
+    await assert.rejects(
+      () => client.call('SETBIT', key, '7', '-1'),
+      errorWithMessage('ERR bit is not an integer or out of range'),
+    )
+    await assert.rejects(
+      () => client.call('SETBIT', key),
+      errorWithMessage("ERR wrong number of arguments for 'setbit' command"),
+    )
+    await assert.rejects(
+      () => client.call('GETBIT', key),
+      errorWithMessage("ERR wrong number of arguments for 'getbit' command"),
+    )
+
+    // The max valid offset is 2^32 - 1.
+    assert.strictEqual(
+      await client.call('SETBIT', `${ns()}:max`, '4294967295', '1'),
+      0,
+    )
+  })
+
+  test('BITCOUNT counts set bits with byte and bit ranges', async () => {
+    const key = `${ns()}:bc`
+    await client.call('SET', key, 'foobar')
+
+    assert.strictEqual(await client.call('BITCOUNT', key), 26)
+    assert.strictEqual(await client.call('BITCOUNT', key, '1', '1'), 6)
+    assert.strictEqual(await client.call('BITCOUNT', key, '0', '0'), 4)
+    assert.strictEqual(
+      await client.call('BITCOUNT', key, '0', '-1', 'BYTE'),
+      26,
+    )
+    assert.strictEqual(await client.call('BITCOUNT', key, '5', '30', 'BIT'), 17)
+    // Modifier is case-insensitive.
+    assert.strictEqual(await client.call('BITCOUNT', key, '5', '30', 'bit'), 17)
+
+    // Negative / inverted / out-of-range byte ranges.
+    assert.strictEqual(await client.call('BITCOUNT', key, '-1', '-1'), 4)
+    assert.strictEqual(await client.call('BITCOUNT', key, '-100', '-1'), 26)
+    assert.strictEqual(await client.call('BITCOUNT', key, '2', '1'), 0)
+    assert.strictEqual(await client.call('BITCOUNT', key, '100', '200'), 0)
+
+    // Missing key counts zero.
+    assert.strictEqual(await client.call('BITCOUNT', `${ns()}:missing`), 0)
+  })
+
+  test('BITCOUNT argument errors match Redis', async () => {
+    const key = `${ns()}:bc`
+    await client.call('SET', key, 'foobar')
+
+    // A lone start index (no end) is a syntax error.
+    await assert.rejects(
+      () => client.call('BITCOUNT', key, '0'),
+      errorWithMessage('ERR syntax error'),
+    )
+    await assert.rejects(
+      () => client.call('BITCOUNT', key, '0', '0', 'NOPE'),
+      errorWithMessage('ERR syntax error'),
+    )
+    await assert.rejects(
+      () => client.call('BITCOUNT'),
+      errorWithMessage("ERR wrong number of arguments for 'bitcount' command"),
+    )
+  })
+
+  test('BITPOS finds the first set/clear bit', async () => {
+    // Pattern with bits 12..23 set (0x00 0x0f 0xff).
+    const pat = `${ns()}:pat`
+    for (let i = 12; i <= 23; i++) {
+      await client.call('SETBIT', pat, String(i), '1')
+    }
+    assert.strictEqual(await client.call('BITPOS', pat, '1'), 12)
+    assert.strictEqual(await client.call('BITPOS', pat, '1', '2'), 16)
+    assert.strictEqual(
+      await client.call('BITPOS', pat, '1', '0', '-1', 'BIT'),
+      12,
+    )
+
+    // All-ones value: searching for a clear bit.
+    const ones = `${ns()}:ones`
+    for (let i = 0; i <= 23; i++) {
+      await client.call('SETBIT', ones, String(i), '1')
+    }
+    // No explicit range: returns the first bit past the end of the string.
+    assert.strictEqual(await client.call('BITPOS', ones, '0'), 24)
+    // With an explicit range: no clear bit found -> -1.
+    assert.strictEqual(await client.call('BITPOS', ones, '0', '0', '-1'), -1)
+    assert.strictEqual(await client.call('BITPOS', ones, '1'), 0)
+
+    // Missing key: 0 when searching for a clear bit, -1 for a set bit.
+    assert.strictEqual(await client.call('BITPOS', `${ns()}:missing`, '0'), 0)
+    assert.strictEqual(await client.call('BITPOS', `${ns()}:missing`, '1'), -1)
+  })
+
+  test('BITPOS argument errors match Redis', async () => {
+    const key = `${ns()}:bp`
+    await client.call('SET', key, 'foobar')
+
+    await assert.rejects(
+      () => client.call('BITPOS', key, '2'),
+      errorWithMessage('ERR The bit argument must be 1 or 0.'),
+    )
+    await assert.rejects(
+      () => client.call('BITPOS', key),
+      errorWithMessage("ERR wrong number of arguments for 'bitpos' command"),
+    )
+  })
+
+  test('BITOP performs bitwise ops and stores the result', async () => {
+    const tag = ns()
+    const a = `${tag}:a`
+    const b = `${tag}:b`
+    await client.call('SET', a, 'abc') // 0x61 0x62 0x63
+    await client.call('SET', b, 'abd') // 0x61 0x62 0x64
+
+    assert.strictEqual(await client.call('BITOP', 'AND', `${tag}:and`, a, b), 3)
+    assert.deepStrictEqual(
+      await client.callBuffer('GET', `${tag}:and`),
+      Buffer.from([0x61, 0x62, 0x60]),
+    )
+
+    assert.strictEqual(await client.call('BITOP', 'OR', `${tag}:or`, a, b), 3)
+    assert.deepStrictEqual(
+      await client.callBuffer('GET', `${tag}:or`),
+      Buffer.from([0x61, 0x62, 0x67]),
+    )
+
+    assert.strictEqual(await client.call('BITOP', 'XOR', `${tag}:xor`, a, b), 3)
+    assert.deepStrictEqual(
+      await client.callBuffer('GET', `${tag}:xor`),
+      Buffer.from([0x00, 0x00, 0x07]),
+    )
+
+    assert.strictEqual(await client.call('BITOP', 'NOT', `${tag}:not`, a), 3)
+    assert.deepStrictEqual(
+      await client.callBuffer('GET', `${tag}:not`),
+      Buffer.from([0x9e, 0x9d, 0x9c]),
+    )
+  })
+
+  test('BITOP zero-pads shorter operands and deletes empty results', async () => {
+    const tag = ns()
+    const long = `${tag}:long`
+    const short = `${tag}:short`
+    await client.call('SET', long, 'abc') // 3 bytes
+    await client.call('SET', short, 'ab') // 2 bytes
+
+    // Result length is the longest operand; the short one is zero-padded.
+    assert.strictEqual(
+      await client.call('BITOP', 'AND', `${tag}:dl`, long, short),
+      3,
+    )
+    assert.deepStrictEqual(
+      await client.callBuffer('GET', `${tag}:dl`),
+      Buffer.from([0x61, 0x62, 0x00]),
+    )
+
+    // All-missing sources produce an empty result and delete the destination.
+    const dest = `${tag}:dest`
+    await client.call('SET', dest, 'preexisting')
+    assert.strictEqual(
+      await client.call('BITOP', 'AND', dest, `${tag}:m1`, `${tag}:m2`),
+      0,
+    )
+    assert.strictEqual(await client.call('EXISTS', dest), 0)
+  })
+
+  test('BITOP argument errors match Redis', async () => {
+    const tag = ns()
+    const a = `${tag}:a`
+    const b = `${tag}:b`
+    await client.call('SET', a, 'abc')
+    await client.call('SET', b, 'abd')
+
+    await assert.rejects(
+      () => client.call('BITOP', 'NOT', `${tag}:d`, a, b),
+      errorWithMessage(
+        'ERR BITOP NOT must be called with a single source key.',
+      ),
+    )
+    await assert.rejects(
+      () => client.call('BITOP', 'NOPE', `${tag}:d`, a),
+      errorWithMessage('ERR syntax error'),
+    )
+    await assert.rejects(
+      () => client.call('BITOP', 'AND', `${tag}:d`),
+      errorWithMessage("ERR wrong number of arguments for 'bitop' command"),
+    )
+  })
+
+  test('BITFIELD GET/SET/INCRBY with overflow modes', async () => {
+    const tag = ns()
+    const key = `${tag}:bf`
+
+    // SET returns the previous value; GET reads it back.
+    assert.deepStrictEqual(
+      await client.call(
+        'BITFIELD',
+        key,
+        'SET',
+        'u8',
+        '0',
+        '255',
+        'GET',
+        'u8',
+        '0',
+      ),
+      [0, 255],
+    )
+    // INCRBY wraps by default (255 + 10 = 9 mod 256).
+    assert.deepStrictEqual(
+      await client.call('BITFIELD', key, 'INCRBY', 'u8', '0', '10'),
+      [9],
+    )
+
+    // OVERFLOW SAT saturates at the type maximum.
+    assert.deepStrictEqual(
+      await client.call(
+        'BITFIELD',
+        `${tag}:sat`,
+        'SET',
+        'u8',
+        '0',
+        '250',
+        'OVERFLOW',
+        'SAT',
+        'INCRBY',
+        'u8',
+        '0',
+        '100',
+      ),
+      [0, 255],
+    )
+
+    // OVERFLOW FAIL returns nil and leaves the value untouched.
+    assert.deepStrictEqual(
+      await client.call(
+        'BITFIELD',
+        `${tag}:fail`,
+        'SET',
+        'u8',
+        '0',
+        '250',
+        'OVERFLOW',
+        'FAIL',
+        'INCRBY',
+        'u8',
+        '0',
+        '100',
+      ),
+      [0, null],
+    )
+
+    // Signed SAT clamps at the type minimum.
+    assert.deepStrictEqual(
+      await client.call(
+        'BITFIELD',
+        `${tag}:smin`,
+        'SET',
+        'i8',
+        '0',
+        '-128',
+        'OVERFLOW',
+        'SAT',
+        'INCRBY',
+        'i8',
+        '0',
+        '-10',
+      ),
+      [0, -128],
+    )
+
+    // `#N` offset notation addresses the Nth field of the given width.
+    assert.deepStrictEqual(
+      await client.call(
+        'BITFIELD',
+        `${tag}:hash`,
+        'SET',
+        'i8',
+        '#1',
+        '-1',
+        'GET',
+        'i8',
+        '8',
+      ),
+      [0, -1],
+    )
+
+    // GET on a missing key / past the end reads 0.
+    assert.deepStrictEqual(
+      await client.call('BITFIELD', `${tag}:miss`, 'GET', 'u8', '0'),
+      [0],
+    )
+    // An empty operation list yields an empty array.
+    assert.deepStrictEqual(await client.call('BITFIELD', key), [])
+  })
+
+  test('BITFIELD argument errors match Redis', async () => {
+    const key = `${ns()}:bf`
+
+    await assert.rejects(
+      () => client.call('BITFIELD', key, 'GET', 'u64', '0'),
+      errorWithMessage(
+        'ERR Invalid bitfield type. Use something like i16 u8. Note that u64 is not supported but i64 is.',
+      ),
+    )
+    for (const badType of ['i0', 'x8', 'i65', 'u64']) {
+      await assert.rejects(
+        () => client.call('BITFIELD', key, 'GET', badType, '0'),
+        errorWithMessage(
+          'ERR Invalid bitfield type. Use something like i16 u8. Note that u64 is not supported but i64 is.',
+        ),
+      )
+    }
+    await assert.rejects(
+      () => client.call('BITFIELD', key, 'OVERFLOW', 'NOPE', 'GET', 'u8', '0'),
+      errorWithMessage('ERR Invalid OVERFLOW type specified'),
+    )
+    await assert.rejects(
+      () => client.call('BITFIELD', key, 'SET', 'u8', '0', 'abc'),
+      errorWithMessage('ERR value is not an integer or out of range'),
+    )
+    await assert.rejects(
+      () => client.call('BITFIELD', key, 'GET', 'u8', 'abc'),
+      errorWithMessage('ERR bit offset is not an integer or out of range'),
+    )
+    await assert.rejects(
+      () => client.call('BITFIELD', key, 'GET', 'u8'),
+      errorWithMessage('ERR syntax error'),
+    )
+  })
+
+  test('BITFIELD_RO supports GET only', async () => {
+    const key = `${ns()}:bfro`
+    await client.call('BITFIELD', key, 'SET', 'i64', '0', '-100')
+
+    assert.deepStrictEqual(
+      await client.call('BITFIELD_RO', key, 'GET', 'i64', '0'),
+      [-100],
+    )
+    await assert.rejects(
+      () => client.call('BITFIELD_RO', key, 'SET', 'u8', '0', '1'),
+      errorWithMessage('ERR BITFIELD_RO only supports the GET subcommand'),
+    )
+  })
+
+  test('bitmap commands reject keys holding the wrong type', async () => {
+    const tag = ns()
+    const key = `${tag}:list`
+    await client.call('RPUSH', key, 'x')
+
+    const wrongType = errorWithMessage(
+      'WRONGTYPE Operation against a key holding the wrong kind of value',
+    )
+    await assert.rejects(() => client.call('SETBIT', key, '0', '1'), wrongType)
+    await assert.rejects(() => client.call('GETBIT', key, '0'), wrongType)
+    await assert.rejects(() => client.call('BITCOUNT', key), wrongType)
+    await assert.rejects(() => client.call('BITPOS', key, '1'), wrongType)
+    await assert.rejects(
+      () => client.call('BITFIELD', key, 'GET', 'u8', '0'),
+      wrongType,
+    )
+    await assert.rejects(
+      () => client.call('BITOP', 'AND', `${tag}:d`, key),
+      wrongType,
+    )
+  })
+})

--- a/tests-integration/node-redis/string/bitmap.test.ts
+++ b/tests-integration/node-redis/string/bitmap.test.ts
@@ -1,0 +1,510 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { RedisClientType, RedisClusterType } from 'redis'
+import { TestRunner } from '../../test-config'
+import {
+  bufferClient,
+  connectToNodeRedisSlotOwner,
+  errorWithMessage,
+  flushNodeRedisCluster,
+  randomKey,
+} from '../../utils'
+
+const testRunner = new TestRunner()
+
+// node-redis twin of the ioredis bitmap suite. Every key shares one hashtag so
+// the whole suite runs over a single direct connection to one slot owner —
+// multi-key BITOP stays same-slot and `sendCommand` gives exact arg control for
+// arity/error assertions.
+const TAG = '{bitmap-nr}'
+
+describe(`Bitmap Commands Integration (node-redis, ${testRunner.getBackendName()})`, () => {
+  let redisClient: RedisClusterType
+  let client: RedisClientType
+
+  before(async () => {
+    redisClient = (await testRunner.setupNodeRedisCluster()) as RedisClusterType
+    await flushNodeRedisCluster(redisClient)
+    client = await connectToNodeRedisSlotOwner(redisClient, TAG)
+  })
+
+  after(async () => {
+    client?.destroy()
+    await testRunner.cleanup()
+  })
+
+  // Per-test key namespace (unique suffix) under the shared hashtag.
+  const ns = (): string => `${TAG}:${randomKey()}`
+  const getBuffer = (key: string): Promise<Buffer> =>
+    bufferClient(client).sendCommand(['GET', key]) as Promise<Buffer>
+
+  test('SETBIT / GETBIT set, return old bit, and auto-grow', async () => {
+    const key = `${ns()}:sb`
+
+    assert.strictEqual(await client.sendCommand(['SETBIT', key, '7', '1']), 0)
+    assert.strictEqual(await client.sendCommand(['GETBIT', key, '7']), 1)
+    // SETBIT returns the previous bit value.
+    assert.strictEqual(await client.sendCommand(['SETBIT', key, '7', '0']), 1)
+    assert.strictEqual(await client.sendCommand(['GETBIT', key, '7']), 0)
+
+    // Auto-grow: setting a high bit extends the underlying string.
+    assert.strictEqual(await client.sendCommand(['SETBIT', key, '100', '1']), 0)
+    assert.strictEqual(await client.sendCommand(['STRLEN', key]), 13)
+
+    // GETBIT past the end and on a missing key reads 0.
+    assert.strictEqual(await client.sendCommand(['GETBIT', key, '100000']), 0)
+    assert.strictEqual(
+      await client.sendCommand(['GETBIT', `${ns()}:missing`, '5']),
+      0,
+    )
+  })
+
+  test('SETBIT / GETBIT argument errors match Redis', async () => {
+    const key = `${ns()}:sb`
+
+    await assert.rejects(
+      () => client.sendCommand(['SETBIT', key, '4294967296', '1']),
+      errorWithMessage('ERR bit offset is not an integer or out of range'),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['SETBIT', key, '-1', '1']),
+      errorWithMessage('ERR bit offset is not an integer or out of range'),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['SETBIT', key, 'abc', '1']),
+      errorWithMessage('ERR bit offset is not an integer or out of range'),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['SETBIT', key, '7', '2']),
+      errorWithMessage('ERR bit is not an integer or out of range'),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['SETBIT', key, '7', '-1']),
+      errorWithMessage('ERR bit is not an integer or out of range'),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['SETBIT', key]),
+      errorWithMessage("ERR wrong number of arguments for 'setbit' command"),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['GETBIT', key]),
+      errorWithMessage("ERR wrong number of arguments for 'getbit' command"),
+    )
+
+    // The max valid offset is 2^32 - 1.
+    assert.strictEqual(
+      await client.sendCommand(['SETBIT', `${ns()}:max`, '4294967295', '1']),
+      0,
+    )
+  })
+
+  test('BITCOUNT counts set bits with byte and bit ranges', async () => {
+    const key = `${ns()}:bc`
+    await client.sendCommand(['SET', key, 'foobar'])
+
+    assert.strictEqual(await client.sendCommand(['BITCOUNT', key]), 26)
+    assert.strictEqual(await client.sendCommand(['BITCOUNT', key, '1', '1']), 6)
+    assert.strictEqual(await client.sendCommand(['BITCOUNT', key, '0', '0']), 4)
+    assert.strictEqual(
+      await client.sendCommand(['BITCOUNT', key, '0', '-1', 'BYTE']),
+      26,
+    )
+    assert.strictEqual(
+      await client.sendCommand(['BITCOUNT', key, '5', '30', 'BIT']),
+      17,
+    )
+    // Modifier is case-insensitive.
+    assert.strictEqual(
+      await client.sendCommand(['BITCOUNT', key, '5', '30', 'bit']),
+      17,
+    )
+
+    // Negative / inverted / out-of-range byte ranges.
+    assert.strictEqual(
+      await client.sendCommand(['BITCOUNT', key, '-1', '-1']),
+      4,
+    )
+    assert.strictEqual(
+      await client.sendCommand(['BITCOUNT', key, '-100', '-1']),
+      26,
+    )
+    assert.strictEqual(await client.sendCommand(['BITCOUNT', key, '2', '1']), 0)
+    assert.strictEqual(
+      await client.sendCommand(['BITCOUNT', key, '100', '200']),
+      0,
+    )
+
+    // Missing key counts zero.
+    assert.strictEqual(
+      await client.sendCommand(['BITCOUNT', `${ns()}:missing`]),
+      0,
+    )
+  })
+
+  test('BITCOUNT argument errors match Redis', async () => {
+    const key = `${ns()}:bc`
+    await client.sendCommand(['SET', key, 'foobar'])
+
+    // A lone start index (no end) is a syntax error.
+    await assert.rejects(
+      () => client.sendCommand(['BITCOUNT', key, '0']),
+      errorWithMessage('ERR syntax error'),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['BITCOUNT', key, '0', '0', 'NOPE']),
+      errorWithMessage('ERR syntax error'),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['BITCOUNT']),
+      errorWithMessage("ERR wrong number of arguments for 'bitcount' command"),
+    )
+  })
+
+  test('BITPOS finds the first set/clear bit', async () => {
+    // Pattern with bits 12..23 set (0x00 0x0f 0xff).
+    const pat = `${ns()}:pat`
+    for (let i = 12; i <= 23; i++) {
+      await client.sendCommand(['SETBIT', pat, String(i), '1'])
+    }
+    assert.strictEqual(await client.sendCommand(['BITPOS', pat, '1']), 12)
+    assert.strictEqual(await client.sendCommand(['BITPOS', pat, '1', '2']), 16)
+    assert.strictEqual(
+      await client.sendCommand(['BITPOS', pat, '1', '0', '-1', 'BIT']),
+      12,
+    )
+
+    // All-ones value: searching for a clear bit.
+    const ones = `${ns()}:ones`
+    for (let i = 0; i <= 23; i++) {
+      await client.sendCommand(['SETBIT', ones, String(i), '1'])
+    }
+    // No explicit range: returns the first bit past the end of the string.
+    assert.strictEqual(await client.sendCommand(['BITPOS', ones, '0']), 24)
+    // With an explicit range: no clear bit found -> -1.
+    assert.strictEqual(
+      await client.sendCommand(['BITPOS', ones, '0', '0', '-1']),
+      -1,
+    )
+    assert.strictEqual(await client.sendCommand(['BITPOS', ones, '1']), 0)
+
+    // Missing key: 0 when searching for a clear bit, -1 for a set bit.
+    assert.strictEqual(
+      await client.sendCommand(['BITPOS', `${ns()}:missing`, '0']),
+      0,
+    )
+    assert.strictEqual(
+      await client.sendCommand(['BITPOS', `${ns()}:missing`, '1']),
+      -1,
+    )
+  })
+
+  test('BITPOS argument errors match Redis', async () => {
+    const key = `${ns()}:bp`
+    await client.sendCommand(['SET', key, 'foobar'])
+
+    await assert.rejects(
+      () => client.sendCommand(['BITPOS', key, '2']),
+      errorWithMessage('ERR The bit argument must be 1 or 0.'),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['BITPOS', key]),
+      errorWithMessage("ERR wrong number of arguments for 'bitpos' command"),
+    )
+  })
+
+  test('BITOP performs bitwise ops and stores the result', async () => {
+    const tag = ns()
+    const a = `${tag}:a`
+    const b = `${tag}:b`
+    await client.sendCommand(['SET', a, 'abc']) // 0x61 0x62 0x63
+    await client.sendCommand(['SET', b, 'abd']) // 0x61 0x62 0x64
+
+    assert.strictEqual(
+      await client.sendCommand(['BITOP', 'AND', `${tag}:and`, a, b]),
+      3,
+    )
+    assert.deepStrictEqual(
+      await getBuffer(`${tag}:and`),
+      Buffer.from([0x61, 0x62, 0x60]),
+    )
+
+    assert.strictEqual(
+      await client.sendCommand(['BITOP', 'OR', `${tag}:or`, a, b]),
+      3,
+    )
+    assert.deepStrictEqual(
+      await getBuffer(`${tag}:or`),
+      Buffer.from([0x61, 0x62, 0x67]),
+    )
+
+    assert.strictEqual(
+      await client.sendCommand(['BITOP', 'XOR', `${tag}:xor`, a, b]),
+      3,
+    )
+    assert.deepStrictEqual(
+      await getBuffer(`${tag}:xor`),
+      Buffer.from([0x00, 0x00, 0x07]),
+    )
+
+    assert.strictEqual(
+      await client.sendCommand(['BITOP', 'NOT', `${tag}:not`, a]),
+      3,
+    )
+    assert.deepStrictEqual(
+      await getBuffer(`${tag}:not`),
+      Buffer.from([0x9e, 0x9d, 0x9c]),
+    )
+  })
+
+  test('BITOP zero-pads shorter operands and deletes empty results', async () => {
+    const tag = ns()
+    const long = `${tag}:long`
+    const short = `${tag}:short`
+    await client.sendCommand(['SET', long, 'abc']) // 3 bytes
+    await client.sendCommand(['SET', short, 'ab']) // 2 bytes
+
+    // Result length is the longest operand; the short one is zero-padded.
+    assert.strictEqual(
+      await client.sendCommand(['BITOP', 'AND', `${tag}:dl`, long, short]),
+      3,
+    )
+    assert.deepStrictEqual(
+      await getBuffer(`${tag}:dl`),
+      Buffer.from([0x61, 0x62, 0x00]),
+    )
+
+    // All-missing sources produce an empty result and delete the destination.
+    const dest = `${tag}:dest`
+    await client.sendCommand(['SET', dest, 'preexisting'])
+    assert.strictEqual(
+      await client.sendCommand([
+        'BITOP',
+        'AND',
+        dest,
+        `${tag}:m1`,
+        `${tag}:m2`,
+      ]),
+      0,
+    )
+    assert.strictEqual(await client.sendCommand(['EXISTS', dest]), 0)
+  })
+
+  test('BITOP argument errors match Redis', async () => {
+    const tag = ns()
+    const a = `${tag}:a`
+    const b = `${tag}:b`
+    await client.sendCommand(['SET', a, 'abc'])
+    await client.sendCommand(['SET', b, 'abd'])
+
+    await assert.rejects(
+      () => client.sendCommand(['BITOP', 'NOT', `${tag}:d`, a, b]),
+      errorWithMessage(
+        'ERR BITOP NOT must be called with a single source key.',
+      ),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['BITOP', 'NOPE', `${tag}:d`, a]),
+      errorWithMessage('ERR syntax error'),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['BITOP', 'AND', `${tag}:d`]),
+      errorWithMessage("ERR wrong number of arguments for 'bitop' command"),
+    )
+  })
+
+  test('BITFIELD GET/SET/INCRBY with overflow modes', async () => {
+    const tag = ns()
+    const key = `${tag}:bf`
+
+    // SET returns the previous value; GET reads it back.
+    assert.deepStrictEqual(
+      await client.sendCommand([
+        'BITFIELD',
+        key,
+        'SET',
+        'u8',
+        '0',
+        '255',
+        'GET',
+        'u8',
+        '0',
+      ]),
+      [0, 255],
+    )
+    // INCRBY wraps by default (255 + 10 = 9 mod 256).
+    assert.deepStrictEqual(
+      await client.sendCommand(['BITFIELD', key, 'INCRBY', 'u8', '0', '10']),
+      [9],
+    )
+
+    // OVERFLOW SAT saturates at the type maximum.
+    assert.deepStrictEqual(
+      await client.sendCommand([
+        'BITFIELD',
+        `${tag}:sat`,
+        'SET',
+        'u8',
+        '0',
+        '250',
+        'OVERFLOW',
+        'SAT',
+        'INCRBY',
+        'u8',
+        '0',
+        '100',
+      ]),
+      [0, 255],
+    )
+
+    // OVERFLOW FAIL returns nil and leaves the value untouched.
+    assert.deepStrictEqual(
+      await client.sendCommand([
+        'BITFIELD',
+        `${tag}:fail`,
+        'SET',
+        'u8',
+        '0',
+        '250',
+        'OVERFLOW',
+        'FAIL',
+        'INCRBY',
+        'u8',
+        '0',
+        '100',
+      ]),
+      [0, null],
+    )
+
+    // Signed SAT clamps at the type minimum.
+    assert.deepStrictEqual(
+      await client.sendCommand([
+        'BITFIELD',
+        `${tag}:smin`,
+        'SET',
+        'i8',
+        '0',
+        '-128',
+        'OVERFLOW',
+        'SAT',
+        'INCRBY',
+        'i8',
+        '0',
+        '-10',
+      ]),
+      [0, -128],
+    )
+
+    // `#N` offset notation addresses the Nth field of the given width.
+    assert.deepStrictEqual(
+      await client.sendCommand([
+        'BITFIELD',
+        `${tag}:hash`,
+        'SET',
+        'i8',
+        '#1',
+        '-1',
+        'GET',
+        'i8',
+        '8',
+      ]),
+      [0, -1],
+    )
+
+    // GET on a missing key / past the end reads 0.
+    assert.deepStrictEqual(
+      await client.sendCommand(['BITFIELD', `${tag}:miss`, 'GET', 'u8', '0']),
+      [0],
+    )
+    // An empty operation list yields an empty array.
+    assert.deepStrictEqual(await client.sendCommand(['BITFIELD', key]), [])
+  })
+
+  test('BITFIELD argument errors match Redis', async () => {
+    const key = `${ns()}:bf`
+
+    await assert.rejects(
+      () => client.sendCommand(['BITFIELD', key, 'GET', 'u64', '0']),
+      errorWithMessage(
+        'ERR Invalid bitfield type. Use something like i16 u8. Note that u64 is not supported but i64 is.',
+      ),
+    )
+    for (const badType of ['i0', 'x8', 'i65', 'u64']) {
+      await assert.rejects(
+        () => client.sendCommand(['BITFIELD', key, 'GET', badType, '0']),
+        errorWithMessage(
+          'ERR Invalid bitfield type. Use something like i16 u8. Note that u64 is not supported but i64 is.',
+        ),
+      )
+    }
+    await assert.rejects(
+      () =>
+        client.sendCommand([
+          'BITFIELD',
+          key,
+          'OVERFLOW',
+          'NOPE',
+          'GET',
+          'u8',
+          '0',
+        ]),
+      errorWithMessage('ERR Invalid OVERFLOW type specified'),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['BITFIELD', key, 'SET', 'u8', '0', 'abc']),
+      errorWithMessage('ERR value is not an integer or out of range'),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['BITFIELD', key, 'GET', 'u8', 'abc']),
+      errorWithMessage('ERR bit offset is not an integer or out of range'),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['BITFIELD', key, 'GET', 'u8']),
+      errorWithMessage('ERR syntax error'),
+    )
+  })
+
+  test('BITFIELD_RO supports GET only', async () => {
+    const key = `${ns()}:bfro`
+    await client.sendCommand(['BITFIELD', key, 'SET', 'i64', '0', '-100'])
+
+    assert.deepStrictEqual(
+      await client.sendCommand(['BITFIELD_RO', key, 'GET', 'i64', '0']),
+      [-100],
+    )
+    await assert.rejects(
+      () => client.sendCommand(['BITFIELD_RO', key, 'SET', 'u8', '0', '1']),
+      errorWithMessage('ERR BITFIELD_RO only supports the GET subcommand'),
+    )
+  })
+
+  test('bitmap commands reject keys holding the wrong type', async () => {
+    const tag = ns()
+    const key = `${tag}:list`
+    await client.sendCommand(['RPUSH', key, 'x'])
+
+    const wrongType = errorWithMessage(
+      'WRONGTYPE Operation against a key holding the wrong kind of value',
+    )
+    await assert.rejects(
+      () => client.sendCommand(['SETBIT', key, '0', '1']),
+      wrongType,
+    )
+    await assert.rejects(
+      () => client.sendCommand(['GETBIT', key, '0']),
+      wrongType,
+    )
+    await assert.rejects(() => client.sendCommand(['BITCOUNT', key]), wrongType)
+    await assert.rejects(
+      () => client.sendCommand(['BITPOS', key, '1']),
+      wrongType,
+    )
+    await assert.rejects(
+      () => client.sendCommand(['BITFIELD', key, 'GET', 'u8', '0']),
+      wrongType,
+    )
+    await assert.rejects(
+      () => client.sendCommand(['BITOP', 'AND', `${tag}:d`, key]),
+      wrongType,
+    )
+  })
+})


### PR DESCRIPTION
## Summary
Implements the Redis Bitmap command family (operating on the String type):
`SETBIT`, `GETBIT`, `BITCOUNT`, `BITPOS`, `BITOP` (AND/OR/XOR/NOT), `BITFIELD`,
and `BITFIELD_RO`. New module `src/commands/bitmaps.ts`, registered in
`src/commands/index.ts`.

Every behavior, sentinel, and error string was ground-truthed against real
Redis 7.0.15 and 6.2.14 before being asserted, including:
- `SETBIT`/`GETBIT` auto-grow, return-old-bit, offset `< 2^32` ceiling, and the
  distinct `bit offset` vs `bit` error messages.
- `BITCOUNT`/`BITPOS` negative/inverted/out-of-range index normalization and the
  `BITPOS` clear-bit-past-end virtual-zero-padding edge case.
- `BITOP` longest-operand zero-padding, empty-result destination deletion, and
  the `NOT` single-source-key rule.
- `BITFIELD` two's-complement field math (`i1..i64`, `u1..u63`; `u64` rejected),
  `WRAP`/`SAT`/`FAIL` overflow, `#N` typed-offset notation, `SET` returns the
  previous value, and write ops grow the key even when an overflow `FAIL`s.

### Compatibility profile
The `BITCOUNT`/`BITPOS` `BYTE|BIT` range modifier is gated behind a new
`bit.byte-bit-range` feature (Redis 7.0 / Valkey 7.2). On `redis-6.2` the
modifier is an unrecognized trailing token → `ERR syntax error`, matching real
Redis 6.2. `BITFIELD_RO` carries `since: redis 6.2.0 / valkey 7.2.0`. Docs:
`docs/API.md` gate table row added; `docs/COMMANDS.md` §17 checkboxes flipped.

Closes #322

## Test plan
- [x] New `tests-integration/ioredis/string/bitmap.test.ts` (13 cases) covers all
  7 commands incl. arity / wrong-type / invalid-arg / overflow / edge paths —
  red on mock before the implementation
- [x] Same suite green against real Redis (`ok 50` in the full real run, and
  13/13 in isolation) — confirms the spec matches real Redis
- [x] Gate boundary asserted in `profile-gates.test.ts` across `redis-6.2`
  (modifier gated) and `redis-7.0`/`valkey-9.0` (available)
- [x] `npm run test` (unit 320/320), `test:integration:mock` (1027/1027),
  `test:integration:compatibility:mock` (7 profiles), `npm run build`,
  `npm run lint` all pass