### PR TITLE
Finish Redis 7.4 compatibility deltas

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -139,6 +139,8 @@ Current profile gates:
 | Redis 7.0 root commands: `BLMPOP`, `BZMPOP`, `EXPIRETIME`, `LMPOP`, `PEXPIRETIME`, `SINTERCARD`, `SORT_RO`, `SPUBLISH`, `SSUBSCRIBE`, `SUNSUBSCRIBE`, `ZINTERCARD`, `ZMPOP` | `redis-7.0+` | `valkey-8.0+` |
 | Redis 7.4 hash-field expiration commands: `HEXPIRE`, `HEXPIREAT`, `HEXPIRETIME`, `HPERSIST`, `HPEXPIRE`, `HPEXPIREAT`, `HPEXPIRETIME`, `HPTTL`, `HTTL` | `redis-7.4+` | `valkey-9.0+` |
 | `HSCAN ... NOVALUES` | `redis-7.4+` | `valkey-9.0+` |
+| `XREAD ... +` latest-entry stream ID | `redis-7.4+` | unsupported |
+| `CLIENT KILL MAXAGE` | `redis-7.4+` | `valkey-9.0+` |
 | Redis 8.0 hash-field read commands: `HGETDEL`, `HGETEX` | `redis-8.0+` | `HGETEX` in `valkey-9.0`; `HGETDEL` is not modeled for Valkey |
 | `COMMAND DOCS` and `COMMAND GETKEYSANDFLAGS` | `redis-7.0+` | `valkey-8.0+` |
 | `CLIENT NO-EVICT` and multi-section `INFO` | `redis-7.0+` | `valkey-8.0+` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -322,7 +322,7 @@ flowchart LR
 is server-wide rather than per-DB: the cluster topology, the Lua
 [`RedisScriptCache`](../src/state/script-cache.ts) (so `FLUSHALL`/`FLUSHDB`
 clear keyspace data but **not** cached scripts — only `SCRIPT FLUSH` does),
