### PR TITLE
feat: implement Geo core commands (GEOADD/GEOPOS/GEODIST/GEOHASH) (#325)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -531,12 +531,12 @@ HyperLogLogs are stored in the String type. None of these are implemented yet.
 ## 19. Geo Commands
 
 Geo commands are stored in the Sorted Set type (members scored by geohash).
-None of these are implemented yet.
+Geo core (GEOADD/GEOPOS/GEODIST/GEOHASH) is implemented; geo search is not.
 
-- [ ] `GEOADD key [NX | XX] [CH] longitude latitude member [longitude latitude member ...]` - Add geospatial members
-- [ ] `GEOPOS key member [member ...]` - Return longitude/latitude of members
-- [ ] `GEODIST key member1 member2 [m | km | ft | mi]` - Distance between two members
-- [ ] `GEOHASH key member [member ...]` - Return Geohash strings for members
+- [x] `GEOADD key [NX | XX] [CH] longitude latitude member [longitude latitude member ...]` - Add geospatial members
+- [x] `GEOPOS key member [member ...]` - Return longitude/latitude of members
+- [x] `GEODIST key member1 member2 [m | km | ft | mi]` - Distance between two members
+- [x] `GEOHASH key member [member ...]` - Return Geohash strings for members
 - [ ] `GEOSEARCH key <FROMMEMBER member | FROMLONLAT longitude latitude> <BYRADIUS radius unit | BYBOX width height unit> [ASC | DESC] [COUNT count [ANY]] [WITHCOORD] [WITHDIST] [WITHHASH]` - Search within a radius or box
 - [ ] `GEOSEARCHSTORE destination source <FROMMEMBER ... | FROMLONLAT ...> <BYRADIUS ... | BYBOX ...> [STOREDIST]` - Store a `GEOSEARCH` result
 - [ ] `GEORADIUS` / `GEORADIUSBYMEMBER` (and `_RO` variants) - Deprecated radius queries

--- a/src/commands/geo/geoadd.ts
+++ b/src/commands/geo/geoadd.ts
@@ -1,0 +1,95 @@
+import { defineCommand } from '../../core/command-definition'
+import { t, type ParseContext } from '../../core/command-schema'
+import {
+  ExpectedFloatError,
+  RedisSyntaxError,
+  WrongNumberOfArgumentsError,
+} from '../../core/redis-error'
+import { integer } from '../helpers'
+import { assertValidCoordinates, encodeGeoScore } from './helpers'
+
+type GeoPoint = { lon: number; lat: number; member: Buffer }
+type GeoAddOptions = { nx: boolean; xx: boolean; ch: boolean }
+type GeoAddArgs = { key: Buffer; options: GeoAddOptions; points: GeoPoint[] }
+
+function parseFloatToken(token: Buffer): number {
+  const n = Number(token.toString())
+  if (!Number.isFinite(n)) throw new ExpectedFloatError()
+  return n
+}
+
+function createGeoAddSchema() {
+  return t.custom<GeoAddArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const key = input[index]
+      if (!key) throw new WrongNumberOfArgumentsError(ctx.commandName)
+
+      let cursor = index + 1
+      if (input.length - cursor < 3) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      const options: GeoAddOptions = { nx: false, xx: false, ch: false }
+      while (cursor < input.length) {
+        const token = input[cursor]!.toString().toUpperCase()
+        if (token === 'NX') {
+          options.nx = true
+          cursor++
+          continue
+        }
+        if (token === 'XX') {
+          options.xx = true
+          cursor++
+          continue
+        }
+        if (token === 'CH') {
+          options.ch = true
+          cursor++
+          continue
+        }
+        break
+      }
+
+      const remaining = input.length - cursor
+      if (options.nx && options.xx) throw new RedisSyntaxError()
+      if (remaining === 0 || remaining % 3 !== 0) {
+        throw new RedisSyntaxError()
+      }
+
+      const points: GeoPoint[] = []
+      while (cursor < input.length) {
+        const lon = parseFloatToken(input[cursor]!)
+        const lat = parseFloatToken(input[cursor + 1]!)
+        assertValidCoordinates(lon, lat)
+        points.push({ lon, lat, member: input[cursor + 2]! })
+        cursor += 3
+      }
+
+      return { value: { key, options, points }, nextIndex: input.length }
+    },
+  )
+}
+
+export const geoaddCommand = defineCommand({
+  name: 'geoadd',
+  schema: createGeoAddSchema(),
+  flags: ['write', 'denyoom'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const replyCount = ctx.db.updateSortedSet(args.key, zset => {
+      let count = 0
+      for (const { lon, lat, member } of args.points) {
+        const score = encodeGeoScore(lon, lat)
+        const existing = zset.getMember(member)
+
+        if (!existing && args.options.xx) continue
+        if (existing && args.options.nx) continue
+
+        const { added, scoreChanged } = zset.setScore(member, score)
+        if (added || (args.options.ch && scoreChanged)) count++
+      }
+      return count
+    })
+    return integer(replyCount)
+  },
+})

