### PR TITLE
feat: implement HSETEX command (#299)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -142,6 +142,7 @@ Current profile gates:
 | `XREAD ... +` latest-entry stream ID | `redis-7.4+` | unsupported |
 | `CLIENT KILL MAXAGE` | `redis-7.4+` | `valkey-9.0+` |
 | Redis 8.0 hash-field read commands: `HGETDEL`, `HGETEX` | `redis-8.0+` | `HGETEX` in `valkey-9.0`; `HGETDEL` is not modeled for Valkey |
+| Redis 8.0 hash-field write command: `HSETEX` | `redis-8.0+` | `valkey-9.0+` |
 | `COMMAND DOCS` and `COMMAND GETKEYSANDFLAGS` | `redis-7.0+` | `valkey-8.0+` |
 | `CLIENT NO-EVICT` and multi-section `INFO` | `redis-7.0+` | `valkey-8.0+` |
 | `EXPIRE`/`PEXPIRE`/`EXPIREAT`/`PEXPIREAT` `NX`, `XX`, `GT`, `LT` options | `redis-7.0+` | `valkey-8.0+` |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -238,6 +238,7 @@ with `GT` or `LT`.
 - [x] `HDEL key field [field ...]` - Delete one or more hash fields
 - [x] `HGETDEL key FIELDS numfields field [field ...]` - Get and delete one or more hash fields
 - [x] `HGETEX key [EX seconds|PX ms|EXAT unix-s|PXAT unix-ms|PERSIST] FIELDS numfields field [field ...]` - Get one or more hash fields and optionally update their TTLs
+- [x] `HSETEX key [FNX|FXX] [EX seconds|PX ms|EXAT unix-s|PXAT unix-ms|KEEPTTL] FIELDS numfields field value [field value ...]` - Set one or more hash fields and optionally their TTLs
 - [x] `HEXPIRE key seconds [NX|XX|GT|LT] FIELDS numfields field [field ...]` - Set hash-field TTLs in seconds
 - [x] `HPEXPIRE key milliseconds [NX|XX|GT|LT] FIELDS numfields field [field ...]` - Set hash-field TTLs in milliseconds
 - [x] `HEXPIREAT key unix-time-seconds [NX|XX|GT|LT] FIELDS numfields field [field ...]` - Set hash-field expiration timestamps in seconds

--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -18,6 +18,7 @@ import {
 } from '../core/redis-error'
 import { RedisResult } from '../core/redis-result'
 import { RedisValue } from '../core/redis-value'
+import type { RedisHashData } from '../state'
 import type { TrackedHashData } from '../state/tracked-values'
 import {
   array,
@@ -49,6 +50,7 @@ type HashExpireMode =
 const HASH_FIELD_EXPIRATION_SINCE = { redis: '7.4.0', valkey: '9.0.0' } as const
 const HGETEX_SINCE = { redis: '8.0.0', valkey: '9.0.0' } as const
 const HGETDEL_SINCE = { redis: '8.0.0', valkey: '9.1.0' } as const
+const HSETEX_SINCE = { redis: '8.0.0', valkey: '9.0.0' } as const
 type HashExpireArgs = {
   key: Buffer
   rawArgs: Buffer[]
@@ -70,6 +72,21 @@ type HgetexArgs = {
   key: Buffer
   expiration: HgetexExpiration
   fields: Buffer[]
+}
+type HsetexCondition = 'FNX' | 'FXX'
+type HsetexExpiration =
+  | { kind: 'clear' }
+  | { kind: 'keepttl' }
+  | { kind: 'set'; mode: HashExpireMode; time: bigint }
+type HsetexPlan =
+  | { kind: 'clear' }
+  | { kind: 'keepttl' }
+  | { kind: 'expireAt'; at: number }
+type HsetexArgs = {
+  key: Buffer
+  condition: HsetexCondition | undefined
+  expiration: HsetexExpiration
+  pairs: FieldValuePair[]
 }
 
 const LONG_MAX = 9223372036854775807n
@@ -241,6 +258,187 @@ function hgetexExpireMode(
   if (token === 'EXAT') return 'unix-seconds'
   if (token === 'PXAT') return 'unix-milliseconds'
   return undefined
+}
+
+function createHsetexSchema() {
+  return t.custom<HsetexArgs>(
+    (input: readonly Buffer[], index: number, ctx: ParseContext) => {
+      const key = input[index]
+      if (!key || input.length - index < 5) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      let cursor = index + 1
+      let condition: HsetexCondition | undefined
+      let expiration: HsetexExpiration = { kind: 'clear' }
+      let expirationSet = false
+
+      // FNX/FXX and the expiration clause may appear in either order, same
+      // as real Redis — keep consuming recognized tokens until FIELDS.
+      while (cursor < input.length) {
+        const token = input[cursor].toString().toUpperCase()
+
+        if (token === 'FNX' || token === 'FXX') {
+          if (condition) {
+            throw new RedisCommandError(
+              'Only one of FXX or FNX arguments can be specified',
+            )
+          }
+          condition = token
+          cursor += 1
+          continue
+        }
+
+        if (token === 'KEEPTTL') {
+          if (expirationSet) {
+            throw new RedisCommandError(
+              'Only one of EX, PX, EXAT, PXAT or KEEPTTL arguments can be specified',
+            )
+          }
+          expiration = { kind: 'keepttl' }
+          expirationSet = true
+          cursor += 1
+          continue
+        }
+
+        const mode = hgetexExpireMode(token)
+        if (mode) {
+          if (expirationSet) {
+            throw new RedisCommandError(
+              'Only one of EX, PX, EXAT, PXAT or KEEPTTL arguments can be specified',
+            )
+          }
+          const timeToken = input[cursor + 1]
+          if (!timeToken) {
+            throw new WrongNumberOfArgumentsError(ctx.commandName)
+          }
+          expiration = {
+            kind: 'set',
+            mode,
+            time: parseHashExpireTime(timeToken),
+          }
+          expirationSet = true
+          cursor += 2
+          continue
+        }
+
+        break
+      }
+
+      const fieldsToken = input[cursor]
+      if (!fieldsToken) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+      if (fieldsToken.toString().toUpperCase() !== 'FIELDS') {
+        throw new RedisCommandError(`unknown argument: ${fieldsToken}`)
+      }
+      cursor += 1
+
+      const fieldCountToken = input[cursor]
+      if (!fieldCountToken) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+      const fieldCount = parseHsetexFieldCount(fieldCountToken)
+      cursor += 1
+
+      const rest = input.slice(cursor)
+      if (BigInt(rest.length) !== fieldCount * 2n) {
+        throw new WrongNumberOfArgumentsError(ctx.commandName)
+      }
+
+      const pairs: FieldValuePair[] = []
+      for (let i = 0; i < rest.length; i += 2) {
+        pairs.push({ field: rest[i], value: rest[i + 1] })
+      }
+
+      return {
+        value: { key, condition, expiration, pairs },
+        nextIndex: input.length,
+      }
+    },
+  )
+}
+
+function parseHsetexFieldCount(token: Buffer): bigint {
+  const raw = token.toString()
+  if (!isIntegerToken(raw)) {
+    throw new RedisCommandError('invalid number of fields')
+  }
+
+  const value = BigInt(raw)
+  if (value < 1n || value > LONG_MAX) {
+    throw new RedisCommandError('invalid number of fields')
+  }
+
+  return value
+}
+
+function hashFieldIsLive(
+  hash: RedisHashData | null,
+  field: Buffer,
+  now: number,
+): boolean {
+  const entry = hash?.fields.get(field.toString('hex'))
+  if (!entry) return false
+  return entry.expiresAt === undefined || entry.expiresAt > now
+}
+
+function resolveHsetexPlan(expiration: HsetexExpiration): HsetexPlan {
+  if (expiration.kind === 'set') {
+    return {
+      kind: 'expireAt',
+      at: hashExpireTimeToTimestamp(expiration.time, expiration.mode, 'hsetex'),
+    }
+  }
+  return expiration
+}
+
+function setexHashFields(
+  args: HsetexArgs,
+  ctx: RedisExecutionContext,
+): RedisResult {
+  // Resolve the target timestamp up front so an invalid expire time is
+  // reported even when the condition would otherwise skip the write,
+  // matching the HGETEX ordering.
+  const plan = resolveHsetexPlan(args.expiration)
+  const now = Date.now()
+
+  if (args.condition) {
+    const existingHash = ctx.db.getHash(args.key)
+    const conditionMet = args.pairs.every(({ field }) => {
+      const exists = hashFieldIsLive(existingHash, field, now)
+      return args.condition === 'FNX' ? !exists : exists
+    })
+    if (!conditionMet) {
+      return integer(0)
+    }
+  }
+
+  let remaining = 0
+  ctx.db.updateHash(args.key, hash => {
+    for (const { field, value } of args.pairs) {
+      if (plan.kind === 'keepttl') {
+        hash.setField(field, value, { forceDirty: true, keepTtl: true })
+        continue
+      }
+
+      hash.setField(field, value, { forceDirty: true })
+      if (plan.kind === 'expireAt') {
+        if (plan.at <= now) {
+          hash.deleteField(field)
+        } else {
+          hash.setFieldExpiration(field, plan.at)
+        }
+      }
+    }
+    remaining = hash.size
+  })
+
+  if (remaining === 0) {
+    ctx.db.delete(args.key)
+  }
+
+  return integer(1)
 }
 
 function persistHashFields(
@@ -738,6 +936,15 @@ export const hgetexCommand = defineCommand({
   execute: getexHashFields,
 })
 
+export const hsetexCommand = defineCommand({
+  name: 'hsetex',
+  since: HSETEX_SINCE,
+  schema: createHsetexSchema(),
+  flags: ['write', 'denyoom', 'fast'],
+  keys: args => [args.key],
+  execute: setexHashFields,
+})
+
 export const hpersistCommand = defineCommand({
   name: 'hpersist',
   since: HASH_FIELD_EXPIRATION_SINCE,
@@ -1055,6 +1262,7 @@ export const hashesCommands = [
   hdelCommand,
   hgetdelCommand,
   hgetexCommand,
+  hsetexCommand,
   hpersistCommand,
   hexpireCommand,
   hpexpireCommand,

--- a/src/commands/hashes.ts
+++ b/src/commands/hashes.ts
@@ -18,7 +18,6 @@ import {
 } from '../core/redis-error'
 import { RedisResult } from '../core/redis-result'
 import { RedisValue } from '../core/redis-value'
-import type { RedisHashData } from '../state'
 import type { TrackedHashData } from '../state/tracked-values'
 import {
   array,
@@ -373,16 +372,6 @@ function parseHsetexFieldCount(token: Buffer): bigint {
   return value
 }
 
-function hashFieldIsLive(
-  hash: RedisHashData | null,
-  field: Buffer,
-  now: number,
-): boolean {
-  const entry = hash?.fields.get(field.toString('hex'))
-  if (!entry) return false
-  return entry.expiresAt === undefined || entry.expiresAt > now
-}
-
 function resolveHsetexPlan(expiration: HsetexExpiration): HsetexPlan {
   if (expiration.kind === 'set') {
     return {
@@ -403,19 +392,21 @@ function setexHashFields(
   const plan = resolveHsetexPlan(args.expiration)
   const now = Date.now()
 
-  if (args.condition) {
-    const existingHash = ctx.db.getHash(args.key)
-    const conditionMet = args.pairs.every(({ field }) => {
-      const exists = hashFieldIsLive(existingHash, field, now)
-      return args.condition === 'FNX' ? !exists : exists
-    })
-    if (!conditionMet) {
-      return integer(0)
-    }
-  }
-
   let remaining = 0
-  ctx.db.updateHash(args.key, hash => {
+  // The condition check and the write share one updateHash call: TrackedHashData
+  // (unlike the raw getHash() result) already knows how to check field
+  // existence with expiry, and skipping any mutating call when the condition
+  // fails means the framework never persists a hash for a previously-missing
+  // key (see keyspace.ts's dirty/committed tracking).
+  const conditionMet = ctx.db.updateHash(args.key, hash => {
+    if (args.condition) {
+      const met = args.pairs.every(({ field }) => {
+        const exists = hash.hasField(field)
+        return args.condition === 'FNX' ? !exists : exists
+      })
+      if (!met) return false
+    }
+
     for (const { field, value } of args.pairs) {
       if (plan.kind === 'keepttl') {
         hash.setField(field, value, { forceDirty: true, keepTtl: true })
@@ -432,7 +423,12 @@ function setexHashFields(
       }
     }
     remaining = hash.size
+    return true
   })
+
+  if (!conditionMet) {
+    return integer(0)
+  }
 
   if (remaining === 0) {
     ctx.db.delete(args.key)

--- a/tests-integration/ioredis/hash/hsetex.test.ts
+++ b/tests-integration/ioredis/hash/hsetex.test.ts
@@ -1,0 +1,407 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { Cluster, Redis } from 'ioredis'
+import { TestRunner } from '../../test-config'
+import { connectToSlotOwner, errorWithMessage, randomKey } from '../../utils'
+
+const testRunner = new TestRunner()
+
+describe(`Hash Commands Integration (${testRunner.getBackendName()})`, () => {
+  let redisClient: Cluster | undefined
+
+  before(async () => {
+    redisClient = await testRunner.setupIoredisCluster('hash-integration')
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  test('HSETEX sets fields and expiration like Redis', async () => {
+    const tag = `{hsetex:${randomKey()}}`
+    const key = `${tag}:hash`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, key)
+
+      // No expiration clause: plain upsert, key created on demand.
+      assert.strictEqual(
+        await directClient.hsetex(key, 'FIELDS', '2', 'f1', 'v1', 'f2', 'v2'),
+        1,
+      )
+      assert.deepStrictEqual(
+        await directClient.httl(key, 'FIELDS', '2', 'f1', 'f2'),
+        [-1, -1],
+      )
+
+      // EX sets a relative TTL.
+      assert.strictEqual(
+        await directClient.hsetex(key, 'EX', '100', 'FIELDS', '1', 'f1', 'v1b'),
+        1,
+      )
+      const ttlSet = (await directClient.httl(
+        key,
+        'FIELDS',
+        '1',
+        'f1',
+      )) as number[]
+      assert.ok(ttlSet[0] > 90 && ttlSet[0] <= 100, `ttl ${ttlSet[0]}`)
+      assert.strictEqual(await directClient.hget(key, 'f1'), 'v1b')
+
+      // Overwriting without an expiration clause clears the field's TTL
+      // (matches real Redis: setting a value on a volatile field removes it).
+      assert.strictEqual(
+        await directClient.hsetex(key, 'FIELDS', '1', 'f1', 'v1c'),
+        1,
+      )
+      assert.deepStrictEqual(
+        await directClient.httl(key, 'FIELDS', '1', 'f1'),
+        [-1],
+      )
+
+      // KEEPTTL retains the existing TTL while updating the value.
+      await directClient.hsetex(key, 'EX', '100', 'FIELDS', '1', 'f1', 'v1d')
+      assert.strictEqual(
+        await directClient.hsetex(key, 'KEEPTTL', 'FIELDS', '1', 'f1', 'v1e'),
+        1,
+      )
+      const ttlKept = (await directClient.httl(
+        key,
+        'FIELDS',
+        '1',
+        'f1',
+      )) as number[]
+      assert.ok(ttlKept[0] > 90 && ttlKept[0] <= 100, `ttl ${ttlKept[0]}`)
+      assert.strictEqual(await directClient.hget(key, 'f1'), 'v1e')
+
+      // PX sets a millisecond TTL.
+      await directClient.hsetex(key, 'PX', '50000', 'FIELDS', '1', 'f2', 'v2b')
+      const pttlSet = (await directClient.hpttl(
+        key,
+        'FIELDS',
+        '1',
+        'f2',
+      )) as number[]
+      assert.ok(pttlSet[0] > 40000 && pttlSet[0] <= 50000, `pttl ${pttlSet[0]}`)
+
+      // EXAT in the past deletes the field immediately (value still set first).
+      assert.strictEqual(
+        await directClient.hsetex(
+          key,
+          'EXAT',
+          '1',
+          'FIELDS',
+          '1',
+          'f2',
+          'gone',
+        ),
+        1,
+      )
+      assert.strictEqual(await directClient.hexists(key, 'f2'), 0)
+
+      // EX 0 also expires immediately.
+      assert.strictEqual(
+        await directClient.hsetex(key, 'EX', '0', 'FIELDS', '1', 'f1', 'gone'),
+        1,
+      )
+      assert.strictEqual(await directClient.hexists(key, 'f1'), 0)
+
+      // Expiring the last field removes the key entirely.
+      const lone = `${tag}:lone`
+      assert.strictEqual(
+        await directClient.hsetex(
+          lone,
+          'EXAT',
+          '1',
+          'FIELDS',
+          '1',
+          'only',
+          'v',
+        ),
+        1,
+      )
+      assert.strictEqual(await directClient.exists(lone), 0)
+    } finally {
+      await directClient?.del(key)
+      directClient?.disconnect()
+    }
+  })
+
+  test('HSETEX FNX/FXX conditions match Redis', async () => {
+    const tag = `{hsetex-cond:${randomKey()}}`
+    const key = `${tag}:hash`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, key)
+      await directClient.hset(key, 'a', '1')
+
+      // FXX on a missing key: no fields exist, nothing set.
+      assert.strictEqual(
+        await directClient.hsetex(
+          `${tag}:nokey`,
+          'FXX',
+          'FIELDS',
+          '1',
+          'f1',
+          'v1',
+        ),
+        0,
+      )
+      assert.strictEqual(await directClient.exists(`${tag}:nokey`), 0)
+
+      // FNX fails if ANY field already exists — nothing is set, not even 'b'.
+      assert.strictEqual(
+        await directClient.hsetex(
+          key,
+          'FNX',
+          'FIELDS',
+          '2',
+          'a',
+          '2',
+          'b',
+          '2',
+        ),
+        0,
+      )
+      assert.deepStrictEqual(await directClient.hgetall(key), { a: '1' })
+
+      // FNX succeeds when none of the fields exist.
+      assert.strictEqual(
+        await directClient.hsetex(key, 'FNX', 'FIELDS', '1', 'b', '2'),
+        1,
+      )
+      assert.strictEqual(await directClient.hget(key, 'b'), '2')
+
+      // FXX fails if ANY field is missing.
+      assert.strictEqual(
+        await directClient.hsetex(
+          key,
+          'FXX',
+          'FIELDS',
+          '2',
+          'a',
+          'x',
+          'c',
+          'x',
+        ),
+        0,
+      )
+      assert.strictEqual(await directClient.hexists(key, 'c'), 0)
+
+      // FXX succeeds when all fields exist.
+      assert.strictEqual(
+        await directClient.hsetex(
+          key,
+          'FXX',
+          'EX',
+          '60',
+          'FIELDS',
+          '1',
+          'a',
+          '9',
+        ),
+        1,
+      )
+      assert.strictEqual(await directClient.hget(key, 'a'), '9')
+
+      // Token order is flexible: expiration clause before the condition.
+      assert.strictEqual(
+        await directClient.hsetex(
+          key,
+          'EX',
+          '60',
+          'FXX',
+          'FIELDS',
+          '1',
+          'a',
+          '10',
+        ),
+        1,
+      )
+      assert.strictEqual(await directClient.hget(key, 'a'), '10')
+    } finally {
+      await directClient?.del(key)
+      directClient?.disconnect()
+    }
+  })
+
+  test('HSETEX errors match Redis', async () => {
+    const tag = `{hsetex-errors:${randomKey()}}`
+    const hashKey = `${tag}:hash`
+    const stringKey = `${tag}:string`
+    let directClient: Redis | undefined
+
+    try {
+      assert.ok(redisClient)
+      directClient = await connectToSlotOwner(redisClient, hashKey)
+      await directClient.hset(hashKey, 'field', 'value')
+      await directClient.set(stringKey, 'value')
+
+      await assert.rejects(
+        () =>
+          directClient?.call('HSETEX', stringKey, 'FIELDS', '1', 'field', 'v'),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
+        () => directClient?.call('HSETEX'),
+        errorWithMessage("ERR wrong number of arguments for 'hsetex' command"),
+      )
+      await assert.rejects(
+        () => directClient?.call('HSETEX', hashKey),
+        errorWithMessage("ERR wrong number of arguments for 'hsetex' command"),
+      )
+      await assert.rejects(
+        () => directClient?.call('HSETEX', hashKey, 'FIELDS', '1'),
+        errorWithMessage("ERR wrong number of arguments for 'hsetex' command"),
+      )
+      // Unrecognized token before FIELDS.
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HSETEX',
+            hashKey,
+            'BOGUS',
+            'FIELDS',
+            '1',
+            'field',
+            'v',
+          ),
+        errorWithMessage('ERR unknown argument: BOGUS'),
+      )
+      // FNX and FXX are mutually exclusive.
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HSETEX',
+            hashKey,
+            'FNX',
+            'FXX',
+            'FIELDS',
+            '1',
+            'field',
+            'v',
+          ),
+        errorWithMessage(
+          'ERR Only one of FXX or FNX arguments can be specified',
+        ),
+      )
+      // Only one expiration clause allowed.
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HSETEX',
+            hashKey,
+            'EX',
+            '60',
+            'KEEPTTL',
+            'FIELDS',
+            '1',
+            'field',
+            'v',
+          ),
+        errorWithMessage(
+          'ERR Only one of EX, PX, EXAT, PXAT or KEEPTTL arguments can be specified',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call('HSETEX', hashKey, 'FIELDS', 'abc', 'field', 'v'),
+        errorWithMessage('ERR invalid number of fields'),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call('HSETEX', hashKey, 'FIELDS', '0', 'field', 'v'),
+        errorWithMessage('ERR invalid number of fields'),
+      )
+      // numfields declared but fewer pairs supplied.
+      await assert.rejects(
+        () =>
+          directClient?.call('HSETEX', hashKey, 'FIELDS', '2', 'field', 'v'),
+        errorWithMessage("ERR wrong number of arguments for 'hsetex' command"),
+      )
+      // More pairs supplied than declared.
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HSETEX',
+            hashKey,
+            'FIELDS',
+            '1',
+            'field',
+            'v',
+            'extra',
+            'v2',
+          ),
+        errorWithMessage("ERR wrong number of arguments for 'hsetex' command"),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HSETEX',
+            hashKey,
+            'EX',
+            'abc',
+            'FIELDS',
+            '1',
+            'field',
+            'v',
+          ),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HSETEX',
+            hashKey,
+            'EX',
+            '-5',
+            'FIELDS',
+            '1',
+            'field',
+            'v',
+          ),
+        errorWithMessage('ERR invalid expire time, must be >= 0'),
+      )
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HSETEX',
+            hashKey,
+            'EXAT',
+            '99999999999',
+            'FIELDS',
+            '1',
+            'field',
+            'v',
+          ),
+        errorWithMessage("ERR invalid expire time in 'hsetex' command"),
+      )
+      // Invalid expire time is reported even when FXX would otherwise skip
+      // (missing key) — the timestamp is resolved before the condition check.
+      await assert.rejects(
+        () =>
+          directClient?.call(
+            'HSETEX',
+            `${tag}:nokey`,
+            'FXX',
+            'EX',
+            '-5',
+            'FIELDS',
+            '1',
+            'field',
+            'v',
+          ),
+        errorWithMessage('ERR invalid expire time, must be >= 0'),
+      )
+    } finally {
+      await directClient?.del(hashKey, stringKey)
+      directClient?.disconnect()
+    }
+  })
+})

--- a/tests-integration/node-redis/hash/hsetex.test.ts
+++ b/tests-integration/node-redis/hash/hsetex.test.ts
@@ -1,0 +1,343 @@
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert'
+import { RedisClientType, RedisClusterType } from 'redis'
+import { TestRunner } from '../../test-config'
+import {
+  connectToNodeRedisSlotOwner,
+  errorWithMessage,
+  flushNodeRedisCluster,
+  randomKey,
+} from '../../utils'
+
+const testRunner = new TestRunner()
+
+describe(`Hash Commands Integration (node-redis, ${testRunner.getBackendName()})`, () => {
+  let redisClient: RedisClusterType
+
+  before(async () => {
+    redisClient = (await testRunner.setupNodeRedisCluster()) as RedisClusterType
+    await flushNodeRedisCluster(redisClient)
+  })
+
+  after(async () => {
+    await testRunner.cleanup()
+  })
+
+  test('HSETEX sets fields and expiration like Redis', async () => {
+    const tag = `{hsetex:${randomKey()}}`
+    const key = `${tag}:hash`
+    let directClient: RedisClientType | undefined
+
+    try {
+      directClient = await connectToNodeRedisSlotOwner(redisClient, key)
+
+      assert.strictEqual(
+        await directClient.hSetEx(key, { f1: 'v1', f2: 'v2' }),
+        1,
+      )
+      assert.deepStrictEqual(
+        await directClient.hTTL(key, ['f1', 'f2']),
+        [-1, -1],
+      )
+
+      assert.strictEqual(
+        await directClient.hSetEx(
+          key,
+          { f1: 'v1b' },
+          { expiration: { type: 'EX', value: 100 } },
+        ),
+        1,
+      )
+      const ttlSet = await directClient.hTTL(key, 'f1')
+      assert.ok(ttlSet[0] > 90 && ttlSet[0] <= 100, `ttl ${ttlSet[0]}`)
+      assert.strictEqual(await directClient.hGet(key, 'f1'), 'v1b')
+
+      // Overwriting without an expiration clause clears the field's TTL.
+      assert.strictEqual(await directClient.hSetEx(key, { f1: 'v1c' }), 1)
+      assert.deepStrictEqual(await directClient.hTTL(key, 'f1'), [-1])
+
+      await directClient.hSetEx(
+        key,
+        { f1: 'v1d' },
+        { expiration: { type: 'EX', value: 100 } },
+      )
+      assert.strictEqual(
+        await directClient.hSetEx(
+          key,
+          { f1: 'v1e' },
+          { expiration: 'KEEPTTL' },
+        ),
+        1,
+      )
+      const ttlKept = await directClient.hTTL(key, 'f1')
+      assert.ok(ttlKept[0] > 90 && ttlKept[0] <= 100, `ttl ${ttlKept[0]}`)
+      assert.strictEqual(await directClient.hGet(key, 'f1'), 'v1e')
+
+      await directClient.hSetEx(
+        key,
+        { f2: 'v2b' },
+        { expiration: { type: 'PX', value: 50000 } },
+      )
+      const pttlSet = await directClient.hpTTL(key, 'f2')
+      assert.ok(pttlSet[0] > 40000 && pttlSet[0] <= 50000, `pttl ${pttlSet[0]}`)
+
+      assert.strictEqual(
+        await directClient.hSetEx(
+          key,
+          { f2: 'gone' },
+          { expiration: { type: 'EXAT', value: 1 } },
+        ),
+        1,
+      )
+      assert.strictEqual(await directClient.hExists(key, 'f2'), 0)
+
+      assert.strictEqual(
+        await directClient.hSetEx(
+          key,
+          { f1: 'gone' },
+          { expiration: { type: 'EX', value: 0 } },
+        ),
+        1,
+      )
+      assert.strictEqual(await directClient.hExists(key, 'f1'), 0)
+
+      const lone = `${tag}:lone`
+      assert.strictEqual(
+        await directClient.hSetEx(
+          lone,
+          { only: 'v' },
+          { expiration: { type: 'EXAT', value: 1 } },
+        ),
+        1,
+      )
+      assert.strictEqual(await directClient.exists(lone), 0)
+    } finally {
+      await directClient?.del(key)
+      directClient?.destroy()
+    }
+  })
+
+  test('HSETEX FNX/FXX conditions match Redis', async () => {
+    const tag = `{hsetex-cond:${randomKey()}}`
+    const key = `${tag}:hash`
+    let directClient: RedisClientType | undefined
+
+    try {
+      directClient = await connectToNodeRedisSlotOwner(redisClient, key)
+      await directClient.hSet(key, { a: '1' })
+
+      assert.strictEqual(
+        await directClient.hSetEx(
+          `${tag}:nokey`,
+          { f1: 'v1' },
+          { mode: 'FXX' },
+        ),
+        0,
+      )
+      assert.strictEqual(await directClient.exists(`${tag}:nokey`), 0)
+
+      assert.strictEqual(
+        await directClient.hSetEx(key, { a: '2', b: '2' }, { mode: 'FNX' }),
+        0,
+      )
+      assert.deepStrictEqual(await directClient.hGetAll(key), { a: '1' })
+
+      assert.strictEqual(
+        await directClient.hSetEx(key, { b: '2' }, { mode: 'FNX' }),
+        1,
+      )
+      assert.strictEqual(await directClient.hGet(key, 'b'), '2')
+
+      assert.strictEqual(
+        await directClient.hSetEx(key, { a: 'x', c: 'x' }, { mode: 'FXX' }),
+        0,
+      )
+      assert.strictEqual(await directClient.hExists(key, 'c'), 0)
+
+      assert.strictEqual(
+        await directClient.hSetEx(
+          key,
+          { a: '9' },
+          { mode: 'FXX', expiration: { type: 'EX', value: 60 } },
+        ),
+        1,
+      )
+      assert.strictEqual(await directClient.hGet(key, 'a'), '9')
+    } finally {
+      await directClient?.del(key)
+      directClient?.destroy()
+    }
+  })
+
+  test('HSETEX errors match Redis', async () => {
+    const tag = `{hsetex-errors:${randomKey()}}`
+    const hashKey = `${tag}:hash`
+    const stringKey = `${tag}:string`
+    let directClient: RedisClientType | undefined
+
+    try {
+      directClient = await connectToNodeRedisSlotOwner(redisClient, hashKey)
+      await directClient.hSet(hashKey, { field: 'value' })
+      await directClient.set(stringKey, 'value')
+
+      await assert.rejects(
+        () => directClient!.hSetEx(stringKey, { field: 'v' }),
+        errorWithMessage(
+          'WRONGTYPE Operation against a key holding the wrong kind of value',
+        ),
+      )
+      await assert.rejects(
+        () => directClient!.sendCommand(['HSETEX']),
+        errorWithMessage("ERR wrong number of arguments for 'hsetex' command"),
+      )
+      await assert.rejects(
+        () => directClient!.sendCommand(['HSETEX', hashKey]),
+        errorWithMessage("ERR wrong number of arguments for 'hsetex' command"),
+      )
+      await assert.rejects(
+        () => directClient!.sendCommand(['HSETEX', hashKey, 'FIELDS', '1']),
+        errorWithMessage("ERR wrong number of arguments for 'hsetex' command"),
+      )
+      await assert.rejects(
+        () =>
+          directClient!.sendCommand([
+            'HSETEX',
+            hashKey,
+            'BOGUS',
+            'FIELDS',
+            '1',
+            'field',
+            'v',
+          ]),
+        errorWithMessage('ERR unknown argument: BOGUS'),
+      )
+      await assert.rejects(
+        () =>
+          directClient!.sendCommand([
+            'HSETEX',
+            hashKey,
+            'FNX',
+            'FXX',
+            'FIELDS',
+            '1',
+            'field',
+            'v',
+          ]),
+        errorWithMessage(
+          'ERR Only one of FXX or FNX arguments can be specified',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          directClient!.sendCommand([
+            'HSETEX',
+            hashKey,
+            'EX',
+            '60',
+            'KEEPTTL',
+            'FIELDS',
+            '1',
+            'field',
+            'v',
+          ]),
+        errorWithMessage(
+          'ERR Only one of EX, PX, EXAT, PXAT or KEEPTTL arguments can be specified',
+        ),
+      )
+      await assert.rejects(
+        () =>
+          directClient!.sendCommand([
+            'HSETEX',
+            hashKey,
+            'FIELDS',
+            'abc',
+            'field',
+            'v',
+          ]),
+        errorWithMessage('ERR invalid number of fields'),
+      )
+      await assert.rejects(
+        () =>
+          directClient!.sendCommand([
+            'HSETEX',
+            hashKey,
+            'FIELDS',
+            '0',
+            'field',
+            'v',
+          ]),
+        errorWithMessage('ERR invalid number of fields'),
+      )
+      await assert.rejects(
+        () =>
+          directClient!.sendCommand([
+            'HSETEX',
+            hashKey,
+            'FIELDS',
+            '2',
+            'field',
+            'v',
+          ]),
+        errorWithMessage("ERR wrong number of arguments for 'hsetex' command"),
+      )
+      await assert.rejects(
+        () =>
+          directClient!.sendCommand([
+            'HSETEX',
+            hashKey,
+            'FIELDS',
+            '1',
+            'field',
+            'v',
+            'extra',
+            'v2',
+          ]),
+        errorWithMessage("ERR wrong number of arguments for 'hsetex' command"),
+      )
+      await assert.rejects(
+        () =>
+          directClient!.sendCommand([
+            'HSETEX',
+            hashKey,
+            'EX',
+            'abc',
+            'FIELDS',
+            '1',
+            'field',
+            'v',
+          ]),
+        errorWithMessage('ERR value is not an integer or out of range'),
+      )
+      await assert.rejects(
+        () =>
+          directClient!.hSetEx(
+            hashKey,
+            { field: 'v' },
+            { expiration: { type: 'EX', value: -5 } },
+          ),
+        errorWithMessage('ERR invalid expire time, must be >= 0'),
+      )
+      await assert.rejects(
+        () =>
+          directClient!.hSetEx(
+            hashKey,
+            { field: 'v' },
+            { expiration: { type: 'EXAT', value: 99999999999 } },
+          ),
+        errorWithMessage("ERR invalid expire time in 'hsetex' command"),
+      )
+      await assert.rejects(
+        () =>
+          directClient!.hSetEx(
+            `${tag}:nokey`,
+            { field: 'v' },
+            { mode: 'FXX', expiration: { type: 'EX', value: -5 } },
+          ),
+        errorWithMessage('ERR invalid expire time, must be >= 0'),
+      )
+    } finally {
+      await directClient?.del([hashKey, stringKey])
+      directClient?.destroy()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `HSETEX key [FNX|FXX] [EX seconds|PX ms|EXAT unix-s|PXAT unix-ms|KEEPTTL] FIELDS numfields field value [field value ...]`, gated `redis-8.0+`/`valkey-9.0+`.
- Matches real Redis 8.0 semantics: `FNX`/`FXX` require all-or-nothing field existence; the condition/expiration tokens may appear in either order; overwriting a field without an expiration clause clears its TTL (like plain `HSET`), `KEEPTTL` retains it, and `EX 0`/past `EXAT`/`PXAT` delete the field immediately; deleting the last field removes the key.
- Error strings (`unknown argument: X`, `Only one of FXX or FNX...`, `Only one of EX, PX, EXAT, PXAT or KEEPTTL...`, `invalid number of fields`, generic wrong-arity for numfields/pair-count mismatches) were verified against a live `redis:8.0` container — several diverge from `HGETEX`'s wording, which is intentional (matches real Redis, not just internal consistency).
- This is part of #299, a large umbrella issue also covering unrelated Redis Stack module families (Search, JSON, Time Series, Bloom, Cuckoo, CMS, Top-K, t-digest, Vector sets) that are out of scope here and left for follow-up issues, per the issue's own acceptance criteria ("track as follow-up sub-issues instead of silently pretending parity"). #299 stays open.

## Test plan
- [x] New ioredis + node-redis integration tests in `tests-integration/{ioredis,node-redis}/hash/hsetex.test.ts` cover: basic set, TTL-clear-on-overwrite, `KEEPTTL`, `EX`/`PX`/`EXAT`/`PXAT` (including immediate-expiry and last-field-removes-key), `FNX`/`FXX` all-or-nothing semantics, flexible token order, and the full error matrix (arity, `WRONGTYPE`, unknown token, mutual exclusion, invalid numfields, numfields/pair mismatch, invalid expire time, ordering of expire-time validation vs. condition).
- [x] Tests pass against real Redis 8.0 (`TEST_BACKEND=real`)
- [x] Tests pass against mock (`TEST_BACKEND=mock`)
- [x] `npm run build`, `npm run lint`, `npm run test:all` all pass (1102/1102 tests)
- [x] `docs/COMMANDS.md` and `docs/API.md` (compatibility gate table) updated