-a registry of connected client sessions for `CLIENT LIST`, and the
+a registry of connected client sessions for `CLIENT LIST` / `CLIENT KILL`, and the
 [`RedisPubSubBroker`](../src/state/pubsub-broker.ts) used by client Pub/Sub
 commands for channel and pattern fan-out within that server state, plus the
 [`RedisMonitorFeed`](../src/state/monitor-feed.ts) used by `MONITOR` to fan out

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -39,9 +39,10 @@ shapes; see the gate matrix in [Compatibility Profiles](API.md#compatibility-pro
 - [x] `CLIENT ID` - Return the connection's ID
 - [x] `CLIENT INFO` - Return a single `key=value` line for the current connection
 - [x] `CLIENT LIST` - Return one `key=value` line per active client connected to the current server node
+- [x] `CLIENT KILL [ID client-id] [MAXAGE seconds] [SKIPME YES|NO]` - Close matching client connections; `MAXAGE` is accepted for Redis 7.4+ / Valkey 9.0+ profiles
 - [x] `CLIENT NO-EVICT ON|OFF` - Toggle the current connection's no-eviction flag
 - [x] `CLIENT HELP` - Return subcommand help
-- [ ] `CLIENT KILL`, `CLIENT PAUSE`/`UNPAUSE`, `CLIENT NO-TOUCH`, `CLIENT REPLY`, `CLIENT TRACKING` - not implemented
+- [ ] `CLIENT PAUSE`/`UNPAUSE`, `CLIENT NO-TOUCH`, `CLIENT REPLY`, `CLIENT TRACKING` - not implemented
 
 ## 2. Server Commands
 
@@ -168,8 +169,8 @@ surface.
 - [x] `MOVE key db` - Move a key to another database, preserving TTL; returns `0` if the source is missing or the destination already exists; rejected in cluster mode
 - [x] `KEYS pattern` - Find all keys matching a glob pattern
 - [x] `SCAN cursor [MATCH pattern] [COUNT count] [TYPE type]` - Incrementally iterate the keyspace (see [Scan Family](#10-scan-family))
-- [x] `SORT key [LIMIT offset count] [ASC | DESC] [ALPHA] [STORE destination]` - Sort a list, set, or zset (zset sorted by member value, not score); numeric by default, `ALPHA` for lexicographic; `STORE` writes the result to a destination list and returns its length
-- [x] `SORT_RO key [LIMIT offset count] [ASC | DESC] [ALPHA]` - Read-only variant of `SORT`; rejects `STORE`
+- [x] `SORT key [BY pattern] [LIMIT offset count] [GET pattern ...] [ASC | DESC] [ALPHA] [STORE destination]` - Sort a list, set, or zset (zset sorted by member value, not score); `BY` / `GET` support string-key pattern expansion and `GET #`; numeric by default, `ALPHA` for lexicographic; `STORE` writes the result to a destination list and returns its length
+- [x] `SORT_RO key [BY pattern] [LIMIT offset count] [GET pattern ...] [ASC | DESC] [ALPHA]` - Read-only variant of `SORT`; rejects `STORE`
 
 #### Expiration
 
@@ -188,8 +189,9 @@ with `GT` or `LT`.
 
 #### Notes / gaps vs. real Redis
 
-- `SORT` / `SORT_RO` do not support the `BY` or `GET` external-key pattern
-  dereference — passing either yields a syntax error (tracked as a follow-up)
+- `SORT` / `SORT_RO` `BY` / `GET` patterns must use the same hash tag as the
+  source key in cluster mode, matching Redis' cluster safety rule. Hash-field
+  dereference patterns such as `object_*->field` are not modeled.
 
 #### Not implemented
 
@@ -345,7 +347,7 @@ with `GT` or `LT`.
 - [x] `XREVRANGE key end start [COUNT count]` - Return entries in descending ID order
 - [x] `XDEL key ID [ID ...]` - Remove entries by ID
 - [x] `XTRIM key MAXLEN|MINID [~] threshold [LIMIT count]` - Trim a stream to a size or minimum ID
-- [x] `XREAD [COUNT count] [BLOCK milliseconds] STREAMS key [key ...] id [id ...]` - Read entries, optionally blocking for new ones (RESP3 map / RESP2 array of stream-entry pairs)
+- [x] `XREAD [COUNT count] [BLOCK milliseconds] STREAMS key [key ...] id|+ [id|+ ...]` - Read entries, optionally blocking for new ones (RESP3 map / RESP2 array of stream-entry pairs); Redis 7.4+ profiles accept `+` to return the latest entry from each stream
 - [x] `XGROUP CREATE|SETID|DESTROY|CREATECONSUMER|DELCONSUMER ...` - Manage stream consumer groups and consumers
 - [x] `XREADGROUP GROUP group consumer [COUNT count] [BLOCK milliseconds] [NOACK] STREAMS key [key ...] id [id ...]` - Read entries through a consumer group and track pending delivery
 - [x] `XACK key group ID [ID ...]` - Acknowledge pending stream entries

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -16,7 +16,14 @@ import {
 } from '../core/redis-error'
 import { RedisResult } from '../core/redis-result'
 import { RedisValue } from '../core/redis-value'
-import { array, bulk, integer, ok, simpleString } from './helpers'
+import {
+  array,
+  bulk,
+  integer,
+  ok,
+  parseIntegerToken,
+  simpleString,
+} from './helpers'
 import { commandSubcommandInfo } from './introspection'
 
 const VALKEY_REDIS_COMPAT_VERSION = '7.2.4'
@@ -245,7 +252,7 @@ function formatClientLine(session: RedisClientSession): string {
     'fd=0',
     `name=${name}`,
     `db=${session.selectedDatabase}`,
-    'age=0',
+    `age=${clientAgeSeconds(session)}`,
     'idle=0',
     `flags=${clientFlags(session)}`,
     `sub=${session.pubsubChannelCount}`,
@@ -284,6 +291,97 @@ function clientFlags(session: RedisClientSession): string {
     flags += 'e'
   }
   return flags
+}
+
+type ClientKillOptions = {
+  id?: number
+  maxAgeSeconds?: number
+  skipMe: boolean
+}
+
+function clientAgeSeconds(session: RedisClientSession): number {
+  return Math.max(0, Math.floor((Date.now() - session.connectedAtMs) / 1000))
+}
+
+function parseClientKillOptions(
+  args: readonly Buffer[],
+  ctx: RedisExecutionContext,
+): ClientKillOptions {
+  if (args.length === 0) {
+    throw new WrongNumberOfArgumentsError('client|kill')
+  }
+
+  const options: ClientKillOptions = { skipMe: true }
+
+  for (let i = 0; i < args.length; i++) {
+    const option = args[i].toString().toLowerCase()
+
+    if (option === 'id') {
+      const value = args[++i]
+      if (!value) {
+        throw new RedisSyntaxError()
+      }
+      options.id = parseIntegerToken(value)
+      continue
+    }
+
+    if (option === 'maxage') {
+      if (!ctx.server.profile.has('client.kill.maxage')) {
+        throw new RedisSyntaxError()
+      }
+
+      const value = args[++i]
+      if (!value) {
+        throw new RedisSyntaxError()
+      }
+
+      options.maxAgeSeconds = parseIntegerToken(value)
+      if (options.maxAgeSeconds < 0) {
+        throw new RedisCommandError('value is out of range')
+      }
+      continue
+    }
+
+    if (option === 'skipme') {
+      const value = args[++i]?.toString().toLowerCase()
+      if (value === 'yes') {
+        options.skipMe = true
+        continue
+      }
+      if (value === 'no') {
+        options.skipMe = false
+        continue
+      }
+      throw new RedisSyntaxError()
+    }
+
+    throw new RedisSyntaxError()
+  }
+
+  return options
+}
+
+function matchesClientKillFilter(
+  session: RedisClientSession,
+  currentSession: RedisClientSession,
+  options: ClientKillOptions,
+): boolean {
+  if (options.skipMe && session === currentSession) {
+    return false
+  }
+
+  if (options.id !== undefined && getClientId(session) !== options.id) {
+    return false
+  }
+
+  if (
+    options.maxAgeSeconds !== undefined &&
+    clientAgeSeconds(session) < options.maxAgeSeconds
+  ) {
+    return false
+  }
+
+  return true
 }
 
 const HELLO_NOAUTH_MESSAGE =
@@ -486,6 +584,7 @@ export const clientCommand = defineCommand({
     subcommands: [
       commandSubcommandInfo('client|id', 2),
       commandSubcommandInfo('client|info', 2),
+      commandSubcommandInfo('client|kill', -3),
       commandSubcommandInfo('client|list', 2),
       commandSubcommandInfo('client|getname', 2),
       commandSubcommandInfo('client|setname', 3),
@@ -543,6 +642,29 @@ export const clientCommand = defineCommand({
       throw new RedisSyntaxError()
     }
 
+    if (subcommand === 'kill') {
+      const options = parseClientKillOptions(args.args, ctx)
+      const victims = ctx.server
+        .getConnectedClients()
+        .filter(session =>
+          matchesClientKillFilter(session, ctx.session, options),
+        )
+
+      for (const victim of victims) {
+        if (victim !== ctx.session) {
+          victim.disconnect('client kill')
+        }
+      }
+
+      if (!victims.includes(ctx.session)) {
+        return integer(victims.length)
+      }
+
+      return RedisResult.create(RedisValue.integer(victims.length), {
+        afterReply: () => ctx.session.disconnect('client kill'),
+      })
+    }
+
     if (subcommand === 'id') {
       expectArgCount('client|id', args.args, 0)
       return integer(getClientId(ctx.session))
@@ -568,6 +690,11 @@ export const clientCommand = defineCommand({
         value('ID'),
         value('INFO'),
         value('LIST'),
+        value(
+          ctx.server.profile.has('client.kill.maxage')
+            ? 'KILL [ID <client-id>] [MAXAGE <seconds>] [SKIPME <YES|NO>]'
+            : 'KILL [ID <client-id>] [SKIPME <YES|NO>]',
+        ),
         value('GETNAME'),
         value('SETNAME <connection-name>'),
       ]

--- a/src/commands/keys.ts
+++ b/src/commands/keys.ts
@@ -573,18 +573,19 @@ export const copyCommand = defineCommand({
   },
 })
 
-// SORT key [LIMIT offset count] [ASC | DESC] [ALPHA] [STORE destination]
+// SORT key [BY pattern] [LIMIT offset count] [GET pattern ...] [ASC | DESC]
+//      [ALPHA] [STORE destination]
 // Sorts the elements of a list, set, or zset (zset is sorted by member value,
 // not score). Numeric by default — every element must parse as a double, or
 // the command errors; ALPHA switches to a byte-wise lexicographic sort. STORE
 // writes the sorted result to a destination list and replies with its length.
-// BY/GET external-key pattern dereference is intentionally not implemented yet
-// (tracked as a follow-up); passing either yields a syntax error.
 type SortArgs = {
   key: Buffer
   desc: boolean
   alpha: boolean
   limit?: { offset: number; count: number }
+  by?: Buffer
+  get: Buffer[]
   store?: Buffer
 }
 
@@ -601,10 +602,28 @@ function parseSort(
   let desc = false
   let alpha = false
   let limit: { offset: number; count: number } | undefined
+  let by: Buffer | undefined
+  const get: Buffer[] = []
   let store: Buffer | undefined
 
   while (cursor < input.length) {
     const option = input[cursor]!.toString().toUpperCase()
+
+    if (option === 'BY') {
+      const pattern = input[cursor + 1]
+      if (!pattern) throw new RedisSyntaxError()
+      by = pattern
+      cursor += 2
+      continue
+    }
+
+    if (option === 'GET') {
+      const pattern = input[cursor + 1]
+      if (!pattern) throw new RedisSyntaxError()
+      get.push(pattern)
+      cursor += 2
+      continue
+    }
 
     if (option === 'ASC') {
       desc = false
@@ -647,7 +666,7 @@ function parseSort(
     throw new RedisSyntaxError()
   }
 
-  return { key, desc, alpha, limit, store }
+  return { key, desc, alpha, limit, by, get, store }
 }
 
 function sortSchema(allowStore: boolean) {
@@ -676,16 +695,26 @@ function sortNumericScore(element: Buffer): number {
   return value
 }
 
-function sortElements(elements: readonly Buffer[], args: SortArgs): Buffer[] {
+function sortElements(
+  elements: readonly Buffer[],
+  args: SortArgs,
+  db: RedisDatabase,
+): Buffer[] {
+  if (args.by && isNoSortPattern(args.by)) {
+    return [...elements]
+  }
+
   if (args.alpha) {
-    const sorted = [...elements].sort((a, b) => Buffer.compare(a, b))
+    const sorted = [...elements].sort((a, b) =>
+      Buffer.compare(sortByValue(a, args, db), sortByValue(b, args, db)),
+    )
     if (args.desc) sorted.reverse()
     return sorted
   }
 
   const scored = elements.map(element => ({
     element,
-    score: sortNumericScore(element),
+    score: sortNumericScore(sortByValue(element, args, db)),
   }))
   scored.sort((a, b) => a.score - b.score)
   if (args.desc) scored.reverse()
@@ -706,24 +735,114 @@ function applySortLimit(
 
 function runSort(args: SortArgs, db: RedisDatabase) {
   const source = readSortSource(db, args.key)
-  const sorted = applySortLimit(sortElements(source, args), args.limit)
+  const sorted = applySortLimit(sortElements(source, args, db), args.limit)
+  const output = projectSortOutput(sorted, args, db)
 
   if (args.store) {
     db.delete(args.store)
-    if (sorted.length > 0) {
-      db.updateList(args.store, list => list.pushRight(sorted))
+    if (output.length > 0) {
+      db.updateList(args.store, list =>
+        list.pushRight(output.map(value => value ?? Buffer.alloc(0))),
+      )
     }
-    return integer(sorted.length)
+    return integer(output.length)
   }
 
-  return array(sorted.map(element => RedisValue.bulkString(element)))
+  return array(output.map(element => RedisValue.bulkString(element)))
+}
+
+function sortByValue(
+  element: Buffer,
+  args: SortArgs,
+  db: RedisDatabase,
+): Buffer {
+  if (!args.by) {
+    return element
+  }
+
+  return readSortPattern(db, args.by, element) ?? Buffer.alloc(0)
+}
+
+function projectSortOutput(
+  elements: readonly Buffer[],
+  args: SortArgs,
+  db: RedisDatabase,
+): Array<Buffer | null> {
+  if (args.get.length === 0) {
+    return elements.map(element => Buffer.from(element))
+  }
+
+  const output: Array<Buffer | null> = []
+  for (const element of elements) {
+    for (const pattern of args.get) {
+      output.push(
+        isSelfSortPattern(pattern)
+          ? Buffer.from(element)
+          : readSortPattern(db, pattern, element),
+      )
+    }
+  }
+  return output
+}
+
+function readSortPattern(
+  db: RedisDatabase,
+  pattern: Buffer,
+  element: Buffer,
+): Buffer | null {
+  const key = expandSortPattern(pattern, element)
+  const type = db.getType(key)
+  if (type === null) {
+    return null
+  }
+  if (type !== 'string') {
+    throw new WrongTypeRedisError()
+  }
+  return db.getString(key)
+}
+
+function expandSortPattern(pattern: Buffer, element: Buffer): Buffer {
+  const index = pattern.indexOf(0x2a)
+  if (index === -1) {
+    return Buffer.from(pattern)
+  }
+
+  return Buffer.concat([
+    pattern.subarray(0, index),
+    element,
+    pattern.subarray(index + 1),
+  ])
+}
+
+function isSelfSortPattern(pattern: Buffer): boolean {
+  return pattern.length === 1 && pattern[0] === 0x23
+}
+
+function isNoSortPattern(pattern: Buffer): boolean {
+  return pattern.toString().toLowerCase() === 'nosort'
+}
+
+function sortRoutingKeys(args: SortArgs): Buffer[] {
+  const keys = [args.key]
+  if (args.by && !isNoSortPattern(args.by)) {
+    keys.push(args.by)
+  }
+  for (const pattern of args.get) {
+    if (!isSelfSortPattern(pattern)) {
+      keys.push(pattern)
+    }
+  }
+  if (args.store) {
+    keys.push(args.store)
+  }
+  return keys
 }
 
 export const sortCommand = defineCommand({
   name: 'sort',
   schema: sortSchema(true),
   flags: ['write', 'denyoom'],
-  keys: args => (args.store ? [args.key, args.store] : [args.key]),
+  keys: sortRoutingKeys,
   execute: (args, ctx) => runSort(args, ctx.db),
 })
 
@@ -732,7 +851,7 @@ export const sortRoCommand = defineCommand({
   since: { redis: '7.0.0', valkey: '7.2.0' },
   schema: sortSchema(false),
   flags: ['readonly'],
-  keys: args => [args.key],
+  keys: sortRoutingKeys,
   execute: (args, ctx) => runSort(args, ctx.db),
 })
 

--- a/src/commands/streams/xread.ts
+++ b/src/commands/streams/xread.ts
@@ -13,8 +13,8 @@ import { compareStreamId, MIN_ID, parseExactId } from './ids'
 import { entryToReply } from './replies'
 
 // XREAD [COUNT count] STREAMS key [key ...] id [id ...]
-// `$` means "start after the stream's current last id" (returns nothing on a non-blocking call).
-type XreadStream = { key: Buffer; afterId: StreamId | '$' }
+// `$` means "start after the stream's current last id"; `+` means "return the stream's latest entry".
+type XreadStream = { key: Buffer; afterId: StreamId | '$' | '+' }
 
 function createXreadSchema() {
   return t.custom<{
@@ -72,7 +72,14 @@ function createXreadSchema() {
     for (let i = 0; i < half; i++) {
       const key = input[cursor + i]
       const idTok = input[cursor + half + i].toString()
-      const afterId: StreamId | '$' = idTok === '$' ? '$' : parseExactId(idTok)
+      let afterId: XreadStream['afterId']
+      if (idTok === '$') {
+        afterId = '$'
+      } else if (idTok === '+' && ctx.profile.has('xread.plus-id')) {
+        afterId = '+'
+      } else {
+        afterId = parseExactId(idTok)
+      }
       streams.push({ key, afterId })
     }
 
@@ -80,7 +87,9 @@ function createXreadSchema() {
   })
 }
 
-type ResolvedXreadStream = { key: Buffer; afterId: StreamId }
+type ResolvedXreadStream =
+  | { key: Buffer; kind: 'after'; afterId: StreamId }
+  | { key: Buffer; kind: 'latest' }
 
 function readStreamEntries(
   streams: ResolvedXreadStream[],
@@ -89,15 +98,24 @@ function readStreamEntries(
 ): RedisResult | null {
   const results: [RedisValue, RedisValue][] = []
 
-  for (const { key, afterId } of streams) {
+  for (const request of streams) {
+    const { key } = request
     const stream = ctx.db.getStream(key)
     if (!stream) continue
 
     const entries: RedisValue[] = []
-    for (const entry of stream.entries) {
-      if (compareStreamId(entry.id, afterId) > 0) {
+
+    if (request.kind === 'latest') {
+      const entry = stream.entries.at(-1)
+      if (entry) {
         entries.push(entryToReply(entry.id, entry.fields))
-        if (count !== null && count > 0 && entries.length >= count) break
+      }
+    } else {
+      for (const entry of stream.entries) {
+        if (compareStreamId(entry.id, request.afterId) > 0) {
+          entries.push(entryToReply(entry.id, entry.fields))
+          if (count !== null && count > 0 && entries.length >= count) break
+        }
       }
     }
 
@@ -171,13 +189,20 @@ export const xreadCommand = defineCommand({
 
     // Resolve '$' to the stream's current last ID before any blocking,
     // so entries added after this call (not before) are returned.
-    const resolved: ResolvedXreadStream[] = streams.map(s => ({
-      key: s.key,
-      afterId:
-        s.afterId === '$'
-          ? (ctx.db.getStream(s.key)?.lastId ?? MIN_ID)
-          : s.afterId,
-    }))
+    const resolved: ResolvedXreadStream[] = streams.map(s => {
+      if (s.afterId === '+') {
+        return { key: s.key, kind: 'latest' }
+      }
+
+      return {
+        key: s.key,
+        kind: 'after',
+        afterId:
+          s.afterId === '$'
+            ? (ctx.db.getStream(s.key)?.lastId ?? MIN_ID)
+            : s.afterId,
+      }
+    })
 
     const immediate = readStreamEntries(resolved, count, ctx)
     if (immediate || blockMs === null) return immediate ?? bulk(null)

--- a/src/core/client-session.ts
+++ b/src/core/client-session.ts
@@ -30,6 +30,7 @@ export type ClientSessionOptions = {
   signal?: AbortSignal
   park?: ParkHandler
   turnQueue?: RedisTurnQueue
+  closeConnection?: (reason?: string) => void
 }
 
 /**
@@ -75,6 +76,7 @@ export class ClientSession implements RedisClientSession {
 
   readonly id: string
   readonly clientAddress?: string
+  readonly connectedAtMs: number
   readonly server: RedisServerState
   /** Aborted when the connection closes; threaded into every command's ctx. */
   readonly signal: AbortSignal
@@ -84,6 +86,7 @@ export class ClientSession implements RedisClientSession {
   private readonly nodeRole?: RedisClusterNodeRole
   private readonly parkHandler: ParkHandler
   private readonly turnQueueOverride?: RedisTurnQueue
+  private readonly closeConnection?: (reason?: string) => void
   /**
    * The turn handle of the command currently executing on this session,
    * exposed so {@link executeTransaction} can hand the turn off to another
@@ -117,12 +120,14 @@ export class ClientSession implements RedisClientSession {
   constructor(options: ClientSessionOptions) {
     this.id = options.id ?? `client-${++ClientSession.nextId}`
     this.clientAddress = options.clientAddress
+    this.connectedAtMs = Date.now()
     this.server = options.server
     this.executor = options.executor
     this.selectedDatabaseId = options.database ?? 0
     this.nodeRole = options.nodeRole
     this.parkHandler = options.park ?? createDefaultParkHandler()
     this.turnQueueOverride = options.turnQueue
+    this.closeConnection = options.closeConnection
 
     if (options.signal) {
       this.signal = options.signal
@@ -832,6 +837,15 @@ export class ClientSession implements RedisClientSession {
     this.transactionDirty = false
     this.sessionMode = 'normal'
     this.clusterReadOnlyMode = false
+  }
+
+  disconnect(reason = 'client disconnected'): void {
+    if (this.closeConnection) {
+      this.closeConnection(reason)
+      return
+    }
+
+    this.close()
   }
 
   /**

--- a/src/core/compatibility/feature-gates.ts
+++ b/src/core/compatibility/feature-gates.ts
@@ -9,6 +9,7 @@ export const FEATURE_GATES: Record<FeatureId, VersionGate> = {
   'command.getkeysandflags': { redis: '7.0.0', valkey: '7.2.0' },
   'acl.dryrun': { redis: '7.0.0', valkey: '7.2.0' },
   'client.no-evict': { redis: '7.0.0', valkey: '7.2.0' },
+  'client.kill.maxage': { redis: '7.4.0', valkey: '9.0.0' },
   'client.setinfo': { redis: '7.2.0', valkey: '7.2.0' },
   'client.setinfo.unknown-subcommand-error': {
     redis: '7.0.0',
@@ -22,5 +23,6 @@ export const FEATURE_GATES: Record<FeatureId, VersionGate> = {
   // BITCOUNT/BITPOS BYTE|BIT range modifier — Redis 7.0 / Valkey 7.2.
   'bit.byte-bit-range': { redis: '7.0.0', valkey: '7.2.0' },
   'hscan.novalues': { redis: '7.4.0', valkey: '9.0.0' },
+  'xread.plus-id': { redis: '7.4.0' },
   'cluster.multi-db': { valkey: '9.0.0' },
 }

--- a/src/core/compatibility/profile.ts
+++ b/src/core/compatibility/profile.ts
@@ -13,6 +13,7 @@ export type FeatureId =
   | 'command.getkeysandflags'
   | 'acl.dryrun'
   | 'client.no-evict'
+  | 'client.kill.maxage'
   | 'client.setinfo'
   | 'client.setinfo.unknown-subcommand-error'
   | 'info.multi-section'
@@ -22,6 +23,7 @@ export type FeatureId =
   | 'stream.xautoclaim-deleted-ids'
   | 'bit.byte-bit-range'
   | 'hscan.novalues'
+  | 'xread.plus-id'
   | 'cluster.multi-db'
 
 export interface CompatibilityProfile {

--- a/src/core/execution-policies/cluster-policy.ts
+++ b/src/core/execution-policies/cluster-policy.ts
@@ -1,4 +1,5 @@
 import type { ExecutionPolicy } from './index'
+import type { CommandPlan } from '../command-definition'
 import {
   RedisClusterDownError,
   RedisCommandError,
@@ -70,6 +71,11 @@ export function createClusterPolicy(
         transactionSlots.delete(ctx.session)
       }
 
+      const sortPatternError = getSortClusterPatternError(plan, topology)
+      if (sortPatternError) {
+        throw sortPatternError
+      }
+
       const slot = validateClusterSlot(
         topology,
         options.localNodeId,
@@ -95,6 +101,80 @@ export function createClusterPolicy(
       }
     },
   }
+}
+
+function getSortClusterPatternError(
+  plan: CommandPlan,
+  topology: RedisClusterTopology,
+): RedisCommandError | null {
+  if (plan.definition.name !== 'sort' && plan.definition.name !== 'sort_ro') {
+    return null
+  }
+
+  const args = plan.args as {
+    key?: unknown
+    by?: unknown
+    get?: unknown
+  }
+  if (!Buffer.isBuffer(args.key)) {
+    return null
+  }
+
+  if (
+    Buffer.isBuffer(args.by) &&
+    sortPatternMayCrossSlot(args.key, args.by, topology)
+  ) {
+    return new RedisCommandError(
+      'BY option of SORT denied in Cluster mode when keys formed by the pattern may be in different slots.',
+    )
+  }
+
+  const get = Array.isArray(args.get) ? args.get : []
+  for (const pattern of get) {
+    if (
+      Buffer.isBuffer(pattern) &&
+      !isSelfSortPattern(pattern) &&
+      sortPatternMayCrossSlot(args.key, pattern, topology)
+    ) {
+      return new RedisCommandError(
+        'GET option of SORT denied in Cluster mode when keys formed by the pattern may be in different slots.',
+      )
+    }
+  }
+
+  return null
+}
+
+function sortPatternMayCrossSlot(
+  source: Buffer,
+  pattern: Buffer,
+  topology: RedisClusterTopology,
+): boolean {
+  if (!pattern.includes(0x2a)) {
+    return topology.calculateSlotForKeys([source, pattern]) === -1
+  }
+
+  const sourceTag = hashTag(source)
+  const patternTag = hashTag(pattern)
+  return !sourceTag || !patternTag || !sourceTag.equals(patternTag)
+}
+
+function hashTag(key: Buffer): Buffer | null {
+  const open = key.indexOf(0x7b)
+  if (open === -1) {
+    return null
+  }
+
+  const close = key.indexOf(0x7d, open + 1)
+  if (close <= open + 1) {
+    return null
+  }
+
+  return key.subarray(open + 1, close)
+}
+
+function isSelfSortPattern(pattern: Buffer): boolean {
+  return pattern.length === 1 && pattern[0] === 0x23
 }
 
 function validateClusterSlot(

--- a/src/core/redis-context.ts
+++ b/src/core/redis-context.ts
@@ -29,6 +29,7 @@ export type RedisMonitorContext = {
 export interface RedisClientSession {
   readonly id: string
   readonly clientAddress?: string
+  readonly connectedAtMs: number
   readonly selectedDatabase: number
   readonly mode: ClientSessionMode
   readonly protocolVersion: RespVersion
@@ -63,6 +64,7 @@ export interface RedisClientSession {
   deferPushesUntilAfterReply(): () => void
   registerResponseStreamCleanup(cleanup: () => void): () => void
   resetResponseStreams(): void
+  disconnect(reason?: string): void
 }
 
 export interface RedisExecutionContext {

--- a/src/core/transports/attach-session.ts
+++ b/src/core/transports/attach-session.ts
@@ -44,6 +44,7 @@ export function attachSession(
     executor: opts.executor,
     nodeRole: opts.nodeRole,
     clientAddress: opts.clientAddress,
+    closeConnection: reason => transport.close(reason ?? 'client disconnected'),
   })
 
   const adapter = new Resp2SessionAdapter({

--- a/tests-integration/compatibility/profile-gates.test.ts
+++ b/tests-integration/compatibility/profile-gates.test.ts
@@ -128,6 +128,7 @@ describe(
     test('applies parser, subcommand, and behavior gates', async () => {
       const key = `compat:${profile}:key`
       const hash = `compat:${profile}:hash`
+      const stream = `compat:${profile}:stream`
 
       await send('SET', key, 'v')
       await expectGate(supportsExpireConditions(), 'EXPIRE', key, '10', 'NX')
@@ -171,6 +172,13 @@ describe(
         'lib-name',
         'compat',
       )
+      await expectGate(
+        supportsClientKillMaxAge(),
+        'CLIENT',
+        'KILL',
+        'MAXAGE',
+        '999999',
+      )
       await expectGate(supportsRedis70Commands(), 'CLIENT', 'NO-EVICT', 'ON')
       await expectGate(supportsShardedPubSub(), 'PUBSUB', 'SHARDCHANNELS')
       await expectGate(supportsShardedPubSub(), 'PUBSUB', 'SHARDNUMSUB')
@@ -207,6 +215,9 @@ describe(
         '1',
         `compat:${profile}:zset`,
       )
+
+      await send('XADD', stream, '1-1', 'field', 'value')
+      await expectGate(supportsXreadPlusId(), 'XREAD', 'STREAMS', stream, '+')
 
       await send('HSET', hash, 'field', 'value', 'delete-me', 'gone')
       await expectGate(supportsHscanNoValues(), 'HSCAN', hash, '0', 'NOVALUES')
@@ -514,6 +525,10 @@ function supportsClientSetinfo(): boolean {
   return !['redis-6.2', 'redis-7.0'].includes(profile)
 }
 
+function supportsClientKillMaxAge(): boolean {
+  return ['redis-7.4', 'redis-8.0', 'valkey-9.0'].includes(profile)
+}
+
 function supportsShardedPubSub(): boolean {
   return profile !== 'redis-6.2'
 }
@@ -532,6 +547,10 @@ function supportsHashFieldExpiration(): boolean {
 
 function supportsHscanNoValues(): boolean {
   return ['redis-7.4', 'redis-8.0', 'valkey-9.0'].includes(profile)
+}
+
+function supportsXreadPlusId(): boolean {
+  return ['redis-7.4', 'redis-8.0'].includes(profile)
 }
 
 function supportsHgetex(): boolean {

--- a/tests-integration/ioredis/sort-integration.test.ts
+++ b/tests-integration/ioredis/sort-integration.test.ts
@@ -164,6 +164,84 @@ describe(`SORT / SORT_RO (${testRunner.getBackendName()})`, () => {
     })
   })
 
+  // ------------------------------------------------------------------- BY/GET
+
+  test('SORT BY orders by external keys and GET returns pattern values', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('ids'), '2', '1', '3')
+      await c.set(k('weight:1'), '20')
+      await c.set(k('weight:2'), '10')
+      await c.set(k('weight:3'), '30')
+      await c.set(k('name:1'), 'one')
+      await c.set(k('name:2'), 'two')
+      await c.set(k('name:3'), 'three')
+
+      assert.deepStrictEqual(
+        await c.sort(k('ids'), 'BY', k('weight:*'), 'GET', k('name:*')),
+        ['two', 'one', 'three'],
+      )
+    })
+  })
+
+  test('SORT GET # returns source elements and missing pattern values as null', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('ids'), '2', '1', '3')
+      await c.set(k('weight:1'), '20')
+      await c.set(k('weight:2'), '10')
+      await c.set(k('weight:3'), '30')
+
+      assert.deepStrictEqual(
+        await c.sort(
+          k('ids'),
+          'BY',
+          k('weight:*'),
+          'GET',
+          '#',
+          'GET',
+          k('missing:*'),
+        ),
+        ['2', null, '1', null, '3', null],
+      )
+    })
+  })
+
+  test('SORT_RO supports BY and GET external patterns', async () => {
+    await withOps(async (c, k) => {
+      await c.rpush(k('ids'), 'a', 'b')
+      await c.set(k('weight:a'), '2')
+      await c.set(k('weight:b'), '1')
+      await c.set(k('name:a'), 'alpha')
+      await c.set(k('name:b'), 'bravo')
+
+      assert.deepStrictEqual(
+        await c.sort_ro(k('ids'), 'BY', k('weight:*'), 'GET', k('name:*')),
+        ['bravo', 'alpha'],
+      )
+    })
+  })
+
+  test('SORT rejects BY or GET patterns that hash to a different slot', async () => {
+    await withOps(async (c, k) => {
+      const otherTag = `{sort-other:${randomKey()}}`
+      await c.rpush(k('ids'), '1')
+      await c.set(k('weight:1'), '1')
+
+      await assert.rejects(
+        () => c.sort(k('ids'), 'BY', `${otherTag}:weight:*`),
+        errorWithMessage(
+          'ERR BY option of SORT denied in Cluster mode when keys formed by the pattern may be in different slots.',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          c.sort(k('ids'), 'BY', k('weight:*'), 'GET', `${otherTag}:name:*`),
+        errorWithMessage(
+          'ERR GET option of SORT denied in Cluster mode when keys formed by the pattern may be in different slots.',
+        ),
+      )
+    })
+  })
+
   // --------------------------------------------------------------- edge cases
 
   test('SORT on a missing key returns an empty array', async () => {

--- a/tests-integration/ioredis/stream/read.test.ts
+++ b/tests-integration/ioredis/stream/read.test.ts
@@ -139,6 +139,38 @@ describe(`Stream Commands Integration (${testRunner.getBackendName()})`, () => {
     }
   })
 
+  test('XREAD with + id returns the last entry from each stream', async () => {
+    const tag = Math.random().toString(36).substring(2, 8)
+    const key1 = `{${tag}}latest-a`
+    const key2 = `{${tag}}latest-b`
+    const node = await connectToSlotOwner(redisClient!, key1)
+
+    try {
+      await node.xadd(key1, '1-1', 'f', 'old-a')
+      await node.xadd(key1, '2-1', 'f', 'new-a')
+      await node.xadd(key2, '1-1', 'f', 'old-b')
+      await node.xadd(key2, '3-1', 'f', 'new-b')
+
+      const result = (await node.xread(
+        'COUNT',
+        2,
+        'STREAMS',
+        key1,
+        key2,
+        '+',
+        '+',
+      )) as [string, [string, string[]][]][]
+
+      assert.deepStrictEqual(result, [
+        [key1, [['2-1', ['f', 'new-a']]]],
+        [key2, [['3-1', ['f', 'new-b']]]],
+      ])
+    } finally {
+      await node.del(key1, key2)
+      node.disconnect()
+    }
+  })
+
   test('XREAD on a missing key returns null', async () => {
     const key = randomKey()
     const node = await connectToSlotOwner(redisClient!, key)

--- a/tests-integration/node-redis/sort-integration.test.ts
+++ b/tests-integration/node-redis/sort-integration.test.ts
@@ -203,6 +203,82 @@ describe(`SORT / SORT_RO (node-redis, ${testRunner.getBackendName()})`, () => {
     })
   })
 
+  // ------------------------------------------------------------------- BY/GET
+
+  test('SORT BY orders by external keys and GET returns pattern values', async () => {
+    await withOps(async (c, k) => {
+      await c.rPush(k('ids'), ['2', '1', '3'])
+      await c.set(k('weight:1'), '20')
+      await c.set(k('weight:2'), '10')
+      await c.set(k('weight:3'), '30')
+      await c.set(k('name:1'), 'one')
+      await c.set(k('name:2'), 'two')
+      await c.set(k('name:3'), 'three')
+
+      assert.deepStrictEqual(
+        await c.sort(k('ids'), { BY: k('weight:*'), GET: k('name:*') }),
+        ['two', 'one', 'three'],
+      )
+    })
+  })
+
+  test('SORT GET # returns source elements and missing pattern values as null', async () => {
+    await withOps(async (c, k) => {
+      await c.rPush(k('ids'), ['2', '1', '3'])
+      await c.set(k('weight:1'), '20')
+      await c.set(k('weight:2'), '10')
+      await c.set(k('weight:3'), '30')
+
+      assert.deepStrictEqual(
+        await c.sort(k('ids'), {
+          BY: k('weight:*'),
+          GET: ['#', k('missing:*')],
+        }),
+        ['2', null, '1', null, '3', null],
+      )
+    })
+  })
+
+  test('SORT_RO supports BY and GET external patterns', async () => {
+    await withOps(async (c, k) => {
+      await c.rPush(k('ids'), ['a', 'b'])
+      await c.set(k('weight:a'), '2')
+      await c.set(k('weight:b'), '1')
+      await c.set(k('name:a'), 'alpha')
+      await c.set(k('name:b'), 'bravo')
+
+      assert.deepStrictEqual(
+        await c.sortRo(k('ids'), { BY: k('weight:*'), GET: k('name:*') }),
+        ['bravo', 'alpha'],
+      )
+    })
+  })
+
+  test('SORT rejects BY or GET patterns that hash to a different slot', async () => {
+    await withOps(async (c, k) => {
+      const otherTag = `{sort-other:${randomKey()}}`
+      await c.rPush(k('ids'), '1')
+      await c.set(k('weight:1'), '1')
+
+      await assert.rejects(
+        () => c.sort(k('ids'), { BY: `${otherTag}:weight:*` }),
+        errorWithMessage(
+          'ERR BY option of SORT denied in Cluster mode when keys formed by the pattern may be in different slots.',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          c.sort(k('ids'), {
+            BY: k('weight:*'),
+            GET: `${otherTag}:name:*`,
+          }),
+        errorWithMessage(
+          'ERR GET option of SORT denied in Cluster mode when keys formed by the pattern may be in different slots.',
+        ),
+      )
+    })
+  })
+
   // --------------------------------------------------------------- edge cases
 
   test('SORT on a missing key returns an empty array', async () => {

--- a/tests-integration/node-redis/stream/read.test.ts
+++ b/tests-integration/node-redis/stream/read.test.ts
@@ -115,6 +115,36 @@ describe(`Stream Commands Integration (node-redis, ${testRunner.getBackendName()
     }
   })
 
+  test('XREAD with + id returns the last entry from each stream', async () => {
+    const tag = Math.random().toString(36).substring(2, 8)
+    const key1 = `{${tag}}latest-a`
+    const key2 = `{${tag}}latest-b`
+    const node = await connectToNodeRedisSlotOwner(redisClient, key1)
+
+    try {
+      await node.xAdd(key1, '1-1', { f: 'old-a' })
+      await node.xAdd(key1, '2-1', { f: 'new-a' })
+      await node.xAdd(key2, '1-1', { f: 'old-b' })
+      await node.xAdd(key2, '3-1', { f: 'new-b' })
+
+      const result = await node.xRead(
+        [
+          { key: key1, id: '+' },
+          { key: key2, id: '+' },
+        ],
+        { COUNT: 2 },
+      )
+
+      assert.deepStrictEqual(result, [
+        { name: key1, messages: [{ id: '2-1', message: { f: 'new-a' } }] },
+        { name: key2, messages: [{ id: '3-1', message: { f: 'new-b' } }] },
+      ])
+    } finally {
+      await node.del(key1, key2)
+      node.destroy()
+    }
+  })
+
   test('XREAD on a missing key returns null', async () => {
     const key = randomKey()
     const node = await connectToNodeRedisSlotOwner(redisClient, key)

--- a/tests-integration/raw-tcp/client-kill.test.ts
+++ b/tests-integration/raw-tcp/client-kill.test.ts
@@ -1,0 +1,88 @@
+import { after, before, describe, test } from 'node:test'
+import assert from 'node:assert'
+import { setTimeout as delay } from 'node:timers/promises'
+import { TestRunner } from '../test-config'
+import { commandFrame } from '../utils'
+import { RawRedisConnection } from './raw-connection'
+
+const testRunner = new TestRunner()
+
+describe(
+  `Raw TCP CLIENT KILL (${testRunner.getBackendName()})`,
+  { skip: testRunner.backend === 'real' && 'real Redis backend is 7.2.1' },
+  () => {
+    let port: number
+    const connections: RawRedisConnection[] = []
+
+    before(async () => {
+      port = await testRunner.setupRawStandalone()
+    })
+
+    after(async () => {
+      for (const connection of connections) {
+        connection.close()
+      }
+      connections.length = 0
+      await testRunner.cleanup()
+    })
+
+    async function connect(): Promise<RawRedisConnection> {
+      const connection = await RawRedisConnection.connect('127.0.0.1', port)
+      connections.push(connection)
+      return connection
+    }
+
+    test('CLIENT KILL ID with MAXAGE closes an old matching client', async () => {
+      const killer = await connect()
+      const victim = await connect()
+      const victimId = await clientId(victim)
+
+      await delay(1100)
+
+      killer.write(
+        commandFrame('CLIENT', 'KILL', 'ID', victimId, 'MAXAGE', '0'),
+      )
+      assert.deepStrictEqual(await killer.readRawFrame(), Buffer.from(':1\r\n'))
+      await assertCloses(victim)
+
+      killer.write(commandFrame('PING'))
+      assert.deepStrictEqual(
+        await killer.readRawFrame(),
+        Buffer.from('+PONG\r\n'),
+      )
+    })
+
+    test('CLIENT KILL MAXAGE leaves newer matching clients connected', async () => {
+      const killer = await connect()
+      const victim = await connect()
+      const victimId = await clientId(victim)
+
+      killer.write(
+        commandFrame('CLIENT', 'KILL', 'ID', victimId, 'MAXAGE', '999999'),
+      )
+      assert.deepStrictEqual(await killer.readRawFrame(), Buffer.from(':0\r\n'))
+
+      victim.write(commandFrame('PING'))
+      assert.deepStrictEqual(
+        await victim.readRawFrame(),
+        Buffer.from('+PONG\r\n'),
+      )
+    })
+  },
+)
+
+async function clientId(connection: RawRedisConnection): Promise<string> {
+  connection.write(commandFrame('CLIENT', 'ID'))
+  const frame = (await connection.readRawFrame()).toString()
+  assert.match(frame, /^:\d+\r\n$/)
+  return frame.slice(1, -2)
+}
+
+async function assertCloses(connection: RawRedisConnection): Promise<void> {
+  await Promise.race([
+    connection.readUntilClose(),
+    delay(3000).then(() => {
+      throw new Error('connection did not close')
+    }),
+  ])
+}

--- a/tests/compatibility/profile.test.ts
+++ b/tests/compatibility/profile.test.ts
@@ -91,6 +91,10 @@ describe('compatibility profiles', () => {
 
     const redis72 = resolveCompatibilityProfile('redis-7.2')
     assert.strictEqual(redis72.has('pubsub.resp3-publish-reply-first'), true)
+    assert.strictEqual(redis72.has('client.kill.maxage'), false)
+
+    const redis74 = resolveCompatibilityProfile('redis-7.4')
+    assert.strictEqual(redis74.has('client.kill.maxage'), true)
 
     const valkey72 = resolveCompatibilityProfile({
       flavor: 'valkey',
@@ -103,5 +107,6 @@ describe('compatibility profiles', () => {
     const valkey9 = resolveCompatibilityProfile('valkey-9.0')
     assert.strictEqual(valkey9.has('pubsub.resp3-publish-reply-first'), true)
     assert.strictEqual(valkey9.has('cluster.multi-db'), true)
+    assert.strictEqual(valkey9.has('client.kill.maxage'), true)
   })
 })


### PR DESCRIPTION
Follow-up to #298. The issue is already closed, so this PR intentionally does not use a closing keyword.

## Summary
- add Redis 7.4-gated `XREAD ... +` support for latest stream entry reads
- implement `CLIENT KILL MAXAGE` using per-session connection age and server-side disconnect hooks
- complete `SORT` / `SORT_RO` `BY` and `GET` pattern support, including Redis-style cluster hash-tag validation for pattern-derived keys
- update command docs and compatibility-profile docs

## Root cause
The remaining compatibility gaps were parser/runtime deltas rather than missing command registration: streams did not accept `+` as an XREAD id, sessions did not expose connection age or a disconnect callback for CLIENT KILL filtering, and SORT did not model external pattern keys or their cluster-safety rules.

## Validation
- `npm run build`
- `npm test`
- `npm run test:integration:mock`
- `npm run test:integration:real` (second full run: 1096 pass, 0 fail)
- `npm run lint`
- focused mock and real integration runs for XREAD, SORT/SORT_RO, CLIENT KILL MAXAGE, and compatibility profile gates

Note: the first full real-integration run hit one transient SCAN assertion; the focused SCAN rerun passed after `npm run clean:redis`, and the second full real-integration run passed cleanly.