### PR TITLE
feat: implement Geo search commands (GEOSEARCH/GEOSEARCHSTORE/GEORADIUS*) (#326)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -143,6 +143,7 @@ Current profile gates:
 | `CLIENT NO-EVICT` and multi-section `INFO` | `redis-7.0+` | `valkey-8.0+` |
 | `EXPIRE`/`PEXPIRE`/`EXPIREAT`/`PEXPIREAT` `NX`, `XX`, `GT`, `LT` options | `redis-7.0+` | `valkey-8.0+` |
 | `SET GET`, `SET EXAT`, `SET PXAT` | `redis-6.2+` | `valkey-8.0+` |
+| `GEOSEARCH`, `GEOSEARCHSTORE` | `redis-6.2+` | `valkey-8.0+` |
 | `SET NX GET` | `redis-7.0+` | `valkey-8.0+` |
 | `CLIENT SETINFO` | `redis-7.2+` | `valkey-8.0+` |
 | Sharded Pub/Sub: `SSUBSCRIBE`, `SUNSUBSCRIBE`, `SPUBLISH`, `PUBSUB SHARDCHANNELS`, `PUBSUB SHARDNUMSUB` | `redis-7.0+` | `valkey-8.0+` |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -534,15 +534,14 @@ rather than Redis's sparse/dense HLL format — not byte-compatible, no
 ## 19. Geo Commands
 
 Geo commands are stored in the Sorted Set type (members scored by geohash).
-Geo core (GEOADD/GEOPOS/GEODIST/GEOHASH) is implemented; geo search is not.
 
 - [x] `GEOADD key [NX | XX] [CH] longitude latitude member [longitude latitude member ...]` - Add geospatial members
 - [x] `GEOPOS key member [member ...]` - Return longitude/latitude of members
 - [x] `GEODIST key member1 member2 [m | km | ft | mi]` - Distance between two members
 - [x] `GEOHASH key member [member ...]` - Return Geohash strings for members
-- [ ] `GEOSEARCH key <FROMMEMBER member | FROMLONLAT longitude latitude> <BYRADIUS radius unit | BYBOX width height unit> [ASC | DESC] [COUNT count [ANY]] [WITHCOORD] [WITHDIST] [WITHHASH]` - Search within a radius or box
-- [ ] `GEOSEARCHSTORE destination source <FROMMEMBER ... | FROMLONLAT ...> <BYRADIUS ... | BYBOX ...> [STOREDIST]` - Store a `GEOSEARCH` result
-- [ ] `GEORADIUS` / `GEORADIUSBYMEMBER` (and `_RO` variants) - Deprecated radius queries
+- [x] `GEOSEARCH key <FROMMEMBER member | FROMLONLAT longitude latitude> <BYRADIUS radius unit | BYBOX width height unit> [ASC | DESC] [COUNT count [ANY]] [WITHCOORD] [WITHDIST] [WITHHASH]` - Search within a radius or box
+- [x] `GEOSEARCHSTORE destination source <FROMMEMBER ... | FROMLONLAT ...> <BYRADIUS ... | BYBOX ...> [STOREDIST]` - Store a `GEOSEARCH` result
+- [x] `GEORADIUS` / `GEORADIUSBYMEMBER` (and `_RO` variants) - Deprecated radius queries
 
 ## Implementation Notes
 

--- a/src/commands/geo/georadius.ts
+++ b/src/commands/geo/georadius.ts
@@ -1,0 +1,111 @@
+import { defineCommand } from '../../core/command-definition'
+import { t, type ParseContext } from '../../core/command-schema'
+import type { RedisExecutionContext } from '../../core/redis-context'
+import { WrongNumberOfArgumentsError } from '../../core/redis-error'
+import { integer } from '../helpers'
+import { assertValidCoordinates } from './helpers'
+import {
+  buildSearchReply,
+  buildStoreMembers,
+  collectMatches,
+  orderAndLimit,
+  parseByRadius,
+  parseGeoFloatToken,
+  parseGeoRadiusFlags,
+  type GeoBy,
+  type GeoRadiusFlags,
+} from './search-core'
+
+type GeoRadiusArgs = GeoRadiusFlags & {
+  key: Buffer
+  lon: number
+  lat: number
+  by: GeoBy
+}
+
+function createGeoRadiusSchema(allowStore: boolean) {
+  return t.custom<GeoRadiusArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const key = input[index]
+      const lonTok = input[index + 1]
+      const latTok = input[index + 2]
+      const radiusTok = input[index + 3]
+      const unitTok = input[index + 4]
+      if (!key || !lonTok || !latTok || !radiusTok || !unitTok) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      const lon = parseGeoFloatToken(lonTok)
+      const lat = parseGeoFloatToken(latTok)
+      assertValidCoordinates(lon, lat)
+      const by = parseByRadius(radiusTok, unitTok)
+      const [flags, nextIndex] = parseGeoRadiusFlags(
+        input,
+        index + 5,
+        allowStore,
+      )
+
+      return { value: { key, lon, lat, by, ...flags }, nextIndex }
+    },
+  )
+}
+
+function executeGeoRadius(args: GeoRadiusArgs, ctx: RedisExecutionContext) {
+  const zset = ctx.db.getSortedSet(args.key)
+  const matches = collectMatches(
+    zset,
+    { lon: args.lon, lat: args.lat },
+    args.by,
+  )
+  const ordered = orderAndLimit(matches, {
+    order: args.order,
+    count: args.count,
+  })
+
+  const dest = args.store ?? args.storeDist
+  if (dest) {
+    const members = buildStoreMembers(
+      ordered,
+      args.storeDist !== undefined,
+      args.by.unit,
+    )
+    if (members.size === 0) {
+      ctx.db.delete(dest)
+      return integer(0)
+    }
+    ctx.db.delete(dest)
+    ctx.db.updateSortedSet(dest, destZset => {
+      destZset.replaceMembers(members, { forceDirty: true })
+    })
+    return integer(members.size)
+  }
+
+  return buildSearchReply(
+    ordered,
+    {
+      withCoord: args.withCoord,
+      withDist: args.withDist,
+      withHash: args.withHash,
+    },
+    args.by.unit,
+  )
+}
+
+export const georadiusCommand = defineCommand({
+  name: 'georadius',
+  schema: createGeoRadiusSchema(true),
+  flags: ['write', 'denyoom'],
+  keys: args =>
+    (args.store ?? args.storeDist)
+      ? [args.key, (args.store ?? args.storeDist)!]
+      : [args.key],
+  execute: executeGeoRadius,
+})
+
+export const georadiusRoCommand = defineCommand({
+  name: 'georadius_ro',
+  schema: createGeoRadiusSchema(false),
+  flags: ['readonly'],
+  keys: args => [args.key],
+  execute: executeGeoRadius,
+})

--- a/src/commands/geo/georadiusbymember.ts
+++ b/src/commands/geo/georadiusbymember.ts
@@ -1,0 +1,105 @@
+import { defineCommand } from '../../core/command-definition'
+import { t, type ParseContext } from '../../core/command-schema'
+import type { RedisExecutionContext } from '../../core/redis-context'
+import { WrongNumberOfArgumentsError } from '../../core/redis-error'
+import { integer } from '../helpers'
+import {
+  buildSearchReply,
+  buildStoreMembers,
+  collectMatches,
+  orderAndLimit,
+  parseByRadius,
+  parseGeoRadiusFlags,
+  resolveCenterFromMember,
+  type GeoBy,
+  type GeoRadiusFlags,
+} from './search-core'
+
+type GeoRadiusByMemberArgs = GeoRadiusFlags & {
+  key: Buffer
+  member: Buffer
+  by: GeoBy
+}
+
+function createGeoRadiusByMemberSchema(allowStore: boolean) {
+  return t.custom<GeoRadiusByMemberArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const key = input[index]
+      const member = input[index + 1]
+      const radiusTok = input[index + 2]
+      const unitTok = input[index + 3]
+      if (!key || !member || !radiusTok || !unitTok) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      const by = parseByRadius(radiusTok, unitTok)
+      const [flags, nextIndex] = parseGeoRadiusFlags(
+        input,
+        index + 4,
+        allowStore,
+      )
+
+      return { value: { key, member, by, ...flags }, nextIndex }
+    },
+  )
+}
+
+function executeGeoRadiusByMember(
+  args: GeoRadiusByMemberArgs,
+  ctx: RedisExecutionContext,
+) {
+  const zset = ctx.db.getSortedSet(args.key)
+  const center = resolveCenterFromMember(zset, args.member)
+  const matches = collectMatches(zset, center, args.by)
+  const ordered = orderAndLimit(matches, {
+    order: args.order,
+    count: args.count,
+  })
+
+  const dest = args.store ?? args.storeDist
+  if (dest) {
+    const members = buildStoreMembers(
+      ordered,
+      args.storeDist !== undefined,
+      args.by.unit,
+    )
+    if (members.size === 0) {
+      ctx.db.delete(dest)
+      return integer(0)
+    }
+    ctx.db.delete(dest)
+    ctx.db.updateSortedSet(dest, destZset => {
+      destZset.replaceMembers(members, { forceDirty: true })
+    })
+    return integer(members.size)
+  }
+
+  return buildSearchReply(
+    ordered,
+    {
+      withCoord: args.withCoord,
+      withDist: args.withDist,
+      withHash: args.withHash,
+    },
+    args.by.unit,
+  )
+}
+
+export const georadiusbymemberCommand = defineCommand({
+  name: 'georadiusbymember',
+  schema: createGeoRadiusByMemberSchema(true),
+  flags: ['write', 'denyoom'],
+  keys: args =>
+    (args.store ?? args.storeDist)
+      ? [args.key, (args.store ?? args.storeDist)!]
+      : [args.key],
+  execute: executeGeoRadiusByMember,
+})
+
+export const georadiusbymemberRoCommand = defineCommand({
+  name: 'georadiusbymember_ro',
+  schema: createGeoRadiusByMemberSchema(false),
+  flags: ['readonly'],
+  keys: args => [args.key],
+  execute: executeGeoRadiusByMember,
+})