--- a/src/commands/geo/geodist.ts
+++ b/src/commands/geo/geodist.ts
@@ -1,0 +1,36 @@
+import { defineCommand } from '../../core/command-definition'
+import { t } from '../../core/command-schema'
+import { GeoUnsupportedUnitError } from '../../core/redis-error'
+import { bulk } from '../helpers'
+import {
+  decodeGeoScore,
+  haversineMeters,
+  isSupportedGeoUnit,
+  metersToUnit,
+} from './helpers'
+
+export const geodistCommand = defineCommand({
+  name: 'geodist',
+  schema: t.object({
+    key: t.key(),
+    member1: t.key(),
+    member2: t.key(),
+    unit: t.optional(t.string()),
+  }),
+  flags: ['readonly'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const unit = args.unit ?? 'm'
+    if (!isSupportedGeoUnit(unit)) throw new GeoUnsupportedUnitError()
+
+    const zset = ctx.db.getSortedSet(args.key)
+    const entry1 = zset?.members.get(args.member1.toString('hex'))
+    const entry2 = zset?.members.get(args.member2.toString('hex'))
+    if (!entry1 || !entry2) return bulk(null)
+
+    const pos1 = decodeGeoScore(entry1.score)
+    const pos2 = decodeGeoScore(entry2.score)
+    const meters = haversineMeters(pos1.lon, pos1.lat, pos2.lon, pos2.lat)
+    return bulk(Buffer.from(metersToUnit(meters, unit).toFixed(4)))
+  },
+})

--- a/src/commands/geo/geohash.ts
+++ b/src/commands/geo/geohash.ts
@@ -1,0 +1,21 @@
+import { defineCommand } from '../../core/command-definition'
+import { t } from '../../core/command-schema'
+import { RedisValue } from '../../core/redis-value'
+import { array } from '../helpers'
+import { geohashString } from './helpers'
+
+export const geohashCommand = defineCommand({
+  name: 'geohash',
+  schema: t.object({ key: t.key(), members: t.variadic(t.key(), { min: 1 }) }),
+  flags: ['readonly'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const zset = ctx.db.getSortedSet(args.key)
+    const items = args.members.map(member => {
+      const entry = zset?.members.get(member.toString('hex'))
+      if (!entry) return RedisValue.null()
+      return RedisValue.bulkString(Buffer.from(geohashString(entry.score)))
+    })
+    return array(items)
+  },
+})

--- a/src/commands/geo/geopos.ts
+++ b/src/commands/geo/geopos.ts
@@ -1,0 +1,25 @@
+import { defineCommand } from '../../core/command-definition'
+import { t } from '../../core/command-schema'
+import { RedisValue } from '../../core/redis-value'
+import { array } from '../helpers'
+import { decodeGeoScore } from './helpers'
+
+export const geoposCommand = defineCommand({
+  name: 'geopos',
+  schema: t.object({ key: t.key(), members: t.variadic(t.key(), { min: 1 }) }),
+  flags: ['readonly'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const zset = ctx.db.getSortedSet(args.key)
+    const items = args.members.map(member => {
+      const entry = zset?.members.get(member.toString('hex'))
+      if (!entry) return RedisValue.null()
+      const { lon, lat } = decodeGeoScore(entry.score)
+      return RedisValue.array([
+        RedisValue.bulkString(Buffer.from(lon.toString())),
+        RedisValue.bulkString(Buffer.from(lat.toString())),
+      ])
+    })
+    return array(items)
+  },
+})

