### PR TITLE
feat: implement HyperLogLog commands (PFADD/PFCOUNT/PFMERGE) (#323)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -521,11 +521,14 @@ key. None of these are implemented yet.
 
 ## 18. HyperLogLog Commands
 
-HyperLogLogs are stored in the String type. None of these are implemented yet.
+HyperLogLogs are stored in the String type. Cardinality is approximate, same
+as real Redis, but the on-disk encoding is a dense 16384-byte register array
+rather than Redis's sparse/dense HLL format — not byte-compatible, no
+`DUMP`/`RESTORE` parity for this type.
 
-- [ ] `PFADD key [element ...]` - Add elements to the HyperLogLog
-- [ ] `PFCOUNT key [key ...]` - Return the approximated cardinality
-- [ ] `PFMERGE destkey [sourcekey ...]` - Merge multiple HyperLogLogs into one
+- [x] `PFADD key [element ...]` - Add elements to the HyperLogLog
+- [x] `PFCOUNT key [key ...]` - Return the approximated cardinality
+- [x] `PFMERGE destkey [sourcekey ...]` - Merge multiple HyperLogLogs into one
 - [ ] `PFDEBUG`, `PFSELFTEST` - Internal/debug subcommands
 
 ## 19. Geo Commands

--- a/src/commands/hyperloglog.ts
+++ b/src/commands/hyperloglog.ts
@@ -1,0 +1,170 @@
+import { createHash } from 'node:crypto'
+import { defineCommand } from '../core/command-definition'
+import { t } from '../core/command-schema'
+import { InvalidHllError } from '../core/redis-error'
+import { ensureStringOrMissing, integer, simpleString } from './helpers'
+import type { RedisDatabase } from '../state'
+
+// Dense HyperLogLog registers: 14-bit index -> 16384 registers, one byte
+// each. Not byte-compatible with real Redis's sparse/dense HLL encoding —
+// PFCOUNT is approximate cardinality in both implementations, so exact wire
+// format parity isn't required (no DUMP/RESTORE support for this type yet).
+const HLL_BITS = 14
+const HLL_REGISTERS = 1 << HLL_BITS
+const HLL_INDEX_SHIFT = BigInt(64 - HLL_BITS)
+const HLL_REST_BITS = 64 - HLL_BITS
+
+function hash64(value: Buffer): bigint {
+  return createHash('sha1').update(value).digest().readBigUInt64BE(0)
+}
+
+// Returns true when adding `value` increased a register (i.e. the HLL was
+// altered).
+function hllAdd(registers: Buffer, value: Buffer): boolean {
+  const h = hash64(value)
+  const index = Number(h >> HLL_INDEX_SHIFT)
+  const rest = h & ((1n << HLL_INDEX_SHIFT) - 1n)
+
+  let rank = 1
+  for (let i = HLL_REST_BITS - 1; i >= 0; i--) {
+    if ((rest >> BigInt(i)) & 1n) break
+    rank++
+  }
+
+  if (registers[index]! < rank) {
+    registers[index] = rank
+    return true
+  }
+  return false
+}
+
+// Standard HyperLogLog cardinality estimator with small/large range
+// corrections (linear counting below 2.5m, large-range correction near 2^32).
+function hllCount(registers: Buffer): number {
+  const m = HLL_REGISTERS
+  let sum = 0
+  let zeros = 0
+  for (let i = 0; i < m; i++) {
+    sum += Math.pow(2, -registers[i]!)
+    if (registers[i] === 0) zeros++
+  }
+
+  const alpha = 0.7213 / (1 + 1.079 / m)
+  let estimate = (alpha * m * m) / sum
+
+  if (estimate <= 2.5 * m && zeros > 0) {
+    estimate = m * Math.log(m / zeros)
+  } else if (estimate > (1 / 30) * Math.pow(2, 32)) {
+    estimate = -Math.pow(2, 32) * Math.log(1 - estimate / Math.pow(2, 32))
+  }
+
+  return Math.round(estimate)
+}
+
+function mergeInto(dest: Buffer, source: Buffer): void {
+  for (let i = 0; i < HLL_REGISTERS; i++) {
+    if (source[i]! > dest[i]!) {
+      dest[i] = source[i]!
+    }
+  }
+}
+
+// Fetches a key as HLL registers. Returns null for a missing key (treated as
+// an empty/all-zero HLL by callers). Throws WRONGTYPE for a non-string key,
+// or the HLL-specific WRONGTYPE for a string that isn't a valid HLL buffer.
+function getHllOrThrow(db: RedisDatabase, key: Buffer): Buffer | null {
+  const existing = ensureStringOrMissing(db, key)
+  if (!existing) {
+    return null
+  }
+  if (existing.length !== HLL_REGISTERS) {
+    throw new InvalidHllError()
+  }
+  return existing
+}
+
+// --- PFADD -------------------------------------------------------------
+
+export const pfaddCommand = defineCommand({
+  name: 'pfadd',
+  schema: t.object({ key: t.key(), elements: t.variadic(t.bulk()) }),
+  flags: ['write', 'denyoom', 'fast'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const existing = getHllOrThrow(ctx.db, args.key)
+    const created = existing === null
+    const registers = existing
+      ? Buffer.from(existing)
+      : Buffer.alloc(HLL_REGISTERS)
+
+    let altered = created
+    for (const element of args.elements) {
+      if (hllAdd(registers, element)) {
+        altered = true
+      }
+    }
+
+    if (altered) {
+      ctx.db.setString(args.key, registers, { keepTtl: true })
+    }
+    return integer(altered ? 1 : 0)
+  },
+})
+
+// --- PFCOUNT -------------------------------------------------------------
+
+export const pfcountCommand = defineCommand({
+  name: 'pfcount',
+  schema: t.object({ keys: t.variadic(t.key(), { min: 1 }) }),
+  flags: ['readonly'],
+  keys: args => args.keys,
+  execute: (args, ctx) => {
+    if (args.keys.length === 1) {
+      const registers = getHllOrThrow(ctx.db, args.keys[0]!)
+      return integer(registers ? hllCount(registers) : 0)
+    }
+
+    const merged = Buffer.alloc(HLL_REGISTERS)
+    for (const key of args.keys) {
+      const registers = getHllOrThrow(ctx.db, key)
+      if (registers) {
+        mergeInto(merged, registers)
+      }
+    }
+    return integer(hllCount(merged))
+  },
+})
+
+// --- PFMERGE -------------------------------------------------------------
+
+export const pfmergeCommand = defineCommand({
+  name: 'pfmerge',
+  schema: t.object({
+    destKey: t.key(),
+    sourceKeys: t.variadic(t.key()),
+  }),
+  flags: ['write', 'denyoom'],
+  keys: args => [args.destKey, ...args.sourceKeys],
+  execute: (args, ctx) => {
+    const destExisting = getHllOrThrow(ctx.db, args.destKey)
+    const merged = destExisting
+      ? Buffer.from(destExisting)
+      : Buffer.alloc(HLL_REGISTERS)
+
+    for (const key of args.sourceKeys) {
+      const registers = getHllOrThrow(ctx.db, key)
+      if (registers) {
+        mergeInto(merged, registers)
+      }
+    }
+
+    ctx.db.setString(args.destKey, merged, { keepTtl: true })
+    return simpleString('OK')
+  },
+})
+
+export const hyperloglogCommands = [
+  pfaddCommand,
+  pfcountCommand,
+  pfmergeCommand,
+]

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -18,6 +18,7 @@ import { commandCommand } from './command'
 import { configCommands } from './config'
 import { connectionCommands } from './connection'
 import { hashesCommands } from './hashes'
+import { hyperloglogCommands } from './hyperloglog'
 import { keysCommands } from './keys'
 import { listsCommands } from './lists'
 import { monitorCommands } from './monitor'
@@ -38,6 +39,7 @@ export const redisCommandDefinitions: readonly CommandDefinition[] = [
   ...monitorCommands,
   ...stringsCommands,
   ...bitmapsCommands,
+  ...hyperloglogCommands,
   ...keysCommands,
   ...scanCommands,
   ...hashesCommands,
@@ -142,6 +144,12 @@ export {
   bitfieldCommand,
   bitfieldRoCommand,
 } from './bitmaps'
+export {
+  hyperloglogCommands,
+  pfaddCommand,
+  pfcountCommand,
+  pfmergeCommand,
+} from './hyperloglog'
 export {
   discardCommand,
   execCommand,

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -240,6 +240,13 @@ export class WrongTypeRedisError extends RedisCommandError {
   }
 }
 
+/** A string-type key whose contents are not a valid HyperLogLog encoding. */
+export class InvalidHllError extends RedisCommandError {
+  constructor() {
+    super('Key is not a valid HyperLogLog string value.', 'WRONGTYPE')
+  }
+}
+
 export class InvalidExpireTimeError extends RedisCommandError {
   constructor(commandName: string) {
     super(`invalid expire time in '${commandName}' command`)

--- a/tests-integration/ioredis/string/hyperloglog.test.ts
+++ b/tests-integration/ioredis/string/hyperloglog.test.ts
@@ -1,0 +1,171 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster, Redis } from 'ioredis'
+import { TestRunner } from '../../test-config'
+import { connectToSlotOwner, errorWithMessage, randomKey } from '../../utils'
+
+const testRunner = new TestRunner()
+
+// Every key shares one hashtag so the whole suite runs over a single direct
+// (unprefixed) connection to one slot owner — multi-key PFCOUNT/PFMERGE stay
+// same-slot, and we avoid churning a fresh connection per test against the
+// shared real cluster.
+const TAG = '{hll}'
+
+// HyperLogLog cardinality is approximate (~0.81% standard error in real
+// Redis). Assert within a tolerance rather than an exact count.
+function assertApprox(actual: number, expected: number, tolerance = 0.1) {
+  const diff = Math.abs(actual - expected)
+  assert.ok(
+    diff <= Math.max(1, expected * tolerance),
+    `expected ~${expected}, got ${actual} (tolerance ${tolerance * 100}%)`,
+  )
+}
+
+describe(`HyperLogLog Commands Integration (${testRunner.getBackendName()})`, () => {
+  let redisClient: Cluster | undefined
+  let client: Redis
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster('hll-integration')
+    client = await connectToSlotOwner(redisClient, TAG)
+  })
+
+  after(async () => {
+    client?.disconnect()
+    await testRunner.cleanup()
+  })
+
+  const ns = (): string => `${TAG}:${randomKey()}`
+
+  test('PFADD creates the key, returns 1 when altered, 0 when not', async () => {
+    const key = `${ns()}:pfadd`
+
+    // Missing key: created even with zero elements, returns 1.
+    assert.strictEqual(await client.call('PFADD', key), 1)
+    assert.strictEqual(await client.call('EXISTS', key), 1)
+    assert.strictEqual(await client.call('TYPE', key), 'string')
+
+    // Existing key, zero elements: no register altered, returns 0.
+    assert.strictEqual(await client.call('PFADD', key), 0)
+
+    // New distinct elements alter registers.
+    assert.strictEqual(await client.call('PFADD', key, 'a', 'b', 'c'), 1)
+    // Re-adding the same elements alters nothing.
+    assert.strictEqual(await client.call('PFADD', key, 'a', 'b', 'c'), 0)
+    // A new element alters again.
+    assert.strictEqual(await client.call('PFADD', key, 'd'), 1)
+  })
+
+  test('PFCOUNT returns approximate cardinality, 0 for missing key', async () => {
+    const key = `${ns()}:pfcount`
+    const missing = `${ns()}:missing`
+
+    assert.strictEqual(await client.call('PFCOUNT', missing), 0)
+
+    await client.call('PFADD', key, 'a', 'b', 'c')
+    assertApprox(Number(await client.call('PFCOUNT', key)), 3)
+
+    // Larger cardinality, still approximate within Redis's documented error.
+    const many = Array.from({ length: 1000 }, (_, i) => `el-${i}`)
+    await client.call('PFADD', key, ...many)
+    assertApprox(Number(await client.call('PFCOUNT', key)), 1000)
+  })
+
+  test('PFCOUNT over multiple keys returns the union cardinality', async () => {
+    const k1 = `${ns()}:u1`
+    const k2 = `${ns()}:u2`
+
+    await client.call('PFADD', k1, 'a', 'b', 'c')
+    await client.call('PFADD', k2, 'd', 'e', 'f')
+    assertApprox(Number(await client.call('PFCOUNT', k1, k2)), 6)
+
+    // Overlapping elements are not double-counted.
+    const k3 = `${ns()}:u3`
+    await client.call('PFADD', k3, 'a', 'b', 'g')
+    assertApprox(Number(await client.call('PFCOUNT', k1, k3)), 4)
+  })
+
+  test('PFMERGE merges sources into destkey (union)', async () => {
+    const dest = `${ns()}:merge-dest`
+    const k1 = `${ns()}:m1`
+    const k2 = `${ns()}:m2`
+
+    await client.call('PFADD', k1, 'a', 'b', 'c')
+    await client.call('PFADD', k2, 'd', 'e', 'f')
+
+    assert.strictEqual(await client.call('PFMERGE', dest, k1, k2), 'OK')
+    assertApprox(Number(await client.call('PFCOUNT', dest)), 6)
+
+    // PFMERGE with only a destkey creates an empty HLL when missing.
+    const solo = `${ns()}:solo`
+    assert.strictEqual(await client.call('PFMERGE', solo), 'OK')
+    assert.strictEqual(await client.call('EXISTS', solo), 1)
+    assert.strictEqual(await client.call('PFCOUNT', solo), 0)
+
+    // Merging into an existing destkey unions with its current contents.
+    await client.call('PFADD', dest, 'g')
+    const extra = `${ns()}:extra`
+    await client.call('PFADD', extra, 'h')
+    await client.call('PFMERGE', dest, extra)
+    assertApprox(Number(await client.call('PFCOUNT', dest)), 8)
+  })
+
+  test('WRONGTYPE on a key holding a non-string type', async () => {
+    const key = `${ns()}:wrongtype`
+    await client.call('RPUSH', key, 'a', 'b')
+
+    await assert.rejects(
+      () => client.call('PFADD', key, 'x'),
+      errorWithMessage(
+        'WRONGTYPE Operation against a key holding the wrong kind of value',
+      ),
+    )
+    await assert.rejects(
+      () => client.call('PFCOUNT', key),
+      errorWithMessage(
+        'WRONGTYPE Operation against a key holding the wrong kind of value',
+      ),
+    )
+    const dest = `${ns()}:merge-into-list`
+    await assert.rejects(
+      () => client.call('PFMERGE', dest, key),
+      errorWithMessage(
+        'WRONGTYPE Operation against a key holding the wrong kind of value',
+      ),
+    )
+  })
+
+  test('WRONGTYPE on a string that is not a valid HyperLogLog', async () => {
+    const key = `${ns()}:notvalid`
+    await client.call('SET', key, 'plain string value')
+
+    await assert.rejects(
+      () => client.call('PFADD', key, 'x'),
+      errorWithMessage(
+        'WRONGTYPE Key is not a valid HyperLogLog string value.',
+      ),
+    )
+    await assert.rejects(
+      () => client.call('PFCOUNT', key),
+      errorWithMessage(
+        'WRONGTYPE Key is not a valid HyperLogLog string value.',
+      ),
+    )
+  })
+
+  test('arity errors match Redis', async () => {
+    await assert.rejects(
+      () => client.call('PFADD'),
+      errorWithMessage("ERR wrong number of arguments for 'pfadd' command"),
+    )
+    await assert.rejects(
+      () => client.call('PFCOUNT'),
+      errorWithMessage("ERR wrong number of arguments for 'pfcount' command"),
+    )
+    await assert.rejects(
+      () => client.call('PFMERGE'),
+      errorWithMessage("ERR wrong number of arguments for 'pfmerge' command"),
+    )
+  })
+})

--- a/tests-integration/node-redis/string/hyperloglog.test.ts
+++ b/tests-integration/node-redis/string/hyperloglog.test.ts
@@ -1,0 +1,176 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { RedisClientType, RedisClusterType } from 'redis'
+import { TestRunner } from '../../test-config'
+import {
+  connectToNodeRedisSlotOwner,
+  errorWithMessage,
+  flushNodeRedisCluster,
+  randomKey,
+} from '../../utils'
+
+const testRunner = new TestRunner()
+
+// node-redis twin of the ioredis HyperLogLog suite. Every key shares one
+// hashtag so the whole suite runs over a single direct connection to one
+// slot owner — multi-key PFCOUNT/PFMERGE stay same-slot and `sendCommand`
+// gives exact arg control for arity/error assertions.
+const TAG = '{hll-nr}'
+
+// HyperLogLog cardinality is approximate (~0.81% standard error in real
+// Redis). Assert within a tolerance rather than an exact count.
+function assertApprox(actual: number, expected: number, tolerance = 0.1) {
+  const diff = Math.abs(actual - expected)
+  assert.ok(
+    diff <= Math.max(1, expected * tolerance),
+    `expected ~${expected}, got ${actual} (tolerance ${tolerance * 100}%)`,
+  )
+}
+
+describe(`HyperLogLog Commands Integration (node-redis, ${testRunner.getBackendName()})`, () => {
+  let redisClient: RedisClusterType
+  let client: RedisClientType
+
+  before(async () => {
+    redisClient = (await testRunner.setupNodeRedisCluster()) as RedisClusterType
+    await flushNodeRedisCluster(redisClient)
+    client = await connectToNodeRedisSlotOwner(redisClient, TAG)
+  })
+
+  after(async () => {
+    client?.destroy()
+    await testRunner.cleanup()
+  })
+
+  const ns = (): string => `${TAG}:${randomKey()}`
+
+  test('PFADD creates the key, returns 1 when altered, 0 when not', async () => {
+    const key = `${ns()}:pfadd`
+
+    // Missing key: created even with zero elements, returns 1.
+    assert.strictEqual(await client.sendCommand(['PFADD', key]), 1)
+    assert.strictEqual(await client.sendCommand(['EXISTS', key]), 1)
+    assert.strictEqual(await client.sendCommand(['TYPE', key]), 'string')
+
+    // Existing key, zero elements: no register altered, returns 0.
+    assert.strictEqual(await client.sendCommand(['PFADD', key]), 0)
+
+    // New distinct elements alter registers.
+    assert.strictEqual(
+      await client.sendCommand(['PFADD', key, 'a', 'b', 'c']),
+      1,
+    )
+    // Re-adding the same elements alters nothing.
+    assert.strictEqual(
+      await client.sendCommand(['PFADD', key, 'a', 'b', 'c']),
+      0,
+    )
+    // A new element alters again.
+    assert.strictEqual(await client.sendCommand(['PFADD', key, 'd']), 1)
+  })
+
+  test('PFCOUNT returns approximate cardinality, 0 for missing key', async () => {
+    const key = `${ns()}:pfcount`
+    const missing = `${ns()}:missing`
+
+    assert.strictEqual(await client.sendCommand(['PFCOUNT', missing]), 0)
+
+    await client.sendCommand(['PFADD', key, 'a', 'b', 'c'])
+    assertApprox(Number(await client.sendCommand(['PFCOUNT', key])), 3)
+
+    // Larger cardinality, still approximate within Redis's documented error.
+    const many = Array.from({ length: 1000 }, (_, i) => `el-${i}`)
+    await client.sendCommand(['PFADD', key, ...many])
+    assertApprox(Number(await client.sendCommand(['PFCOUNT', key])), 1000)
+  })
+
+  test('PFCOUNT over multiple keys returns the union cardinality', async () => {
+    const k1 = `${ns()}:u1`
+    const k2 = `${ns()}:u2`
+
+    await client.sendCommand(['PFADD', k1, 'a', 'b', 'c'])
+    await client.sendCommand(['PFADD', k2, 'd', 'e', 'f'])
+    assertApprox(Number(await client.sendCommand(['PFCOUNT', k1, k2])), 6)
+
+    // Overlapping elements are not double-counted.
+    const k3 = `${ns()}:u3`
+    await client.sendCommand(['PFADD', k3, 'a', 'b', 'g'])
+    assertApprox(Number(await client.sendCommand(['PFCOUNT', k1, k3])), 4)
+  })
+
+  test('PFMERGE merges sources into destkey (union)', async () => {
+    const dest = `${ns()}:merge-dest`
+    const k1 = `${ns()}:m1`
+    const k2 = `${ns()}:m2`
+
+    await client.sendCommand(['PFADD', k1, 'a', 'b', 'c'])
+    await client.sendCommand(['PFADD', k2, 'd', 'e', 'f'])
+
+    assert.strictEqual(
+      await client.sendCommand(['PFMERGE', dest, k1, k2]),
+      'OK',
+    )
+    assertApprox(Number(await client.sendCommand(['PFCOUNT', dest])), 6)
+
+    // PFMERGE with only a destkey creates an empty HLL when missing.
+    const solo = `${ns()}:solo`
+    assert.strictEqual(await client.sendCommand(['PFMERGE', solo]), 'OK')
+    assert.strictEqual(await client.sendCommand(['EXISTS', solo]), 1)
+    assert.strictEqual(await client.sendCommand(['PFCOUNT', solo]), 0)
+
+    // Merging into an existing destkey unions with its current contents.
+    await client.sendCommand(['PFADD', dest, 'g'])
+    const extra = `${ns()}:extra`
+    await client.sendCommand(['PFADD', extra, 'h'])
+    await client.sendCommand(['PFMERGE', dest, extra])
+    assertApprox(Number(await client.sendCommand(['PFCOUNT', dest])), 8)
+  })
+
+  test('WRONGTYPE on a key holding a non-string type', async () => {
+    const key = `${ns()}:wrongtype`
+    await client.sendCommand(['RPUSH', key, 'a', 'b'])
+
+    const wrongType = errorWithMessage(
+      'WRONGTYPE Operation against a key holding the wrong kind of value',
+    )
+    await assert.rejects(
+      () => client.sendCommand(['PFADD', key, 'x']),
+      wrongType,
+    )
+    await assert.rejects(() => client.sendCommand(['PFCOUNT', key]), wrongType)
+    const dest = `${ns()}:merge-into-list`
+    await assert.rejects(
+      () => client.sendCommand(['PFMERGE', dest, key]),
+      wrongType,
+    )
+  })
+
+  test('WRONGTYPE on a string that is not a valid HyperLogLog', async () => {
+    const key = `${ns()}:notvalid`
+    await client.sendCommand(['SET', key, 'plain string value'])
+
+    const invalidHll = errorWithMessage(
+      'WRONGTYPE Key is not a valid HyperLogLog string value.',
+    )
+    await assert.rejects(
+      () => client.sendCommand(['PFADD', key, 'x']),
+      invalidHll,
+    )
+    await assert.rejects(() => client.sendCommand(['PFCOUNT', key]), invalidHll)
+  })
+
+  test('arity errors match Redis', async () => {
+    await assert.rejects(
+      () => client.sendCommand(['PFADD']),
+      errorWithMessage("ERR wrong number of arguments for 'pfadd' command"),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['PFCOUNT']),
+      errorWithMessage("ERR wrong number of arguments for 'pfcount' command"),
+    )
+    await assert.rejects(
+      () => client.sendCommand(['PFMERGE']),
+      errorWithMessage("ERR wrong number of arguments for 'pfmerge' command"),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Implements `PFADD`, `PFCOUNT`, `PFMERGE` (issue #323). No prior PF* implementation existed anywhere in `src/` (confirmed via grep before starting).
- Cardinality stored as a dense 16384-byte HyperLogLog register array in the existing String type. A SHA-1-derived 64-bit hash feeds the standard HLL cardinality estimator (linear-counting correction below 2.5m registers, large-range correction near 2^32) — same approximate-cardinality contract real Redis exposes (~0.81% standard error), but **not** byte-compatible with Redis's own sparse/dense HLL wire encoding. No `since` gate added: HLL has existed since Redis 2.8.9, well below this repo's oldest supported profile (`redis-6.2`).
- `PFADD key [element ...]` creates the key (even with zero elements) if missing and returns `1`; returns `1` only when a register was actually raised (including the create-on-missing case), `0` otherwise — matches real Redis precisely, verified against a local `redis-server 7.2.1`.
- `PFCOUNT key [key ...]` returns the (approximate) cardinality of a single key, or the union cardinality across multiple keys; missing keys count as empty/zero contribution.
- `PFMERGE destkey [sourcekey ...]` unions all source registers into destkey (creating destkey if missing, even with zero sources).
- New `InvalidHllError` (`src/core/redis-error.ts`) for `WRONGTYPE Key is not a valid HyperLogLog string value.` — distinct from the generic `WrongTypeRedisError`, matching real Redis's two-tier WRONGTYPE behavior (non-string key vs. string key with invalid HLL contents), both probed against real Redis before implementing.
- `PFDEBUG`/`PFSELFTEST` intentionally left unimplemented (internal/debug subcommands, out of scope per the issue).
- `docs/COMMANDS.md` §18 updated: PFADD/PFCOUNT/PFMERGE checked off, PFDEBUG/PFSELFTEST left unchecked.

Closes #323

## Test plan
- [x] New integration test `tests-integration/ioredis/string/hyperloglog.test.ts` covers: PFADD create/no-op/altered semantics, PFCOUNT single + union + missing-key, PFMERGE (including destkey-only, merging into existing destkey), both WRONGTYPE variants, and arity errors — red before the fix (unknown command), confirmed.
- [x] Test passes against real Redis (`TEST_BACKEND=real`, local `redis-server 7.2.1` on port 6399).
- [x] Fix makes the test pass on mock too (`TEST_BACKEND=mock`).
- [x] `npm run build`, `npm run lint`, `npm run test:all` all pass (1041/1041 tests).