--- a/src/commands/geo/geosearch.ts
+++ b/src/commands/geo/geosearch.ts
@@ -1,0 +1,113 @@
+import { defineCommand } from '../../core/command-definition'
+import { t, type ParseContext } from '../../core/command-schema'
+import {
+  RedisSyntaxError,
+  WrongNumberOfArgumentsError,
+} from '../../core/redis-error'
+import {
+  buildSearchReply,
+  collectMatches,
+  orderAndLimit,
+  parseGeoBy,
+  parseGeoFrom,
+  resolveCenterFromMember,
+  tryParseOrderOrCount,
+  type GeoBy,
+  type GeoFrom,
+  type GeoOrderCount,
+} from './search-core'
+
+type GeoSearchArgs = GeoOrderCount & {
+  key: Buffer
+  from: GeoFrom
+  by: GeoBy
+  withCoord: boolean
+  withDist: boolean
+  withHash: boolean
+}
+
+function createGeoSearchSchema() {
+  return t.custom<GeoSearchArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const key = input[index]
+      if (!key) throw new WrongNumberOfArgumentsError(ctx.commandName)
+
+      let cursor = index + 1
+      if (cursor >= input.length) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+      const [from, afterFrom] = parseGeoFrom(input, cursor, ctx.commandName)
+      cursor = afterFrom
+
+      if (cursor >= input.length) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+      const [by, afterBy] = parseGeoBy(input, cursor)
+      cursor = afterBy
+
+      const options: GeoOrderCount = {}
+      let withCoord = false
+      let withDist = false
+      let withHash = false
+      while (cursor < input.length) {
+        const advanced = tryParseOrderOrCount(input, cursor, options)
+        if (advanced !== null) {
+          cursor = advanced
+          continue
+        }
+        const token = input[cursor]!.toString().toUpperCase()
+        if (token === 'WITHCOORD') {
+          withCoord = true
+          cursor++
+          continue
+        }
+        if (token === 'WITHDIST') {
+          withDist = true
+          cursor++
+          continue
+        }
+        if (token === 'WITHHASH') {
+          withHash = true
+          cursor++
+          continue
+        }
+        throw new RedisSyntaxError()
+      }
+
+      return {
+        value: { key, from, by, withCoord, withDist, withHash, ...options },
+        nextIndex: input.length,
+      }
+    },
+  )
+}
+
+export const geosearchCommand = defineCommand({
+  name: 'geosearch',
+  since: { redis: '6.2.0', valkey: '7.2.0' },
+  schema: createGeoSearchSchema(),
+  flags: ['readonly'],
+  keys: args => [args.key],
+  execute: (args, ctx) => {
+    const zset = ctx.db.getSortedSet(args.key)
+    const center =
+      args.from.type === 'member'
+        ? resolveCenterFromMember(zset, args.from.member)
+        : { lon: args.from.lon, lat: args.from.lat }
+
+    const matches = collectMatches(zset, center, args.by)
+    const ordered = orderAndLimit(matches, {
+      order: args.order,
+      count: args.count,
+    })
+    return buildSearchReply(
+      ordered,
+      {
+        withCoord: args.withCoord,
+        withDist: args.withDist,
+        withHash: args.withHash,
+      },
+      args.by.unit,
+    )
+  },
+})

--- a/src/commands/geo/geosearchstore.ts
+++ b/src/commands/geo/geosearchstore.ts
@@ -1,0 +1,115 @@
+import { defineCommand } from '../../core/command-definition'
+import { t, type ParseContext } from '../../core/command-schema'
+import {
+  GeoSearchStoreWithOptionsError,
+  RedisSyntaxError,
+  WrongNumberOfArgumentsError,
+} from '../../core/redis-error'
+import { integer } from '../helpers'
+import {
+  buildStoreMembers,
+  collectMatches,
+  orderAndLimit,
+  parseGeoBy,
+  parseGeoFrom,
+  resolveCenterFromMember,
+  tryParseOrderOrCount,
+  type GeoBy,
+  type GeoFrom,
+  type GeoOrderCount,
+} from './search-core'
+
+type GeoSearchStoreArgs = GeoOrderCount & {
+  destination: Buffer
+  source: Buffer
+  from: GeoFrom
+  by: GeoBy
+  storeDist: boolean
+}
+
+function createGeoSearchStoreSchema() {
+  return t.custom<GeoSearchStoreArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const destination = input[index]
+      const source = input[index + 1]
+      if (!destination || !source) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      let cursor = index + 2
+      if (cursor >= input.length) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+      const [from, afterFrom] = parseGeoFrom(input, cursor, ctx.commandName)
+      cursor = afterFrom
+
+      if (cursor >= input.length) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+      const [by, afterBy] = parseGeoBy(input, cursor)
+      cursor = afterBy
+
+      const options: GeoOrderCount = {}
+      let storeDist = false
+      while (cursor < input.length) {
+        const advanced = tryParseOrderOrCount(input, cursor, options)
+        if (advanced !== null) {
+          cursor = advanced
+          continue
+        }
+        const token = input[cursor]!.toString().toUpperCase()
+        if (token === 'STOREDIST') {
+          storeDist = true
+          cursor++
+          continue
+        }
+        if (
+          token === 'WITHCOORD' ||
+          token === 'WITHDIST' ||
+          token === 'WITHHASH'
+        ) {
+          throw new GeoSearchStoreWithOptionsError()
+        }
+        throw new RedisSyntaxError()
+      }
+
+      return {
+        value: { destination, source, from, by, storeDist, ...options },
+        nextIndex: input.length,
+      }
+    },
+  )
+}
+
+export const geosearchstoreCommand = defineCommand({
+  name: 'geosearchstore',
+  since: { redis: '6.2.0', valkey: '7.2.0' },
+  schema: createGeoSearchStoreSchema(),
+  flags: ['write', 'denyoom'],
+  keys: args => [args.destination, args.source],
+  execute: (args, ctx) => {
+    const zset = ctx.db.getSortedSet(args.source)
+    const center =
+      args.from.type === 'member'
+        ? resolveCenterFromMember(zset, args.from.member)
+        : { lon: args.from.lon, lat: args.from.lat }
+
+    const matches = collectMatches(zset, center, args.by)
+    const ordered = orderAndLimit(matches, {
+      order: args.order,
+      count: args.count,
+    })
+    const members = buildStoreMembers(ordered, args.storeDist, args.by.unit)
+
+    if (members.size === 0) {
+      ctx.db.delete(args.destination)
+      return integer(0)
+    }
+
+    ctx.db.delete(args.destination)
+    ctx.db.updateSortedSet(args.destination, destZset => {
+      destZset.replaceMembers(members, { forceDirty: true })
+    })
+    return integer(members.size)
+  },
+})

--- a/src/commands/geo/helpers.ts
+++ b/src/commands/geo/helpers.ts
@@ -29,6 +29,10 @@ export function metersToUnit(meters: number, unit: string): number {
   return meters / UNIT_TO_METERS[unit.toLowerCase()]!
 }
 