--- a/src/commands/geo/helpers.ts
+++ b/src/commands/geo/helpers.ts
@@ -1,0 +1,171 @@
+import { InvalidLongitudeLatitudeError } from '../../core/redis-error'
+
+const STEP = 26n
+const CELLS = Number(1n << STEP)
+
+export const GEO_LON_MIN = -180
+export const GEO_LON_MAX = 180
+export const GEO_LAT_MIN = -85.05112878
+export const GEO_LAT_MAX = 85.05112878
+
+const GEO_ALPHABET = '0123456789bcdefghjkmnpqrstuvwxyz'
+
+const EARTH_RADIUS_M = 6372797.560856
+
+// Meters-per-unit divisors matching Redis' exact GEODIST constants (not the
+// rounded 3.28084 ft/m reciprocal, which drifts in the 4th decimal place).
+const UNIT_TO_METERS: Record<string, number> = {
+  m: 1,
+  km: 1000,
+  ft: 0.3048,
+  mi: 1609.34,
+}
+
+export function isSupportedGeoUnit(unit: string): boolean {
+  return unit.toLowerCase() in UNIT_TO_METERS
+}
+
+export function metersToUnit(meters: number, unit: string): number {
+  return meters / UNIT_TO_METERS[unit.toLowerCase()]!
+}
+
+export function assertValidCoordinates(lon: number, lat: number): void {
+  if (
+    lon < GEO_LON_MIN ||
+    lon > GEO_LON_MAX ||
+    lat < GEO_LAT_MIN ||
+    lat > GEO_LAT_MAX
+  ) {
+    throw new InvalidLongitudeLatitudeError(lon, lat)
+  }
+}
+
+// Bit-spreads a 26-bit value into the even bit positions of a 52-bit result
+// (Redis' geohash.c interleave64, truncated to the 26-bit step this repo uses).
+function interleave64(latBits: bigint, lonBits: bigint): bigint {
+  const B = [
+    0x5555555555555555n,
+    0x3333333333333333n,
+    0x0f0f0f0f0f0f0f0fn,
+    0x00ff00ff00ff00ffn,
+    0x0000ffff0000ffffn,
+  ]
+  const S = [1n, 2n, 4n, 8n, 16n]
+  let x = latBits
+  let y = lonBits
+  for (let i = 4; i >= 0; i--) {
+    x = (x | (x << S[i]!)) & B[i]!
+    y = (y | (y << S[i]!)) & B[i]!
+  }
+  return x | (y << 1n)
+}
+
+function deinterleave64(bits: bigint): bigint {
+  const B = [
+    0x5555555555555555n,
+    0x3333333333333333n,
+    0x0f0f0f0f0f0f0f0fn,
+    0x00ff00ff00ff00ffn,
+    0x0000ffff0000ffffn,
+    0x00000000ffffffffn,
+  ]
+  const S = [0n, 1n, 2n, 4n, 8n, 16n]
+  let x = bits & B[0]!
+  for (let i = 1; i <= 5; i++) {
+    x = (x | (x >> S[i]!)) & B[i]!
+  }
+  return x
+}
+
+function encodeBits(
+  lon: number,
+  lat: number,
+  lonMin: number,
+  lonMax: number,
+  latMin: number,
+  latMax: number,
+): bigint {
+  const lonOffset = (lon - lonMin) / (lonMax - lonMin)
+  const latOffset = (lat - latMin) / (latMax - latMin)
+  const lonBits = BigInt(Math.floor(lonOffset * CELLS))
+  const latBits = BigInt(Math.floor(latOffset * CELLS))
+  return interleave64(latBits, lonBits)
+}
+
+function decodeBits(
+  bits: bigint,
+  lonMin: number,
+  lonMax: number,
+  latMin: number,
+  latMax: number,
+): { lon: number; lat: number } {
+  const latBits = deinterleave64(bits)
+  const lonBits = deinterleave64(bits >> 1n)
+
+  const latLo = latMin + (Number(latBits) / CELLS) * (latMax - latMin)
+  const latHi = latMin + (Number(latBits + 1n) / CELLS) * (latMax - latMin)
+  const lonLo = lonMin + (Number(lonBits) / CELLS) * (lonMax - lonMin)
+  const lonHi = lonMin + (Number(lonBits + 1n) / CELLS) * (lonMax - lonMin)
+
+  return { lon: (lonLo + lonHi) / 2, lat: (latLo + latHi) / 2 }
+}
+
+// The stored zset score: a 52-bit geohash interleaving lon/lat over Redis'
+// internal ranges (lat clamped to ±85.05112878 so the projection stays square).
+export function encodeGeoScore(lon: number, lat: number): number {
+  return Number(
+    encodeBits(lon, lat, GEO_LON_MIN, GEO_LON_MAX, GEO_LAT_MIN, GEO_LAT_MAX),
+  )
+}
+
+export function decodeGeoScore(score: number): { lon: number; lat: number } {
+  return decodeBits(
+    BigInt(score),
+    GEO_LON_MIN,
+    GEO_LON_MAX,
+    GEO_LAT_MIN,
+    GEO_LAT_MAX,
+  )
+}
+
+// GEOHASH renders the standard geohash.org string, which uses a ±90 latitude
+// range rather than the ±85.05112878 range the zset score is stored with. Real
+// Redis re-derives it by decoding the stored score with the real range, then
+// re-encoding that position with the standard range (see geohashCommand in
+// geo.c) — encoding straight from the original lon/lat produces a different
+// string because decode-then-reencode loses the sub-cell fraction.
+export function geohashString(score: number): string {
+  const pos = decodeGeoScore(score)
+  const bits = encodeBits(pos.lon, pos.lat, GEO_LON_MIN, GEO_LON_MAX, -90, 90)
+
+  let out = ''
+  for (let i = 0; i < 10; i++) {
+    const idx = Number((bits >> BigInt(52 - i * 5 - 5)) & 0x1fn)
+    out += GEO_ALPHABET[idx]
+  }
+  // The 52-bit hash only covers 10 full 5-bit groups (50 bits); Redis pads
+  // the unused 11th character with a literal '0' rather than the leftover 2 bits.
+  return out + '0'
+}
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180
+}
+
+// Haversine great-circle distance in meters, matching Redis' geohashGetDistance.
+export function haversineMeters(
+  lon1: number,
+  lat1: number,
+  lon2: number,
+  lat2: number,
+): number {
+  const lat1r = toRadians(lat1)
+  const lat2r = toRadians(lat2)
+  const u = Math.sin((toRadians(lat2) - toRadians(lat1)) / 2)
+  const v = Math.sin((toRadians(lon2) - toRadians(lon1)) / 2)
+  return (
+    2.0 *
+    EARTH_RADIUS_M *
+    Math.asin(Math.sqrt(u * u + Math.cos(lat1r) * Math.cos(lat2r) * v * v))
+  )
+}

