### PR TITLE
compat: support HSCAN NOVALUES

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -137,7 +137,8 @@ Current profile gates:
 | --- | --- | --- |
 | Redis 6.2 root commands: `BLMOVE`, `COPY`, `GETDEL`, `GETEX`, `HRANDFIELD`, `LMOVE`, `RESET`, `SMISMEMBER`, `XAUTOCLAIM`, `ZMSCORE` | `redis-6.2+` | `valkey-8.0+` |
 | Redis 7.0 root commands: `BLMPOP`, `BZMPOP`, `EXPIRETIME`, `LMPOP`, `PEXPIRETIME`, `SINTERCARD`, `SORT_RO`, `SPUBLISH`, `SSUBSCRIBE`, `SUNSUBSCRIBE`, `ZINTERCARD`, `ZMPOP` | `redis-7.0+` | `valkey-8.0+` |
-| Redis 7.4 hash-field expiration commands: `HEXPIRE`, `HEXPIREAT`, `HPERSIST`, `HPEXPIRE`, `HPEXPIREAT`, `HPTTL`, `HTTL` | `redis-7.4+` | `valkey-9.0+` |
+| Redis 7.4 hash-field expiration commands: `HEXPIRE`, `HEXPIREAT`, `HEXPIRETIME`, `HPERSIST`, `HPEXPIRE`, `HPEXPIREAT`, `HPEXPIRETIME`, `HPTTL`, `HTTL` | `redis-7.4+` | `valkey-9.0+` |
+| `HSCAN ... NOVALUES` | `redis-7.4+` | `valkey-9.0+` |
 | Redis 8.0 hash-field read commands: `HGETDEL`, `HGETEX` | `redis-8.0+` | `HGETEX` in `valkey-9.0`; `HGETDEL` is not modeled for Valkey |
 | `COMMAND DOCS` and `COMMAND GETKEYSANDFLAGS` | `redis-7.0+` | `valkey-8.0+` |
 | `CLIENT NO-EVICT` and multi-section `INFO` | `redis-7.0+` | `valkey-8.0+` |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -251,7 +251,7 @@ with `GT` or `LT`.
 - [x] `HINCRBY key field increment` - Increment the integer value of a hash field
 - [x] `HINCRBYFLOAT key field increment` - Increment the float value of a hash field
 - [x] `HRANDFIELD key [count [WITHVALUES]]` - Return one or more random hash fields, optionally with values