+export function unitToMeters(value: number, unit: string): number {
+  return value * UNIT_TO_METERS[unit.toLowerCase()]!
+}
+
 export function assertValidCoordinates(lon: number, lat: number): void {
   if (
     lon < GEO_LON_MIN ||

--- a/src/commands/geo/index.ts
+++ b/src/commands/geo/index.ts
@@ -1,13 +1,37 @@
 import { geoaddCommand } from './geoadd'
 import { geodistCommand } from './geodist'
+import { georadiusCommand, georadiusRoCommand } from './georadius'
+import {
+  georadiusbymemberCommand,
+  georadiusbymemberRoCommand,
+} from './georadiusbymember'
 import { geohashCommand } from './geohash'
 import { geoposCommand } from './geopos'
+import { geosearchCommand } from './geosearch'
+import { geosearchstoreCommand } from './geosearchstore'
 
 export const geoCommands = [
   geoaddCommand,
   geoposCommand,
   geodistCommand,
   geohashCommand,
+  geosearchCommand,
+  geosearchstoreCommand,
+  georadiusCommand,
+  georadiusRoCommand,
+  georadiusbymemberCommand,
+  georadiusbymemberRoCommand,
 ]
 
-export { geoaddCommand, geoposCommand, geodistCommand, geohashCommand }
+export {
+  geoaddCommand,
+  geoposCommand,
+  geodistCommand,
+  geohashCommand,
+  geosearchCommand,
+  geosearchstoreCommand,
+  georadiusCommand,
+  georadiusRoCommand,
+  georadiusbymemberCommand,
+  georadiusbymemberRoCommand,
+}

--- a/src/commands/geo/search-core.ts
+++ b/src/commands/geo/search-core.ts
@@ -1,0 +1,399 @@
+import { RedisValue } from '../../core/redis-value'
+import { RedisResult } from '../../core/redis-result'
+import {
+  ExpectedFloatError,
+  GeoAnyRequiresCountError,
+  GeoBoxNegativeError,
+  GeoCountNotPositiveError,
+  GeoHeightNotNumericError,
+  GeoMissingMemberError,
+  GeoRadiusNegativeError,
+  GeoRadiusNotNumericError,
+  GeoRadiusStoreWithOptionsError,
+  GeoUnsupportedUnitError,
+  GeoWidthNotNumericError,
+  RedisSyntaxError,
+  WrongNumberOfArgumentsError,
+} from '../../core/redis-error'
+import type {
+  RedisSortedSetData,
+  RedisSortedSetMember,
+} from '../../state/data-types'
+import { array, parseIntegerToken } from '../helpers'
+import { getSortedMembers } from '../zsets/helpers'
+import {
+  assertValidCoordinates,
+  decodeGeoScore,
+  haversineMeters,
+  isSupportedGeoUnit,
+  metersToUnit,
+  unitToMeters,
+} from './helpers'
+
+export type GeoCenter = { lon: number; lat: number }
+
+export type GeoBy =
+  | { kind: 'radius'; radiusMeters: number; unit: string }
+  | { kind: 'box'; widthMeters: number; heightMeters: number; unit: string }
+
+export type GeoOrderCount = {
+  order?: 'ASC' | 'DESC'
+  count?: { count: number; any: boolean }
+}
+
+export type GeoWithFlags = {
+  withCoord: boolean
+  withDist: boolean
+  withHash: boolean
+}
+
+export type GeoMatch = {
+  member: Buffer
+  score: number
+  distanceMeters: number
+  lon: number
+  lat: number
+}
+
+export function parseGeoFloatToken(token: Buffer): number {
+  const n = Number(token.toString())
+  if (!Number.isFinite(n)) throw new ExpectedFloatError()
+  return n
+}
+
+function parseGeoUnit(token: Buffer | undefined): string {
+  if (!token) throw new RedisSyntaxError()
+  const unit = token.toString()
+  if (!isSupportedGeoUnit(unit)) throw new GeoUnsupportedUnitError()
+  return unit
+}
+
+export function parseByRadius(
+  radiusTok: Buffer | undefined,
+  unitTok: Buffer | undefined,
+): GeoBy {
+  if (!radiusTok) throw new RedisSyntaxError()
+  const radius = Number(radiusTok.toString())
+  if (!Number.isFinite(radius)) throw new GeoRadiusNotNumericError()
+  if (radius < 0) throw new GeoRadiusNegativeError()
+  const unit = parseGeoUnit(unitTok)
+  return { kind: 'radius', radiusMeters: unitToMeters(radius, unit), unit }
+}
+
+export function parseByBox(
+  widthTok: Buffer | undefined,
+  heightTok: Buffer | undefined,
+  unitTok: Buffer | undefined,
+): GeoBy {
+  if (!widthTok) throw new RedisSyntaxError()
+  const width = Number(widthTok.toString())
+  if (!Number.isFinite(width)) throw new GeoWidthNotNumericError()
+  if (!heightTok) throw new RedisSyntaxError()
+  const height = Number(heightTok.toString())
+  if (!Number.isFinite(height)) throw new GeoHeightNotNumericError()
+  if (width < 0 || height < 0) throw new GeoBoxNegativeError()
+  const unit = parseGeoUnit(unitTok)
+  return {
+    kind: 'box',
+    widthMeters: unitToMeters(width, unit),
+    heightMeters: unitToMeters(height, unit),
+    unit,
+  }
+}
+
+export type GeoFrom =
+  | { type: 'member'; member: Buffer }
+  | { type: 'lonlat'; lon: number; lat: number }
+
+// FROMMEMBER member | FROMLONLAT lon lat, shared by GEOSEARCH and
+// GEOSEARCHSTORE. A present-but-incomplete FROM clause is a wrong-number-of-
+// arguments error in real Redis (ground-truthed), not a syntax error.
+export function parseGeoFrom(
+  input: readonly Buffer[],
+  cursor: number,
+  commandName: string,
+): [GeoFrom, number] {
+  const token = input[cursor]?.toString().toUpperCase()
+  if (token === 'FROMMEMBER') {
+    const member = input[cursor + 1]
+    if (!member) throw new WrongNumberOfArgumentsError(commandName)
+    return [{ type: 'member', member }, cursor + 2]
+  }
+  if (token === 'FROMLONLAT') {
+    const lonTok = input[cursor + 1]
+    const latTok = input[cursor + 2]
+    if (!lonTok || !latTok) throw new WrongNumberOfArgumentsError(commandName)
+    const lon = parseGeoFloatToken(lonTok)
+    const lat = parseGeoFloatToken(latTok)
+    assertValidCoordinates(lon, lat)
+    return [{ type: 'lonlat', lon, lat }, cursor + 3]
+  }
+  throw new RedisSyntaxError()
+}
+
+// BYRADIUS radius unit | BYBOX width height unit, shared the same way.
+export function parseGeoBy(
+  input: readonly Buffer[],
+  cursor: number,
+): [GeoBy, number] {
+  const token = input[cursor]?.toString().toUpperCase()
+  if (token === 'BYRADIUS') {
+    return [parseByRadius(input[cursor + 1], input[cursor + 2]), cursor + 3]
+  }
+  if (token === 'BYBOX') {
+    return [
+      parseByBox(input[cursor + 1], input[cursor + 2], input[cursor + 3]),
+      cursor + 4,
+    ]
+  }
+  throw new RedisSyntaxError()
+}
+
+// Parses a single ASC | DESC | COUNT n [ANY] token starting at cursor into
+// `acc`. Returns the advanced cursor, or null if the token at cursor isn't
+// one of these — the caller decides what to do with an unmatched token.
+export function tryParseOrderOrCount(
+  input: readonly Buffer[],
+  cursor: number,
+  acc: GeoOrderCount,
+): number | null {
+  const token = input[cursor]?.toString().toUpperCase()
+  if (token === 'ASC') {
+    acc.order = 'ASC'
+    return cursor + 1
+  }
+  if (token === 'DESC') {
+    acc.order = 'DESC'
+    return cursor + 1
+  }
+  if (token === 'COUNT') {
+    const countTok = input[cursor + 1]
+    if (!countTok) throw new RedisSyntaxError()
+    const count = parseIntegerToken(countTok)
+    if (count <= 0) throw new GeoCountNotPositiveError()
+    let next = cursor + 2
+    let any = false
+    if (input[next]?.toString().toUpperCase() === 'ANY') {
+      any = true
+      next++
+    }
+    acc.count = { count, any }
+    return next
+  }
+  if (token === 'ANY') throw new GeoAnyRequiresCountError()
+  return null
+}
+
+export type GeoRadiusFlags = GeoOrderCount & {
+  withCoord: boolean
+  withDist: boolean
+  withHash: boolean
+  store?: Buffer
+  storeDist?: Buffer
+}
+
+// Shared WITH*/ASC|DESC/COUNT[/STORE/STOREDIST] tail for GEORADIUS[BYMEMBER]
+// [_RO]. `allowStore` is false for the _RO variants, where STORE/STOREDIST
+// aren't recognized at all (falls through to a generic syntax error, matching
+// real Redis) rather than being accepted and then rejected.
+export function parseGeoRadiusFlags(
+  input: readonly Buffer[],
+  cursor: number,
+  allowStore: boolean,
+): [GeoRadiusFlags, number] {
+  const options: GeoOrderCount = {}
+  let withCoord = false
+  let withDist = false
+  let withHash = false
+  let store: Buffer | undefined
+  let storeDist: Buffer | undefined
+
+  while (cursor < input.length) {
+    const advanced = tryParseOrderOrCount(input, cursor, options)
+    if (advanced !== null) {
+      cursor = advanced
+      continue
+    }
+    const token = input[cursor]!.toString().toUpperCase()
+    if (token === 'WITHCOORD') {
+      withCoord = true
+      cursor++
+      continue
+    }
+    if (token === 'WITHDIST') {
+      withDist = true
+      cursor++
+      continue
+    }
+    if (token === 'WITHHASH') {
+      withHash = true
+      cursor++
+      continue
+    }
+    if (allowStore && token === 'STORE') {
+      const dest = input[cursor + 1]
+      if (!dest) throw new RedisSyntaxError()
+      store = dest
+      cursor += 2
+      continue
+    }
+    if (allowStore && token === 'STOREDIST') {
+      const dest = input[cursor + 1]
+      if (!dest) throw new RedisSyntaxError()
+      storeDist = dest
+      cursor += 2
+      continue
+    }
+    throw new RedisSyntaxError()
+  }
+
+  if ((store || storeDist) && (withCoord || withDist || withHash)) {
+    throw new GeoRadiusStoreWithOptionsError()
+  }
+
+  return [
+    { ...options, withCoord, withDist, withHash, store, storeDist },
+    cursor,
+  ]
+}
+
+// The stored zset score is a 52-bit geohash; real Redis' box test compares
+// component-wise great-circle distances (same-lon for latitude, same-lat for
+// longitude) against half the width/height, not a single radial distance —
+// see geohashGetDistanceIfInRectangle in Redis' geohash_helper.c.
+function withinBy(
+  center: GeoCenter,
+  point: GeoCenter,
+  by: GeoBy,
+): number | null {
+  if (by.kind === 'radius') {
+    const dist = haversineMeters(center.lon, center.lat, point.lon, point.lat)
+    return dist <= by.radiusMeters ? dist : null
+  }
+
+  const latDist = haversineMeters(center.lon, center.lat, center.lon, point.lat)
+  if (latDist > by.heightMeters / 2) return null
+  const lonDist = haversineMeters(center.lon, center.lat, point.lon, center.lat)
+  if (lonDist > by.widthMeters / 2) return null
+  return haversineMeters(center.lon, center.lat, point.lon, point.lat)
+}
+
+export function resolveCenterFromMember(
+  zset: RedisSortedSetData | null,
+  member: Buffer,
+): GeoCenter {
+  const entry = zset?.members.get(member.toString('hex'))
+  if (!entry) throw new GeoMissingMemberError()
+  return decodeGeoScore(entry.score)
+}
+
+// Brute-force scan: decode every member and test it against the search
+// shape. O(n) rather than Redis' neighbor-cell box scan, but the same result
+// set — see issue #326 implementation notes (ponytail: box-scan optimizer
+// only pays off once a test proves brute force is too slow, which it hasn't).
+export function collectMatches(
+  zset: RedisSortedSetData | null,
+  center: GeoCenter,
+  by: GeoBy,
+): GeoMatch[] {
+  if (!zset) return []
+  const matches: GeoMatch[] = []
+  for (const entry of getSortedMembers(zset)) {
+    const point = decodeGeoScore(entry.score)
+    const distanceMeters = withinBy(center, point, by)
+    if (distanceMeters === null) continue
+    matches.push({
+      member: entry.member,
+      score: entry.score,
+      distanceMeters,
+      lon: point.lon,
+      lat: point.lat,
+    })
+  }
+  return matches
+}
+
+function sortByDistance(
+  matches: GeoMatch[],
+  order: 'ASC' | 'DESC',
+): GeoMatch[] {
+  const sorted = matches
+    .slice()
+    .sort((a, b) => a.distanceMeters - b.distanceMeters)
+  return order === 'DESC' ? sorted.reverse() : sorted
+}
+
+// Ordering matches real Redis' observed behavior: plain COUNT (no ASC/DESC)
+// defaults to nearest-first; COUNT ANY skips the distance sort entirely and
+// takes the first N in zset score order (only sorting that subset if
+// ASC/DESC was also given) — real Redis' ANY doesn't guarantee "closest N"
+// either, so this is not a fixed neighbor-cell traversal order to match.
+export function orderAndLimit(
+  matches: GeoMatch[],
+  options: GeoOrderCount,
+): GeoMatch[] {
+  if (options.count?.any) {
+    const limited = matches.slice(0, options.count.count)
+    return options.order ? sortByDistance(limited, options.order) : limited
+  }
+
+  let working = matches
+  if (options.order) {
+    working = sortByDistance(matches, options.order)
+  } else if (options.count) {
+    working = sortByDistance(matches, 'ASC')
+  }
+  return options.count ? working.slice(0, options.count.count) : working
+}
+
+export function buildSearchReply(
+  matches: GeoMatch[],
+  flags: GeoWithFlags,
+  unit: string,
+): RedisResult {
+  if (!flags.withCoord && !flags.withDist && !flags.withHash) {
+    return array(matches.map(m => RedisValue.bulkString(m.member)))
+  }
+
+  return array(
+    matches.map(m => {
+      const parts: RedisValue[] = [RedisValue.bulkString(m.member)]
+      if (flags.withDist) {
+        parts.push(
+          RedisValue.bulkString(
+            Buffer.from(metersToUnit(m.distanceMeters, unit).toFixed(4)),
+          ),
+        )
+      }
+      if (flags.withHash) parts.push(RedisValue.integer(m.score))
+      if (flags.withCoord) {
+        parts.push(
+          RedisValue.array([
+            RedisValue.bulkString(Buffer.from(m.lon.toString())),
+            RedisValue.bulkString(Buffer.from(m.lat.toString())),
+          ]),
+        )
+      }
+      return RedisValue.array(parts)
+    }),
+  )
+}
+
+// STOREDIST stores the query-unit distance as the score instead of the
+// geohash; without it the original geohash score is reused as-is (not
+// re-derived from the decoded lon/lat, which would lose precision).
+export function buildStoreMembers(
+  matches: GeoMatch[],
+  storeDist: boolean,
+  unit: string,
+): Map<string, RedisSortedSetMember> {
+  return new Map(
+    matches.map(m => [
+      m.member.toString('hex'),
+      {
+        member: Buffer.from(m.member),
+        score: storeDist ? metersToUnit(m.distanceMeters, unit) : m.score,
+      },
+    ]),
+  )
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -307,6 +307,12 @@ export {
   geoposCommand,
   geodistCommand,
   geohashCommand,
+  geosearchCommand,
+  geosearchstoreCommand,
+  georadiusCommand,
+  georadiusRoCommand,
+  georadiusbymemberCommand,
+  georadiusbymemberRoCommand,
 } from './geo'
 export {
   zsetsCommands,

--- a/src/core/redis-error.ts
+++ b/src/core/redis-error.ts
@@ -186,6 +186,70 @@ export class GeoUnsupportedUnitError extends RedisCommandError {
   }
 }
 
+export class GeoMissingMemberError extends RedisCommandError {
+  constructor() {
+    super('could not decode requested zset member')
+  }
+}
+
+export class GeoCountNotPositiveError extends RedisCommandError {
+  constructor() {
+    super('COUNT must be > 0')
+  }
+}
+
+export class GeoAnyRequiresCountError extends RedisCommandError {
+  constructor() {
+    super('the ANY argument requires COUNT argument')
+  }
+}
+
+export class GeoRadiusNotNumericError extends RedisCommandError {
+  constructor() {
+    super('need numeric radius')
+  }
+}
+
+export class GeoRadiusNegativeError extends RedisCommandError {
+  constructor() {
+    super('radius cannot be negative')
+  }
+}
+
+export class GeoWidthNotNumericError extends RedisCommandError {
+  constructor() {
+    super('need numeric width')
+  }
+}
+
+export class GeoHeightNotNumericError extends RedisCommandError {
+  constructor() {
+    super('need numeric height')
+  }
+}
+
+export class GeoBoxNegativeError extends RedisCommandError {
+  constructor() {
+    super('height or width cannot be negative')
+  }
+}
+
+export class GeoRadiusStoreWithOptionsError extends RedisCommandError {
+  constructor() {
+    super(
+      'STORE option in GEORADIUS is not compatible with WITHDIST, WITHHASH and WITHCOORD options',
+    )
+  }
+}
+
+export class GeoSearchStoreWithOptionsError extends RedisCommandError {
+  constructor() {
+    super(
+      'GEOSEARCHSTORE is not compatible with WITHDIST, WITHHASH and WITHCOORD options',
+    )
+  }
+}
+
 export class OffsetOutOfRangeError extends RedisCommandError {
   constructor() {
     super('offset is out of range')

--- a/tests-integration/ioredis/geo/search.test.ts
+++ b/tests-integration/ioredis/geo/search.test.ts
@@ -1,0 +1,519 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster } from 'ioredis'
+import { TestRunner } from '../../test-config'
+import { errorWithMessage, randomKey } from '../../utils'
+
+const testRunner = new TestRunner()
+
+// Same fixture as core.test.ts: Redis' own GEOADD documentation example.
+const PALERMO = { lon: 13.361389, lat: 38.115556, member: 'Palermo' }
+const CATANIA = { lon: 15.087269, lat: 37.502669, member: 'Catania' }
+
+describe(`Geo Search Commands Integration (${testRunner.getBackendName()})`, () => {
+  let redisClient: Cluster | undefined
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster('geo-search-integration')
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  async function seedSicily(key: string) {
+    await redisClient?.geoadd(
+      key,
+      PALERMO.lon,
+      PALERMO.lat,
+      PALERMO.member,
+      CATANIA.lon,
+      CATANIA.lat,
+      CATANIA.member,
+    )
+  }
+
+  test('GEOSEARCH FROMLONLAT BYRADIUS with WITHCOORD/WITHDIST/WITHHASH', async () => {
+    const key = `{geosearch:${randomKey()}}`
+    try {
+      await seedSicily(key)
+
+      const plain = await redisClient?.geosearch(
+        key,
+        'FROMLONLAT',
+        '15',
+        '37',
+        'BYRADIUS',
+        '200',
+        'km',
+        'ASC',
+      )
+      assert.deepStrictEqual(plain, ['Catania', 'Palermo'])
+
+      const withAll = (await redisClient?.geosearch(
+        key,
+        'FROMLONLAT',
+        '15',
+        '37',
+        'BYRADIUS',
+        '200',
+        'km',
+        'ASC',
+        'WITHCOORD',
+        'WITHDIST',
+        'WITHHASH',
+      )) as unknown as [string, string, number, [string, string]][]
+
+      assert.strictEqual(withAll[0]![0], 'Catania')
+      assert.strictEqual(withAll[0]![1], '56.4413')
+      assert.strictEqual(withAll[0]![2], 3479447370796909)
+      assert.strictEqual(withAll[1]![0], 'Palermo')
+      assert.strictEqual(withAll[1]![1], '190.4424')
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('GEOSEARCH FROMMEMBER BYBOX matches real Redis component-wise box test', async () => {
+    const key = `{geosearch-box:${randomKey()}}`
+    try {
+      await redisClient?.geoadd(key, 15, 37, 'center')
+      await redisClient?.geoadd(key, 15, 37.5, 'north') // ~55.5km north
+      await redisClient?.geoadd(key, 15.7, 37, 'east') // ~62km east at lat 37
+
+      const tall = await redisClient?.geosearch(
+        key,
+        'FROMMEMBER',
+        'center',
+        'BYBOX',
+        '50',
+        '200',
+        'km',
+        'ASC',
+      )
+      assert.deepStrictEqual(tall?.sort(), ['center', 'north'].sort())
+
+      const wide = await redisClient?.geosearch(
+        key,
+        'FROMMEMBER',
+        'center',
+        'BYBOX',
+        '200',
+        '50',
+        'km',
+        'ASC',
+      )
+      assert.deepStrictEqual(wide?.sort(), ['center', 'east'].sort())
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('GEOSEARCH COUNT / COUNT ANY semantics', async () => {
+    const key = `{geosearch-count:${randomKey()}}`
+    try {
+      await seedSicily(key)
+      await redisClient?.geoadd(key, 14, 38, 'Mid1')
+      await redisClient?.geoadd(key, 14.5, 38, 'Mid2')
+
+      // No ASC/DESC + COUNT defaults to nearest-first.
+      const nearest2 = await redisClient?.geosearch(
+        key,
+        'FROMLONLAT',
+        '15',
+        '37',
+        'BYRADIUS',
+        '500',
+        'km',
+        'COUNT',
+        '2',
+      )
+      assert.deepStrictEqual(nearest2, ['Catania', 'Mid2'])
+
+      // COUNT ANY without ASC/DESC returns the first match in zset score
+      // order, not necessarily the closest.
+      const any1 = await redisClient?.geosearch(
+        key,
+        'FROMLONLAT',
+        '15',
+        '37',
+        'BYRADIUS',
+        '500',
+        'km',
+        'COUNT',
+        '1',
+        'ANY',
+      )
+      assert.deepStrictEqual(any1, ['Palermo'])
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('GEOSEARCH argument and edge-case errors match Redis', async () => {
+    const key = `{geosearch-errors:${randomKey()}}`
+    try {
+      await seedSicily(key)
+
+      await assert.rejects(
+        () =>
+          redisClient?.geosearch(
+            key,
+            'FROMMEMBER',
+            'NoSuchMember',
+            'BYRADIUS',
+            '200',
+            'km',
+          ),
+        errorWithMessage('ERR could not decode requested zset member'),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.geosearch(
+            key,
+            'FROMMEMBER',
+            PALERMO.member,
+            'FROMLONLAT',
+            '1',
+            '1',
+            'BYRADIUS',
+            '1',
+            'km',
+          ),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => redisClient?.geosearch(key, 'FROMLONLAT', '15', '37'),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'geosearch' command",
+        ),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.geosearch(
+            key,
+            'FROMLONLAT',
+            '15',
+            '37',
+            'BYRADIUS',
+            '1',
+            'parsec',
+          ),
+        errorWithMessage(
+          'ERR unsupported unit provided. please use M, KM, FT, MI',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.geosearch(
+            key,
+            'FROMLONLAT',
+            '15',
+            '37',
+            'BYRADIUS',
+            '-1',
+            'km',
+          ),
+        errorWithMessage('ERR radius cannot be negative'),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.geosearch(
+            key,
+            'FROMLONLAT',
+            '15',
+            '37',
+            'BYBOX',
+            '-1',
+            '5',
+            'km',
+          ),
+        errorWithMessage('ERR height or width cannot be negative'),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.geosearch(
+            key,
+            'FROMLONLAT',
+            '15',
+            '37',
+            'BYRADIUS',
+            '500',
+            'km',
+            'COUNT',
+            '0',
+          ),
+        errorWithMessage('ERR COUNT must be > 0'),
+      )
+      await assert.rejects(
+        () =>
+          redisClient?.geosearch(
+            key,
+            'FROMLONLAT',
+            '15',
+            '37',
+            'BYRADIUS',
+            '500',
+            'km',
+            'ANY',
+          ),
+        errorWithMessage('ERR the ANY argument requires COUNT argument'),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('GEOSEARCH on missing key returns empty array', async () => {
+    const key = `{geosearch-missing:${randomKey()}}`
+    const result = await redisClient?.geosearch(
+      key,
+      'FROMLONLAT',
+      '1',
+      '1',
+      'BYRADIUS',
+      '1',
+      'km',
+    )
+    assert.deepStrictEqual(result, [])
+  })
+
+  test('GEOSEARCH rejects wrong type key', async () => {
+    const key = `{geosearch-wrongtype:${randomKey()}}`
+    try {
+      await redisClient?.set(key, 'v')
+      await assert.rejects(
+        () =>
+          redisClient?.geosearch(
+            key,
+            'FROMLONLAT',
+            '1',
+            '1',
+            'BYRADIUS',
+            '1',
+            'km',
+          ),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('GEOSEARCHSTORE stores geohash score, STOREDIST stores distance', async () => {
+    const tag = `geosearchstore:${randomKey()}`
+    const key = `{${tag}}src`
+    const dest = `{${tag}}dst`
+    const destDist = `{${tag}}dstdist`
+    try {
+      await seedSicily(key)
+
+      const count = await redisClient?.geosearchstore(
+        dest,
+        key,
+        'FROMLONLAT',
+        '15',
+        '37',
+        'BYRADIUS',
+        '200',
+        'km',
+      )
+      assert.strictEqual(count, 2)
+      assert.strictEqual(
+        await redisClient?.zscore(dest, CATANIA.member),
+        '3479447370796909',
+      )
+
+      const countDist = await redisClient?.geosearchstore(
+        destDist,
+        key,
+        'FROMLONLAT',
+        '15',
+        '37',
+        'BYRADIUS',
+        '200',
+        'km',
+        'STOREDIST',
+      )
+      assert.strictEqual(countDist, 2)
+      const distScore = Number(
+        await redisClient?.zscore(destDist, CATANIA.member),
+      )
+      assert.ok(Math.abs(distScore - 56.44125787015819) < 0.001)
+
+      // Empty result deletes a pre-existing destination key.
+      await redisClient?.set(`{${tag}}empty`, 'pre')
+      await redisClient?.geosearchstore(
+        `{${tag}}empty`,
+        key,
+        'FROMLONLAT',
+        '1',
+        '1',
+        'BYRADIUS',
+        '1',
+        'km',
+      )
+      assert.strictEqual(await redisClient?.exists(`{${tag}}empty`), 0)
+    } finally {
+      await redisClient?.del(key, dest, destDist)
+    }
+  })
+
+  test('GEOSEARCHSTORE rejects WITH* options', async () => {
+    const tag = `geosearchstore-errors:${randomKey()}`
+    const key = `{${tag}}src`
+    const dest = `{${tag}}dst`
+    try {
+      await seedSicily(key)
+      await assert.rejects(
+        () =>
+          redisClient?.geosearchstore(
+            dest,
+            key,
+            'FROMLONLAT',
+            '15',
+            '37',
+            'BYRADIUS',
+            '200',
+            'km',
+            'WITHCOORD',
+          ),
+        errorWithMessage(
+          'ERR GEOSEARCHSTORE is not compatible with WITHDIST, WITHHASH and WITHCOORD options',
+        ),
+      )
+    } finally {
+      await redisClient?.del(key, dest)
+    }
+  })
+
+  test('GEORADIUS (deprecated) matches GEOSEARCH-equivalent behavior', async () => {
+    const key = `{georadius:${randomKey()}}`
+    try {
+      await seedSicily(key)
+
+      const withAll = (await redisClient?.georadius(
+        key,
+        '15',
+        '37',
+        '200',
+        'km',
+        'ASC',
+        'WITHCOORD',
+        'WITHDIST',
+        'WITHHASH',
+      )) as unknown as [string, string, string, [string, string]][]
+      assert.strictEqual(withAll[0]![0], 'Catania')
+      assert.strictEqual(withAll[1]![0], 'Palermo')
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('GEORADIUS STORE / STOREDIST write results, reject combining with WITH*', async () => {
+    const tag = `georadius-store:${randomKey()}`
+    const key = `{${tag}}src`
+    const dest = `{${tag}}dst`
+    try {
+      await seedSicily(key)
+
+      const count = await redisClient?.georadius(
+        key,
+        '15',
+        '37',
+        '200',
+        'km',
+        'STORE',
+        dest,
+      )
+      assert.strictEqual(count, 2)
+      assert.strictEqual(await redisClient?.zcard(dest), 2)
+
+      await assert.rejects(
+        () =>
+          redisClient?.georadius(
+            key,
+            '15',
+            '37',
+            '200',
+            'km',
+            'STORE',
+            dest,
+            'WITHCOORD',
+          ),
+        errorWithMessage(
+          'ERR STORE option in GEORADIUS is not compatible with WITHDIST, WITHHASH and WITHCOORD options',
+        ),
+      )
+    } finally {
+      await redisClient?.del(key, dest)
+    }
+  })
+
+  test('GEORADIUS_RO rejects STORE', async () => {
+    const key = `{georadius-ro:${randomKey()}}`
+    try {
+      await seedSicily(key)
+      await assert.rejects(
+        () =>
+          (
+            redisClient as unknown as {
+              georadius_ro: (...a: unknown[]) => Promise<unknown>
+            }
+          )?.georadius_ro(key, '15', '37', '200', 'km', 'STORE', 'x'),
+        errorWithMessage('ERR syntax error'),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('GEORADIUSBYMEMBER matches GEOSEARCH FROMMEMBER-equivalent behavior', async () => {
+    const key = `{georadiusbymember:${randomKey()}}`
+    try {
+      await seedSicily(key)
+
+      const result = await redisClient?.georadiusbymember(
+        key,
+        PALERMO.member,
+        '200',
+        'km',
+      )
+      assert.deepStrictEqual(result?.sort(), ['Catania', 'Palermo'].sort())
+
+      await assert.rejects(
+        () => redisClient?.georadiusbymember(key, 'NoSuchMember', '200', 'km'),
+        errorWithMessage('ERR could not decode requested zset member'),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+
+  test('GEORADIUSBYMEMBER_RO rejects STORE', async () => {
+    const key = `{georadiusbymember-ro:${randomKey()}}`
+    try {
+      await seedSicily(key)
+      await assert.rejects(
+        () =>
+          (
+            redisClient as unknown as {
+              georadiusbymember_ro: (...a: unknown[]) => Promise<unknown>
+            }
+          )?.georadiusbymember_ro(
+            key,
+            PALERMO.member,
+            '200',
+            'km',
+            'STORE',
+            'x',
+          ),
+        errorWithMessage('ERR syntax error'),
+      )
+    } finally {
+      await redisClient?.del(key)
+    }
+  })
+})

--- a/tests-integration/node-redis/geo/core.test.ts
+++ b/tests-integration/node-redis/geo/core.test.ts
@@ -1,0 +1,283 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { RedisClusterType } from 'redis'
+import { TestRunner } from '../../test-config'
+import { errorWithMessage, flushNodeRedisCluster, randomKey } from '../../utils'
+
+const testRunner = new TestRunner()
+
+// Redis' own GEOADD documentation example: Sicily with Palermo and Catania.
+const PALERMO = { lon: 13.361389, lat: 38.115556, member: 'Palermo' }
+const CATANIA = { lon: 15.087269, lat: 37.502669, member: 'Catania' }
+
+function assertCloseTo(actual: number, expected: number, epsilon = 1e-6) {
+  assert.ok(
+    Math.abs(actual - expected) < epsilon,
+    `expected ${actual} to be close to ${expected}`,
+  )
+}
+
+describe(`Geo Commands Integration (node-redis, ${testRunner.getBackendName()})`, () => {
+  let redisClient: RedisClusterType
+
+  before(async () => {
+    redisClient = (await testRunner.setupNodeRedisCluster()) as RedisClusterType
+    await flushNodeRedisCluster(redisClient)
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  test('GEOADD adds members and GEOPOS/GEODIST/GEOHASH read them back', async () => {
+    const key = `{geo-core:${randomKey()}}`
+
+    try {
+      const added = await redisClient.geoAdd(key, [
+        {
+          longitude: PALERMO.lon,
+          latitude: PALERMO.lat,
+          member: PALERMO.member,
+        },
+        {
+          longitude: CATANIA.lon,
+          latitude: CATANIA.lat,
+          member: CATANIA.member,
+        },
+      ])
+      assert.strictEqual(added, 2)
+
+      const score = await redisClient.zScore(key, PALERMO.member)
+      assert.strictEqual(Number(score), 3479099956230698)
+
+      const positions = await redisClient.geoPos(key, [
+        PALERMO.member,
+        CATANIA.member,
+        'NonExisting',
+      ])
+      assert.strictEqual(positions.length, 3)
+      assertCloseTo(positions[0]!.longitude, PALERMO.lon, 1e-5)
+      assertCloseTo(positions[0]!.latitude, PALERMO.lat, 1e-5)
+      assertCloseTo(positions[1]!.longitude, CATANIA.lon, 1e-5)
+      assertCloseTo(positions[1]!.latitude, CATANIA.lat, 1e-5)
+      assert.strictEqual(positions[2], null)
+
+      const distM = await redisClient.geoDist(
+        key,
+        PALERMO.member,
+        CATANIA.member,
+      )
+      assertCloseTo(Number(distM), 166274.1516, 0.01)
+
+      const distKm = await redisClient.geoDist(
+        key,
+        PALERMO.member,
+        CATANIA.member,
+        'km',
+      )
+      assertCloseTo(Number(distKm), 166.2742, 0.001)
+
+      const distMi = await redisClient.geoDist(
+        key,
+        PALERMO.member,
+        CATANIA.member,
+        'mi',
+      )
+      assertCloseTo(Number(distMi), 103.3182, 0.001)
+
+      const distFt = await redisClient.geoDist(
+        key,
+        PALERMO.member,
+        CATANIA.member,
+        'ft',
+      )
+      assertCloseTo(Number(distFt), 545518.87, 0.5)
+
+      const missingDist = await redisClient.geoDist(
+        key,
+        PALERMO.member,
+        'NonExisting',
+      )
+      assert.strictEqual(missingDist, null)
+
+      const hashes = await redisClient.geoHash(key, [
+        PALERMO.member,
+        CATANIA.member,
+        'NonExisting',
+      ])
+      assert.deepStrictEqual(hashes, ['sqc8b49rny0', 'sqdtr74hyu0', null])
+    } finally {
+      await redisClient.del(key)
+    }
+  })
+
+  test('GEOADD NX/XX/CH option flags match Redis', async () => {
+    const key = `{geo-options:${randomKey()}}`
+
+    try {
+      assert.strictEqual(
+        await redisClient.geoAdd(
+          key,
+          { longitude: 13.361389, latitude: 38.115556, member: 'one' },
+          { condition: 'NX' },
+        ),
+        1,
+      )
+      assert.strictEqual(
+        await redisClient.geoAdd(
+          key,
+          { longitude: 20, latitude: 40, member: 'one' },
+          { condition: 'NX' },
+        ),
+        0,
+      )
+      assertCloseTo(
+        (await redisClient.geoPos(key, 'one'))[0]!.longitude,
+        13.361389,
+        1e-5,
+      )
+
+      assert.strictEqual(
+        await redisClient.geoAdd(
+          key,
+          { longitude: 14, latitude: 39, member: 'one' },
+          { condition: 'XX' },
+        ),
+        0,
+      )
+      assertCloseTo(
+        (await redisClient.geoPos(key, 'one'))[0]!.longitude,
+        14,
+        1e-5,
+      )
+      assert.strictEqual(
+        await redisClient.geoAdd(
+          key,
+          { longitude: 1, latitude: 1, member: 'two' },
+          { condition: 'XX' },
+        ),
+        0,
+      )
+      assert.deepStrictEqual(await redisClient.geoPos(key, 'two'), [null])
+
+      assert.strictEqual(
+        await redisClient.geoAdd(
+          key,
+          [
+            { longitude: 15, latitude: 40, member: 'one' },
+            { longitude: 2, latitude: 2, member: 'two' },
+          ],
+          { CH: true },
+        ),
+        2,
+      )
+      assert.strictEqual(
+        await redisClient.geoAdd(
+          key,
+          { longitude: 15, latitude: 40, member: 'one' },
+          { CH: true },
+        ),
+        0,
+      )
+    } finally {
+      await redisClient.del(key)
+    }
+  })
+
+  test('GEOADD option/argument errors match Redis', async () => {
+    const key = `{geo-errors:${randomKey()}}`
+    const send = (args: string[]) => redisClient.sendCommand(key, false, args)
+
+    try {
+      await assert.rejects(
+        () => send(['GEOADD', key, 'NX', 'XX', '1', '2', 'm']),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => send(['GEOADD', key, 'GT', '1', '2', 'm']),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => send(['GEOADD', key, 'abc', '38', 'm1']),
+        errorWithMessage('ERR value is not a valid float'),
+      )
+      await assert.rejects(
+        () => send(['GEOADD', key, '200', '38.115556', 'Invalid']),
+        errorWithMessage(
+          'ERR invalid longitude,latitude pair 200.000000,38.115556',
+        ),
+      )
+      await assert.rejects(
+        () => send(['GEOADD', key, '13.361389', '-86', 'Invalid']),
+        errorWithMessage(
+          'ERR invalid longitude,latitude pair 13.361389,-86.000000',
+        ),
+      )
+      await assert.rejects(
+        () => send(['GEOADD', key]),
+        errorWithMessage("ERR wrong number of arguments for 'geoadd' command"),
+      )
+      await assert.rejects(
+        () => send(['GEOADD', key, '1', '2']),
+        errorWithMessage("ERR wrong number of arguments for 'geoadd' command"),
+      )
+      await assert.rejects(
+        () => send(['GEODIST', key, 'a', 'b', 'xyz']),
+        errorWithMessage(
+          'ERR unsupported unit provided. please use M, KM, FT, MI',
+        ),
+      )
+    } finally {
+      await redisClient.del(key)
+    }
+  })
+
+  test('GEO commands on missing key return nil/empty per Redis semantics', async () => {
+    const key = `{geo-missing:${randomKey()}}`
+
+    const positions = await redisClient.geoPos(key, ['m1', 'm2'])
+    assert.deepStrictEqual(positions, [null, null])
+
+    const dist = await redisClient.geoDist(key, 'm1', 'm2')
+    assert.strictEqual(dist, null)
+
+    const hashes = await redisClient.geoHash(key, ['m1', 'm2'])
+    assert.deepStrictEqual(hashes, [null, null])
+  })
+
+  test('GEO commands reject wrong type keys', async () => {
+    const key = `{geo-wrongtype:${randomKey()}}`
+
+    try {
+      await redisClient.set(key, 'foo')
+
+      await assert.rejects(
+        () =>
+          redisClient.geoAdd(key, { longitude: 1, latitude: 2, member: 'm' }),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
+        () => redisClient.geoPos(key, 'm'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
+        () => redisClient.geoDist(key, 'm1', 'm2'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
+        () => redisClient.geoHash(key, 'm'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+    } finally {
+      await redisClient.del(key)
+    }
+  })
+})

--- a/tests-integration/node-redis/geo/search.test.ts
+++ b/tests-integration/node-redis/geo/search.test.ts
@@ -1,0 +1,481 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { GEO_REPLY_WITH, RedisClusterType } from 'redis'
+import { TestRunner } from '../../test-config'
+import { errorWithMessage, flushNodeRedisCluster, randomKey } from '../../utils'
+
+const testRunner = new TestRunner()
+
+// Same fixture as core.test.ts: Redis' own GEOADD documentation example.
+const PALERMO = { lon: 13.361389, lat: 38.115556, member: 'Palermo' }
+const CATANIA = { lon: 15.087269, lat: 37.502669, member: 'Catania' }
+
+describe(`Geo Search Commands Integration (node-redis, ${testRunner.getBackendName()})`, () => {
+  let redisClient: RedisClusterType
+
+  before(async () => {
+    redisClient = (await testRunner.setupNodeRedisCluster()) as RedisClusterType
+    await flushNodeRedisCluster(redisClient)
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  async function seedSicily(key: string) {
+    await redisClient.geoAdd(key, [
+      { longitude: PALERMO.lon, latitude: PALERMO.lat, member: PALERMO.member },
+      { longitude: CATANIA.lon, latitude: CATANIA.lat, member: CATANIA.member },
+    ])
+  }
+
+  test('GEOSEARCH FROMLONLAT BYRADIUS with WITHCOORD/WITHDIST/WITHHASH', async () => {
+    const key = `{geosearch:${randomKey()}}`
+    try {
+      await seedSicily(key)
+
+      const plain = await redisClient.geoSearch(
+        key,
+        { longitude: 15, latitude: 37 },
+        { radius: 200, unit: 'km' },
+        { SORT: 'ASC' },
+      )
+      assert.deepStrictEqual(plain, ['Catania', 'Palermo'])
+
+      const withAll = await redisClient.geoSearchWith(
+        key,
+        { longitude: 15, latitude: 37 },
+        { radius: 200, unit: 'km' },
+        [
+          GEO_REPLY_WITH.COORDINATES,
+          GEO_REPLY_WITH.DISTANCE,
+          GEO_REPLY_WITH.HASH,
+        ],
+        { SORT: 'ASC' },
+      )
+
+      assert.strictEqual(withAll[0]!.member, 'Catania')
+      assert.strictEqual(Number(withAll[0]!.distance), 56.4413)
+      assert.strictEqual(Number(withAll[0]!.hash), 3479447370796909)
+      assert.strictEqual(withAll[1]!.member, 'Palermo')
+      assert.strictEqual(Number(withAll[1]!.distance), 190.4424)
+    } finally {
+      await redisClient.del(key)
+    }
+  })
+
+  test('GEOSEARCH FROMMEMBER BYBOX matches real Redis component-wise box test', async () => {
+    const key = `{geosearch-box:${randomKey()}}`
+    try {
+      await redisClient.geoAdd(key, {
+        longitude: 15,
+        latitude: 37,
+        member: 'center',
+      })
+      await redisClient.geoAdd(key, {
+        longitude: 15,
+        latitude: 37.5,
+        member: 'north',
+      }) // ~55.5km north
+      await redisClient.geoAdd(key, {
+        longitude: 15.7,
+        latitude: 37,
+        member: 'east',
+      }) // ~62km east at lat 37
+
+      const tall = await redisClient.geoSearch(
+        key,
+        'center',
+        { width: 50, height: 200, unit: 'km' },
+        { SORT: 'ASC' },
+      )
+      assert.deepStrictEqual(tall.sort(), ['center', 'north'].sort())
+
+      const wide = await redisClient.geoSearch(
+        key,
+        'center',
+        { width: 200, height: 50, unit: 'km' },
+        { SORT: 'ASC' },
+      )
+      assert.deepStrictEqual(wide.sort(), ['center', 'east'].sort())
+    } finally {
+      await redisClient.del(key)
+    }
+  })
+
+  test('GEOSEARCH COUNT / COUNT ANY semantics', async () => {
+    const key = `{geosearch-count:${randomKey()}}`
+    try {
+      await seedSicily(key)
+      await redisClient.geoAdd(key, {
+        longitude: 14,
+        latitude: 38,
+        member: 'Mid1',
+      })
+      await redisClient.geoAdd(key, {
+        longitude: 14.5,
+        latitude: 38,
+        member: 'Mid2',
+      })
+
+      // No ASC/DESC + COUNT defaults to nearest-first.
+      const nearest2 = await redisClient.geoSearch(
+        key,
+        { longitude: 15, latitude: 37 },
+        { radius: 500, unit: 'km' },
+        { COUNT: 2 },
+      )
+      assert.deepStrictEqual(nearest2, ['Catania', 'Mid2'])
+
+      // COUNT ANY without ASC/DESC returns the first match in zset score
+      // order, not necessarily the closest.
+      const any1 = await redisClient.geoSearch(
+        key,
+        { longitude: 15, latitude: 37 },
+        { radius: 500, unit: 'km' },
+        { COUNT: { value: 1, ANY: true } },
+      )
+      assert.deepStrictEqual(any1, ['Palermo'])
+    } finally {
+      await redisClient.del(key)
+    }
+  })
+
+  test('GEOSEARCH argument and edge-case errors match Redis', async () => {
+    const key = `{geosearch-errors:${randomKey()}}`
+    const send = (args: string[]) => redisClient.sendCommand(key, true, args)
+
+    try {
+      await seedSicily(key)
+
+      await assert.rejects(
+        () =>
+          redisClient.geoSearch(key, 'NoSuchMember', {
+            radius: 200,
+            unit: 'km',
+          }),
+        errorWithMessage('ERR could not decode requested zset member'),
+      )
+      await assert.rejects(
+        () =>
+          send([
+            'GEOSEARCH',
+            key,
+            'FROMMEMBER',
+            PALERMO.member,
+            'FROMLONLAT',
+            '1',
+            '1',
+            'BYRADIUS',
+            '1',
+            'km',
+          ]),
+        errorWithMessage('ERR syntax error'),
+      )
+      await assert.rejects(
+        () => send(['GEOSEARCH', key, 'FROMLONLAT', '15', '37']),
+        errorWithMessage(
+          "ERR wrong number of arguments for 'geosearch' command",
+        ),
+      )
+      await assert.rejects(
+        () =>
+          redisClient.geoSearch(
+            key,
+            { longitude: 15, latitude: 37 },
+            { radius: 1, unit: 'parsec' as never },
+          ),
+        errorWithMessage(
+          'ERR unsupported unit provided. please use M, KM, FT, MI',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          redisClient.geoSearch(
+            key,
+            { longitude: 15, latitude: 37 },
+            { radius: -1, unit: 'km' },
+          ),
+        errorWithMessage('ERR radius cannot be negative'),
+      )
+      await assert.rejects(
+        () =>
+          redisClient.geoSearch(
+            key,
+            { longitude: 15, latitude: 37 },
+            { width: -1, height: 5, unit: 'km' },
+          ),
+        errorWithMessage('ERR height or width cannot be negative'),
+      )
+      // node-redis' typed COUNT option silently drops `0` (falsy check in
+      // the client's own parser), so this needs the raw command form.
+      await assert.rejects(
+        () =>
+          send([
+            'GEOSEARCH',
+            key,
+            'FROMLONLAT',
+            '15',
+            '37',
+            'BYRADIUS',
+            '500',
+            'km',
+            'COUNT',
+            '0',
+          ]),
+        errorWithMessage('ERR COUNT must be > 0'),
+      )
+      await assert.rejects(
+        () =>
+          send([
+            'GEOSEARCH',
+            key,
+            'FROMLONLAT',
+            '15',
+            '37',
+            'BYRADIUS',
+            '500',
+            'km',
+            'ANY',
+          ]),
+        errorWithMessage('ERR the ANY argument requires COUNT argument'),
+      )
+    } finally {
+      await redisClient.del(key)
+    }
+  })
+
+  test('GEOSEARCH on missing key returns empty array', async () => {
+    const key = `{geosearch-missing:${randomKey()}}`
+    const result = await redisClient.geoSearch(
+      key,
+      { longitude: 1, latitude: 1 },
+      { radius: 1, unit: 'km' },
+    )
+    assert.deepStrictEqual(result, [])
+  })
+
+  test('GEOSEARCH rejects wrong type key', async () => {
+    const key = `{geosearch-wrongtype:${randomKey()}}`
+    try {
+      await redisClient.set(key, 'v')
+      await assert.rejects(
+        () =>
+          redisClient.geoSearch(
+            key,
+            { longitude: 1, latitude: 1 },
+            { radius: 1, unit: 'km' },
+          ),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+    } finally {
+      await redisClient.del(key)
+    }
+  })
+
+  test('GEOSEARCHSTORE stores geohash score, STOREDIST stores distance', async () => {
+    const tag = `{geosearchstore:${randomKey()}}`
+    const key = `${tag}:src`
+    const dest = `${tag}:dst`
+    const destDist = `${tag}:dstdist`
+    try {
+      await seedSicily(key)
+
+      const count = await redisClient.geoSearchStore(
+        dest,
+        key,
+        { longitude: 15, latitude: 37 },
+        { radius: 200, unit: 'km' },
+      )
+      assert.strictEqual(count, 2)
+      assert.strictEqual(
+        Number(await redisClient.zScore(dest, CATANIA.member)),
+        3479447370796909,
+      )
+
+      const countDist = await redisClient.geoSearchStore(
+        destDist,
+        key,
+        { longitude: 15, latitude: 37 },
+        { radius: 200, unit: 'km' },
+        { STOREDIST: true },
+      )
+      assert.strictEqual(countDist, 2)
+      const distScore = Number(
+        await redisClient.zScore(destDist, CATANIA.member),
+      )
+      assert.ok(Math.abs(distScore - 56.44125787015819) < 0.001)
+
+      // Empty result deletes a pre-existing destination key.
+      await redisClient.set(`${tag}:empty`, 'pre')
+      await redisClient.geoSearchStore(
+        `${tag}:empty`,
+        key,
+        { longitude: 1, latitude: 1 },
+        { radius: 1, unit: 'km' },
+      )
+      assert.strictEqual(await redisClient.exists(`${tag}:empty`), 0)
+    } finally {
+      await redisClient.del([key, dest, destDist])
+    }
+  })
+
+  test('GEOSEARCHSTORE rejects WITH* options', async () => {
+    const tag = `{geosearchstore-errors:${randomKey()}}`
+    const key = `${tag}:src`
+    const dest = `${tag}:dst`
+    const send = (args: string[]) => redisClient.sendCommand(dest, false, args)
+    try {
+      await seedSicily(key)
+      await assert.rejects(
+        () =>
+          send([
+            'GEOSEARCHSTORE',
+            dest,
+            key,
+            'FROMLONLAT',
+            '15',
+            '37',
+            'BYRADIUS',
+            '200',
+            'km',
+            'WITHCOORD',
+          ]),
+        errorWithMessage(
+          'ERR GEOSEARCHSTORE is not compatible with WITHDIST, WITHHASH and WITHCOORD options',
+        ),
+      )
+    } finally {
+      await redisClient.del([key, dest])
+    }
+  })
+
+  test('GEORADIUS (deprecated) matches GEOSEARCH-equivalent behavior', async () => {
+    const key = `{georadius:${randomKey()}}`
+    try {
+      await seedSicily(key)
+
+      const withAll = await redisClient.geoRadiusWith(
+        key,
+        { longitude: 15, latitude: 37 },
+        200,
+        'km',
+        [
+          GEO_REPLY_WITH.COORDINATES,
+          GEO_REPLY_WITH.DISTANCE,
+          GEO_REPLY_WITH.HASH,
+        ],
+        { SORT: 'ASC' },
+      )
+      assert.strictEqual(withAll[0]!.member, 'Catania')
+      assert.strictEqual(withAll[1]!.member, 'Palermo')
+    } finally {
+      await redisClient.del(key)
+    }
+  })
+
+  test('GEORADIUS STORE / STOREDIST write results, reject combining with WITH*', async () => {
+    const tag = `{georadius-store:${randomKey()}}`
+    const key = `${tag}:src`
+    const dest = `${tag}:dst`
+    const send = (args: string[]) => redisClient.sendCommand(key, false, args)
+    try {
+      await seedSicily(key)
+
+      const count = await redisClient.geoRadiusStore(
+        key,
+        { longitude: 15, latitude: 37 },
+        200,
+        'km',
+        dest,
+      )
+      assert.strictEqual(count, 2)
+      assert.strictEqual(await redisClient.zCard(dest), 2)
+
+      // node-redis has no typed method that combines STORE with WITH* (the
+      // client design forbids constructing the invalid combination), so this
+      // is exercised via sendCommand like the other raw-syntax assertions.
+      await assert.rejects(
+        () =>
+          send([
+            'GEORADIUS',
+            key,
+            '15',
+            '37',
+            '200',
+            'km',
+            'STORE',
+            dest,
+            'WITHCOORD',
+          ]),
+        errorWithMessage(
+          'ERR STORE option in GEORADIUS is not compatible with WITHDIST, WITHHASH and WITHCOORD options',
+        ),
+      )
+    } finally {
+      await redisClient.del([key, dest])
+    }
+  })
+
+  test('GEORADIUS_RO rejects STORE', async () => {
+    const key = `{georadius-ro:${randomKey()}}`
+    const send = (args: string[]) => redisClient.sendCommand(key, true, args)
+    try {
+      await seedSicily(key)
+      await assert.rejects(
+        () =>
+          send(['GEORADIUS_RO', key, '15', '37', '200', 'km', 'STORE', 'x']),
+        errorWithMessage('ERR syntax error'),
+      )
+    } finally {
+      await redisClient.del(key)
+    }
+  })
+
+  test('GEORADIUSBYMEMBER matches GEOSEARCH FROMMEMBER-equivalent behavior', async () => {
+    const key = `{georadiusbymember:${randomKey()}}`
+    try {
+      await seedSicily(key)
+
+      const result = await redisClient.geoRadiusByMember(
+        key,
+        PALERMO.member,
+        200,
+        'km',
+      )
+      assert.deepStrictEqual(result.sort(), ['Catania', 'Palermo'].sort())
+
+      await assert.rejects(
+        () => redisClient.geoRadiusByMember(key, 'NoSuchMember', 200, 'km'),
+        errorWithMessage('ERR could not decode requested zset member'),
+      )
+    } finally {
+      await redisClient.del(key)
+    }
+  })
+
+  test('GEORADIUSBYMEMBER_RO rejects STORE', async () => {
+    const key = `{georadiusbymember-ro:${randomKey()}}`
+    const send = (args: string[]) => redisClient.sendCommand(key, true, args)
+    try {
+      await seedSicily(key)
+      await assert.rejects(
+        () =>
+          send([
+            'GEORADIUSBYMEMBER_RO',
+            key,
+            PALERMO.member,
+            '200',
+            'km',
+            'STORE',
+            'x',
+          ]),
+        errorWithMessage('ERR syntax error'),
+      )
+    } finally {
+      await redisClient.del(key)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Implements the second half of the Geo command family: `GEOSEARCH`, `GEOSEARCHSTORE`, `GEORADIUS`/`GEORADIUS_RO`, `GEORADIUSBYMEMBER`/`GEORADIUSBYMEMBER_RO`.
- Shared search core (`src/commands/geo/search-core.ts`) brute-force scans the zset (decode + filter by radius/box) instead of Redis' neighbor-cell traversal — same result set, O(n). Box containment uses component-wise great-circle distances (same-lon for latitude, same-lat for longitude vs half-width/half-height), matching Redis' `geohashGetDistanceIfInRectangle`.
- Ordering, `COUNT`/`COUNT ANY` semantics, `WITH*` reply shape/order, and `STORE`/`STOREDIST` score semantics were all ground-truthed against a live `redis-server` (7.2.1) rather than assumed from docs.
- `GEOSEARCH`/`GEOSEARCHSTORE` are gated `redis-6.2+`/`valkey-8.0+` (new in Redis 6.2). `GEORADIUS*` predate the repo's oldest supported profile, so they ship ungated.
- Added several new error classes to `redis-error.ts` matching exact Redis wording (`could not decode requested zset member`, `COUNT must be > 0`, `the ANY argument requires COUNT argument`, `need numeric radius/width/height`, `radius cannot be negative`, `height or width cannot be negative`, the STORE/WITH* incompatibility messages).

Closes #326

## Test plan
- [x] New integration test (`tests-integration/ioredis/geo/search.test.ts`, 13 tests) covers: WITHCOORD/WITHDIST/WITHHASH shape and ordering, BYBOX component-wise filtering, COUNT/COUNT ANY ordering semantics, argument/edge-case errors, missing-key and wrong-type behavior, GEOSEARCHSTORE (with/without STOREDIST) including empty-result deletion, GEORADIUS/GEORADIUSBYMEMBER (+ deprecated STORE/STOREDIST and their `_RO` read-only rejection).
- [x] All 13 pass against real Redis (ground-truthing confirmed, not just mock-matching)
- [x] All 13 pass against the mock backend
- [x] `npm run build` / `npm run lint` clean
- [x] `npm run test:all` passes (1066/1066)