--- a/src/commands/geo/index.ts
+++ b/src/commands/geo/index.ts
@@ -1,0 +1,13 @@
+import { geoaddCommand } from './geoadd'
+import { geodistCommand } from './geodist'
+import { geohashCommand } from './geohash'
+import { geoposCommand } from './geopos'
+
+export const geoCommands = [
+  geoaddCommand,
+  geoposCommand,
+  geodistCommand,
+  geohashCommand,
+]
+
+export { geoaddCommand, geoposCommand, geodistCommand, geohashCommand }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -17,6 +17,7 @@ import { bitmapsCommands } from './bitmaps'
 import { commandCommand } from './command'
 import { configCommands } from './config'
 import { connectionCommands } from './connection'
+import { geoCommands } from './geo'
 import { hashesCommands } from './hashes'
 import { keysCommands } from './keys'
 import { listsCommands } from './lists'
@@ -44,6 +45,7 @@ export const redisCommandDefinitions: readonly CommandDefinition[] = [
   ...listsCommands,
   ...setsCommands,
   ...zsetsCommands,
+  ...geoCommands,
   ...pubsubCommands,
   ...streamsCommands,
   ...scriptsCommands,
@@ -291,6 +293,13 @@ export {
   streamsCommands,
   xtrimCommand,
 } from './streams'
+export {
+  geoCommands,
+  geoaddCommand,
+  geoposCommand,
+  geodistCommand,
+  geohashCommand,
+} from './geo'
 export {
   zsetsCommands,
   zaddCommand,

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -174,6 +174,18 @@ export class ZaddIncrPairError extends RedisCommandError {
   }
 }
 
+export class InvalidLongitudeLatitudeError extends RedisCommandError {
+  constructor(lon: number, lat: number) {
+    super(`invalid longitude,latitude pair ${lon.toFixed(6)},${lat.toFixed(6)}`)
+  }
+}
+
+export class GeoUnsupportedUnitError extends RedisCommandError {
+  constructor() {
+    super('unsupported unit provided. please use M, KM, FT, MI')
+  }
+}
+
 export class OffsetOutOfRangeError extends RedisCommandError {
   constructor() {
     super('offset is out of range')

--- a/tests-integration/ioredis/geo/core.test.ts
+++ b/tests-integration/ioredis/geo/core.test.ts
@@ -1,0 +1,240 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster } from 'ioredis'
+import { TestRunner } from '../../test-config'
+import { errorWithMessage, randomKey } from '../../utils'
+
+const testRunner = new TestRunner()
+
+// Redis' own GEOADD documentation example: Sicily with Palermo and Catania.
+const PALERMO = { lon: 13.361389, lat: 38.115556, member: 'Palermo' }
+const CATANIA = { lon: 15.087269, lat: 37.502669, member: 'Catania' }
+
+function assertCloseTo(actual: number, expected: number, epsilon = 1e-6) {
+  assert.ok(
+    Math.abs(actual - expected) < epsilon,
+    `expected ${actual} to be close to ${expected}`,
+  )
+}
+
+describe(`Geo Commands Integration (${testRunner.getBackendName()})`, () => {
+  let redisClient: Cluster | undefined
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster('geo-integration')
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  test('GEOADD adds members and GEOPOS/GEODIST/GEOHASH read them back', async () => {
+    const key = `{geo-core:${randomKey()}}`
+
+    try {
+      const added = await redisClient?.geoadd(
+        key,
+        PALERMO.lon,
+        PALERMO.lat,
+        PALERMO.member,
+        CATANIA.lon,
+        CATANIA.lat,
+        CATANIA.member,
+      )
+      assert.strictEqual(added, 2)
+
+      const score = await redisClient?.zscore(key, PALERMO.member)
+      assert.strictEqual(score, '3479099956230698')
+
+      const positions = await redisClient?.geopos(
+        key,
+        PALERMO.member,
+        CATANIA.member,
+        'NonExisting',
+      )
+      assert.strictEqual(positions?.length, 3)
+      assertCloseTo(Number(positions![0]![0]), PALERMO.lon, 1e-5)
+      assertCloseTo(Number(positions![0]![1]), PALERMO.lat, 1e-5)
+      assertCloseTo(Number(positions![1]![0]), CATANIA.lon, 1e-5)
+      assertCloseTo(Number(positions![1]![1]), CATANIA.lat, 1e-5)
+      assert.strictEqual(positions![2], null)
+
+      const distM = await redisClient?.geodist(
+        key,
+        PALERMO.member,
+        CATANIA.member,
+      )
+      assertCloseTo(Number(distM), 166274.1516, 0.01)
+
+      const distKm = await redisClient?.geodist(
+        key,
+        PALERMO.member,
+        CATANIA.member,
+        'km',
+      )
+      assertCloseTo(Number(distKm), 166.2742, 0.001)
+
+      const distMi = await redisClient?.geodist(
+        key,
+        PALERMO.member,
+        CATANIA.member,
+        'mi',
+      )
+      assertCloseTo(Number(distMi), 103.3182, 0.001)
+
+      const distFt = await redisClient?.geodist(
+        key,
+        PALERMO.member,
+        CATANIA.member,
+        'ft',
+      )
+      assertCloseTo(Number(distFt), 545518.87, 0.5)
+
+      const missingDist = await redisClient?.geodist(
+        key,
+        PALERMO.member,
+        'NonExisting',
+      )
+      assert.strictEqual(missingDist, null)
+
+      const hashes = await redisClient?.geohash(
+        key,
+        PALERMO.member,
+        CATANIA.member,
+        'NonExisting',
+      )
+      assert.deepStrictEqual(hashes, ['sqc8b49rny0', 'sqdtr74hyu0', null])
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('GEOADD NX/XX/CH option flags match Redis', async () => {
+    const key = `{geo-options:${randomKey()}}`
+
+    try {
+      assert.strictEqual(
+        await redisClient?.geoadd(key, 'NX', 13.361389, 38.115556, 'one'),
+        1,
+      )
+      assert.strictEqual(await redisClient?.geoadd(key, 'NX', 20, 40, 'one'), 0)
+      assertCloseTo(
+        (await redisClient?.geopos(key, 'one'))![0]![0] as unknown as number,
+        13.361389,
+        1e-5,
+      )
+
+      assert.strictEqual(await redisClient?.geoadd(key, 'XX', 14, 39, 'one'), 0)
+      assertCloseTo(
+        Number((await redisClient?.geopos(key, 'one'))![0]![0]),
+        14,
+        1e-5,
+      )
+      assert.strictEqual(await redisClient?.geoadd(key, 'XX', 1, 1, 'two'), 0)
+      assert.deepStrictEqual(await redisClient?.geopos(key, 'two'), [null])
+
+      assert.strictEqual(
+        await redisClient?.geoadd(key, 'CH', 15, 40, 'one', 2, 2, 'two'),
+        2,
+      )
+      assert.strictEqual(await redisClient?.geoadd(key, 'CH', 15, 40, 'one'), 0)
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('GEOADD option/argument errors match Redis', async () => {
+    const key = `{geo-errors:${randomKey()}}`
+
+    try {
+      await assert.rejects(
+        () => redisClient?.geoadd(key, 'NX', 'XX', 1, 2, 'm'),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => redisClient?.geoadd(key, 'GT', 1, 2, 'm'),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => redisClient?.geoadd(key, 'abc', 38, 'm1'),
+        errorWithMessage('ERR value is not a valid float'),
+      )
+      await assert.rejects(
+        () => redisClient?.geoadd(key, 200, 38.115556, 'Invalid'),
+        errorWithMessage(
+          'ERR invalid longitude,latitude pair 200.000000,38.115556',
+        ),
+      )
+      await assert.rejects(
+        () => redisClient?.geoadd(key, 13.361389, -86, 'Invalid'),
+        errorWithMessage(
+          'ERR invalid longitude,latitude pair 13.361389,-86.000000',
+        ),
+      )
+      await assert.rejects(
+        () => redisClient?.geoadd(key),
+        errorWithMessage("ERR wrong number of arguments for 'geoadd' command"),
+      )
+      await assert.rejects(
+        () => redisClient?.geoadd(key, 1, 2),
+        errorWithMessage("ERR wrong number of arguments for 'geoadd' command"),
+      )
+      await assert.rejects(
+        () => redisClient?.geodist(key, 'a', 'b', 'xyz'),
+        errorWithMessage(
+          'ERR unsupported unit provided. please use M, KM, FT, MI',
+        ),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('GEO commands on missing key return nil/empty per Redis semantics', async () => {
+    const key = `{geo-missing:${randomKey()}}`
+
+    const positions = await redisClient?.geopos(key, 'm1', 'm2')
+    assert.deepStrictEqual(positions, [null, null])
+
+    const dist = await redisClient?.geodist(key, 'm1', 'm2')
+    assert.strictEqual(dist, null)
+
+    const hashes = await redisClient?.geohash(key, 'm1', 'm2')
+    assert.deepStrictEqual(hashes, [null, null])
+  })
+
+  test('GEO commands reject wrong type keys', async () => {
+    const key = `{geo-wrongtype:${randomKey()}}`
+
+    try {
+      await redisClient?.set(key, 'foo')
+
+      await assert.rejects(
+        () => redisClient?.geoadd(key, 1, 2, 'm'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
+        () => redisClient?.geopos(key, 'm'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
+        () => redisClient?.geodist(key, 'm1', 'm2'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
+        () => redisClient?.geohash(key, 'm'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Adds GEOADD, GEOPOS, GEODIST, GEOHASH. Members are stored as sorted-set entries scored by a 52-bit interleaved geohash (lon/lat over Redis' ±180/±85.05112878 ranges), bit-for-bit matching real Redis so ZADD/ZSCORE/ZRANGE interop holds for free.
- GEOADD reuses the sorted-set write path (`updateSortedSet`/`setScore`) and implements the real GEOADD option grammar: only `NX`/`XX`/`CH` are recognized (no `GT`/`LT`/`INCR`, unlike ZADD); an unrecognized leading token breaks option parsing and the remaining-argument count must be a positive multiple of 3, matching Redis' exact arity/syntax-error boundaries (verified against a live `redis-server` for every edge case).
- GEOHASH renders the standard geohash.org string by decoding the stored (±85.05) score, re-encoding it with the ±90 range Redis uses for display, and fixing the 11th character to a literal `'0'` (the 52-bit hash only covers 10 full 5-bit groups) — verified bit-for-bit against real Redis output for 11 coordinate pairs, including the documented Sicily/Palermo/Catania example.
- New error classes `InvalidLongitudeLatitudeError` and `GeoUnsupportedUnitError` match Redis' exact wording.
- Descends into sub-issue #325 of parent #324; geo search (#326) is left for a follow-up PR since it depends on this core codec.

Closes #325

## Test plan
- [x] New integration test `tests-integration/ioredis/geo/core.test.ts` covers GEOADD (incl. NX/XX/CH), GEOPOS, GEODIST (all units), GEOHASH, missing-key/member nil semantics, WRONGTYPE, and every GEOADD arity/syntax-error edge case
- [x] Test passes against real Redis (confirms the spec matches actual behavior)
- [x] Test passes against mock after the fix
- [x] `npm run build`, `npm run lint`, `npm run test:all` all pass (1039/1039)
- [x] `docs/COMMANDS.md` §19 checkboxes updated for the four implemented commands