-- [x] `HSCAN key cursor [MATCH pattern] [COUNT count]` - Incrementally iterate hash fields and values (see [Scan Family](#10-scan-family))
+- [x] `HSCAN key cursor [MATCH pattern] [COUNT count] [NOVALUES]` - Incrementally iterate hash fields and values (see [Scan Family](#10-scan-family))
 
 ## 6. List Commands
 
@@ -365,7 +365,7 @@ with `GT` or `LT`.
 ## 10. Scan Family
 
 - [x] `SCAN cursor [MATCH pattern] [COUNT count] [TYPE type]` - Iterate the keyspace
-- [x] `HSCAN key cursor [MATCH pattern] [COUNT count]` - Iterate hash fields/values
+- [x] `HSCAN key cursor [MATCH pattern] [COUNT count] [NOVALUES]` - Iterate hash fields/values
 - [x] `SSCAN key cursor [MATCH pattern] [COUNT count]` - Iterate set members
 - [x] `ZSCAN key cursor [MATCH pattern] [COUNT count]` - Iterate sorted set members/scores
 - [x] `KEYS pattern` - Return all keys matching a glob pattern
@@ -373,7 +373,7 @@ with `GT` or `LT`.
 `TYPE` is only accepted by `SCAN` (matching real Redis); `HSCAN`/`SSCAN`/`ZSCAN`
 reject it.
 
-- [ ] `HSCAN ... NOVALUES` (Redis 7.4)
+`NOVALUES` is only accepted by `HSCAN` for Redis 7.4+ / Valkey 9.0+ profiles.
 
 ## 11. Transaction Commands
 

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -16,6 +16,7 @@ type ScanOptions = {
   match?: Buffer
   count?: number
   type?: string
+  noValues?: boolean
 }
 
 type KeyedScanOptions = {
@@ -23,6 +24,7 @@ type KeyedScanOptions = {
   cursor: bigint
   match?: Buffer
   count?: number
+  noValues?: boolean
 }
 
 type ScanResultOptions = {
@@ -76,6 +78,10 @@ export const hscanCommand = defineCommand({
   flags: ['readonly', 'random'],
   keys: args => [args.key],
   execute: (args, ctx) => {
+    if (args.noValues && !ctx.server.profile.has('hscan.novalues')) {
+      throw new RedisSyntaxError()
+    }
+
     const hash = ctx.db.getHash(args.key)
     if (!hash) {
       return scanResult([], args)
@@ -86,7 +92,9 @@ export const hscanCommand = defineCommand({
     )
     const items: ScanItem[] = entries.map(({ field, value }) => ({
       matchValue: field,
-      values: [RedisValue.bulkString(field), RedisValue.bulkString(value)],
+      values: args.noValues
+        ? [RedisValue.bulkString(field)]
+        : [RedisValue.bulkString(field), RedisValue.bulkString(value)],
     }))
 
     return scanResult(items, args)
@@ -171,7 +179,13 @@ function createKeyedScanOptionsSchema() {
   return t.custom<KeyedScanOptions>((input, index, ctx) => {
     const key = readRequired(input, index, ctx.commandName)
     const cursor = parseCursor(readRequired(input, index + 1, ctx.commandName))
-    const options = parseScanOptions(input, index + 2, ctx.commandName, false)
+    const options = parseScanOptions(
+      input,
+      index + 2,
+      ctx.commandName,
+      false,
+      ctx.commandName === 'hscan',
+    )
 
     return {
       value: { key, cursor, ...options },
@@ -185,6 +199,7 @@ function parseScanOptions(
   index: number,
   commandName: string,
   allowType: boolean,
+  allowNoValues = false,
 ): Omit<ScanOptions, 'cursor'> {
   const options: Omit<ScanOptions, 'cursor'> = {}
   let cursor = index
@@ -209,6 +224,15 @@ function parseScanOptions(
         .toString()
         .toLowerCase()
       cursor += 2
+      continue
+    }
+
+    if (option === 'novalues') {
+      if (!allowNoValues) {
+        throw new RedisCommandError('NOVALUES option can only be used in HSCAN')
+      }
+      options.noValues = true
+      cursor++
       continue
     }
 

--- a/src/core/compatibility/feature-gates.ts
+++ b/src/core/compatibility/feature-gates.ts
@@ -21,5 +21,6 @@ export const FEATURE_GATES: Record<FeatureId, VersionGate> = {
   'stream.xautoclaim-deleted-ids': { redis: '7.0.0', valkey: '7.2.0' },
   // BITCOUNT/BITPOS BYTE|BIT range modifier — Redis 7.0 / Valkey 7.2.
   'bit.byte-bit-range': { redis: '7.0.0', valkey: '7.2.0' },
+  'hscan.novalues': { redis: '7.4.0', valkey: '9.0.0' },
   'cluster.multi-db': { valkey: '9.0.0' },
 }

--- a/src/core/compatibility/profile.ts
+++ b/src/core/compatibility/profile.ts
@@ -21,6 +21,7 @@ export type FeatureId =
   | 'pubsub.resp3-publish-reply-first'
   | 'stream.xautoclaim-deleted-ids'
   | 'bit.byte-bit-range'
+  | 'hscan.novalues'
   | 'cluster.multi-db'
 
 export interface CompatibilityProfile {

--- a/tests-integration/compatibility/profile-gates.test.ts
+++ b/tests-integration/compatibility/profile-gates.test.ts
@@ -209,6 +209,7 @@ describe(
       )
 
       await send('HSET', hash, 'field', 'value', 'delete-me', 'gone')
+      await expectGate(supportsHscanNoValues(), 'HSCAN', hash, '0', 'NOVALUES')
       await expectGate(
         supportsHashFieldExpiration(),
         'HEXPIRE',
@@ -526,6 +527,10 @@ function supportsBitByteBitRange(): boolean {
 }
 
 function supportsHashFieldExpiration(): boolean {
+  return ['redis-7.4', 'redis-8.0', 'valkey-9.0'].includes(profile)
+}
+
+function supportsHscanNoValues(): boolean {
   return ['redis-7.4', 'redis-8.0', 'valkey-9.0'].includes(profile)
 }
 

--- a/tests-integration/ioredis/scan/typed-scan.test.ts
+++ b/tests-integration/ioredis/scan/typed-scan.test.ts
@@ -48,6 +48,27 @@ describe(`Scan Commands Integration (${testRunner.getBackendName()})`, () => {
     return { entries, iterations }
   }
 
+  async function collectHashScanNoValues(
+    key: string,
+    count: number,
+    match?: string,
+  ): Promise<string[]> {
+    const fields: string[] = []
+    await new Promise<void>((resolve, reject) => {
+      const stream = redisClient!.hscanStream(key, {
+        count,
+        ...(match ? { match } : {}),
+        noValues: true,
+      })
+
+      stream.on('data', (items: string[]) => fields.push(...items))
+      stream.on('error', reject)
+      stream.on('end', resolve)
+    })
+
+    return fields.sort()
+  }
+
   async function collectSetScan(
     key: string,
     count: number,
@@ -169,6 +190,21 @@ describe(`Scan Commands Integration (${testRunner.getBackendName()})`, () => {
       sortedEntries(result.entries),
       sortedEntries(expected),
     )
+  })
+
+  test('HSCAN NOVALUES returns only matching fields', async () => {
+    const key = taggedKey('hash-novalues')
+
+    try {
+      await redisClient!.hset(key, 'hit:1', 'v1', 'hit:2', 'v2', 'miss', 'v3')
+
+      assert.deepStrictEqual(await collectHashScanNoValues(key, 1, 'hit:*'), [
+        'hit:1',
+        'hit:2',
+      ])
+    } finally {
+      await redisClient!.del(key)
+    }
   })
 
   test('keyed scan MATCH advances across non-matching COUNT batches', async () => {

--- a/tests-integration/node-redis/scan/keys-scan.test.ts
+++ b/tests-integration/node-redis/scan/keys-scan.test.ts
@@ -382,9 +382,39 @@ describe(`Scan Commands Integration (node-redis, ${testRunner.getBackendName()})
     assertBufferSetsEqual(zscan[1], [rawZsetMember, Buffer.from('1')])
   })
 
+  test('HSCAN NOVALUES returns only matching fields', async () => {
+    const key = taggedKey('hscan-novalues')
+    const directClient = await connectToNodeRedisSlotOwner(redisClient, key)
+
+    try {
+      await directClient.hSet(key, {
+        'hit:1': 'v1',
+        'hit:2': 'v2',
+        miss: 'v3',
+      })
+
+      assert.deepStrictEqual(
+        await collectHashScanNoValues(directClient, key, [
+          'MATCH',
+          'hit:*',
+          'COUNT',
+          '1',
+          'NOVALUES',
+          'novalues',
+        ]),
+        ['hit:1', 'hit:2'],
+      )
+    } finally {
+      await directClient.del(key)
+      directClient.destroy()
+    }
+  })
+
   test('scan COUNT errors match Redis', async () => {
     const key = taggedKey('errors')
+    const setKey = taggedKey('errors-set')
     await redisClient.hSet(key, 'field', 'value')
+    await redisClient.sAdd(setKey, 'member')
 
     await assert.rejects(
       () => redisClient.sendCommand(undefined, true, ['SCAN']),
@@ -426,6 +456,31 @@ describe(`Scan Commands Integration (node-redis, ${testRunner.getBackendName()})
     await assert.rejects(
       () =>
         redisClient.sendCommand(key, true, ['HSCAN', key, '0', 'COUNT', '0']),
+      errorWithMessage('ERR syntax error'),
+    )
+    await assert.rejects(
+      () => redisClient.sendCommand(undefined, true, ['SCAN', '0', 'NOVALUES']),
+      errorWithMessage('ERR NOVALUES option can only be used in HSCAN'),
+    )
+    await assert.rejects(
+      () =>
+        redisClient.sendCommand(setKey, true, [
+          'SSCAN',
+          setKey,
+          '0',
+          'NOVALUES',
+        ]),
+      errorWithMessage('ERR NOVALUES option can only be used in HSCAN'),
+    )
+    await assert.rejects(
+      () =>
+        redisClient.sendCommand(key, true, [
+          'HSCAN',
+          key,
+          '0',
+          'NOVALUES',
+          'EXTRA',
+        ]),
       errorWithMessage('ERR syntax error'),
     )
   })
@@ -493,6 +548,31 @@ async function collectTopLevelScanBuffers(
   } while (cursor.toString() !== '0')
 
   return values
+}
+
+async function collectHashScanNoValues(
+  client: RedisClientType,
+  key: string,
+  options: Array<string | Buffer>,
+): Promise<string[]> {
+  const values: string[] = []
+  let cursor = '0'
+  let iterations = 0
+
+  do {
+    const [nextCursor, items] = (await client.sendCommand([
+      'HSCAN',
+      key,
+      cursor,
+      ...options,
+    ])) as ScanReply
+    values.push(...items)
+    cursor = nextCursor
+    iterations++
+    assert.ok(iterations < 1000)
+  } while (cursor !== '0')
+
+  return values.sort()
 }
 
 function stripTag(keys: string[], tag: string): string[] {


### PR DESCRIPTION
## Summary
- Add Redis 7.4 / Valkey 9.0 profile gating for `HSCAN ... NOVALUES`.
- Parse `NOVALUES` as an HSCAN-only flag and return fields without values when enabled.
- Add ioredis, node-redis, and profile-boundary coverage, plus command/API docs.

## Root cause
The scan option parser only accepted `MATCH` and `COUNT` for keyed scans, and HSCAN always flattened fields with values. Redis 7.4 added `NOVALUES`, so the mock rejected a valid HSCAN option and could not produce the fields-only reply shape.

## Validation
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/node-redis/scan/keys-scan.test.ts`
- `TEST_BACKEND=mock node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/ioredis/scan/typed-scan.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/node-redis/scan/keys-scan.test.ts`
- `TEST_BACKEND=real node --enable-source-maps --import tsx --no-warnings --test-concurrency 1 --test-timeout 30000 --test ./tests-integration/ioredis/scan/typed-scan.test.ts`
- `TEST_BACKEND=mock REDIS_COMPAT=redis-7.2 node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/compatibility/profile-gates.test.ts`
- `TEST_BACKEND=mock REDIS_COMPAT=redis-7.4 node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/compatibility/profile-gates.test.ts`
- `TEST_BACKEND=mock REDIS_COMPAT=valkey-8.0 node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/compatibility/profile-gates.test.ts`
- `TEST_BACKEND=mock REDIS_COMPAT=valkey-9.0 node --enable-source-maps --import tsx --no-warnings --test ./tests-integration/compatibility/profile-gates.test.ts`
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real`
- `npm run lint`

Part of #298. This does not close #298; it covers the `HSCAN NOVALUES` Redis 7.4 surface only.
