### PR TITLE
feat: publish js-valkey-server alongside js-redis-server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,32 @@ jobs:
       - name: Run unit tests
         run: npm test
 
+  packages:
+    name: package (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [js-redis-server, js-valkey-server]
+    env:
+      NPM_PACKAGE_NAME: ${{ matrix.package }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'npm'
+      - run: npm ci
+      - name: Select npm package identity
+        run: |
+          npm pkg set "name=$NPM_PACKAGE_NAME"
+          npm pkg delete bin
+          npm pkg set "bin.$NPM_PACKAGE_NAME=./dist/cli.js"
+      - name: Verify both module formats and package contents
+        run: |
+          npm run test:package
+          npm pack --dry-run --ignore-scripts
+
   integration:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,12 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [js-redis-server, js-valkey-server]
+    env:
+      NPM_PACKAGE_NAME: ${{ matrix.package }}
 
     permissions:
       contents: read
@@ -27,6 +33,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify release tag matches package version
+        run: node -e 'require("node:assert/strict").equal(process.env.GITHUB_REF_NAME, "v" + require("./package.json").version)'
+
+      - name: Select npm package identity
+        run: |
+          npm pkg set "name=$NPM_PACKAGE_NAME"
+          npm pkg delete bin
+          npm pkg set "bin.$NPM_PACKAGE_NAME=./dist/cli.js"
+
       - name: Build
         run: npm run build
 
@@ -35,7 +50,7 @@ jobs:
 
       - name: Verify dual ESM/CJS package
         # Resolves the built package by name through both the `require` and
-        # `import` conditions for the root and the `js-redis-server/core`
+        # `import` conditions for the root and the selected package's `/core`
         # subpath — guards the exports map and dual output before publish.
         run: npm run test:package
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,23 @@ npm run test:all
 - Update documentation if needed
 - Ensure CI passes before requesting review
 
+## Releasing both npm packages
+
+`js-redis-server` and `js-valkey-server` share this repository, version, source,
+and API. Neither name replaces the other. Keep the checked-in package name
+`js-redis-server`; the release workflow selects the other name and its matching
+CLI in a separate job, after installing dependencies from the shared lockfile.
+
+Update the version in `package.json` and `package-lock.json` together. After CI
+passes, a `v<version>` tag runs both publish jobs. The tag must match the package
+version. The `NPM_TOKEN` secret needs permission to publish **both** names;
+verify access to `js-valkey-server` before the first release.
+
+Each job builds and tests its selected identity, including CommonJS, ESM, and
+`/core`. npm cannot publish two packages atomically: if one job publishes and
+the other fails, rerun only the failed job after resolving the failure. Do not
+deprecate either package or change the GitHub repository/demo URLs.
+
 ## Questions?
 
 Feel free to open an issue for any questions or discussions.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,33 @@ production. Jump to [Use as a Redis mock in tests](#use-as-a-redis-mock-in-tests
 npm install js-redis-server
 ```
 
+Starting with the next release, **0.3.0**, the same implementation is also
+published as `js-valkey-server`. Choose one package; you do not need both:
+
+```bash
+npm install js-valkey-server
+```
+
+Both names share the same version, API, compatibility defaults, and GitHub
+repository. `js-redis-server` remains supported and is not deprecated. The
+repository and browser demo URLs are unchanged.
+
+Both packages export `createRedisMock` and `createValkeyMock`; the latter is an
+alias, not a different engine or default compatibility profile:
+
+```typescript
+import { createValkeyMock } from 'js-valkey-server'
+
+const mock = await createValkeyMock({ compatibility: 'valkey-9.0' })
+// Connect your normal client to mock.url.
+await mock.close()
+```
+
+The `/core` subpath is available under either package name. Each package also
+provides its matching CLI: `npx js-redis-server` or `npx js-valkey-server`.
+Neither package downloads or wraps the official Redis/Valkey binary; the
+server is implemented in JavaScript/TypeScript and Lua uses WebAssembly.
+
 ## Use as a Redis mock in tests
 
 `createRedisMock()` owns the whole lifecycle: it spins up a standalone server

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-redis-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "js-redis-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "cluster-key-slot": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "js-redis-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "In-memory Redis-compatible server implementation in JavaScript, useful for testing and client-agnostic mocks",
   "keywords": [
     "redis",
+    "valkey",
     "resp",
     "server",
     "mock",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -142,6 +142,7 @@ function createLogger(debug = false): Logger {
 
 function printHelp() {
   console.log(`Usage: js-redis-server [options]
+       js-valkey-server [options]
 
 Modes:
   --single               Run a single Redis server (default)

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@
 // Test-mock facade
 export {
   createRedisMock,
+  createValkeyMock,
   createRedisServer,
   type CreateRedisMockOptions,
   type CreateRedisServerOptions,

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -191,6 +191,9 @@ export async function createRedisMock(
   return createTcpStandaloneMock(options)
 }
 
+/** Alternative name for the same factory; compatibility defaults are unchanged. */
+export const createValkeyMock = createRedisMock
+
 async function createTcpStandaloneMock(
   options: CreateRedisMockOptions,
 ): Promise<RedisMock> {

--- a/tests-package/dual-format.test.ts
+++ b/tests-package/dual-format.test.ts
@@ -1,17 +1,20 @@
 import { test, describe, before } from 'node:test'
 import assert from 'node:assert'
 import { createRequire } from 'node:module'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 // Validates the published package end-to-end: the `exports` map, the dual
-// ESM + CJS builds, and the `js-redis-server/core` subpath. Resolution goes
+// ESM + CJS builds, and the `/core` subpath under either npm name. Resolution goes
 // through the package *name* (self-reference), so this exercises the real
 // `exports` conditions a consumer hits — not relative dist paths.
 //
 // Requires `dist/` to exist; run via `npm run test:package` (which builds first).
 
 const require = createRequire(import.meta.url)
+const { name: packageName } = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as { name: string }
 const distIndex = fileURLToPath(new URL('../dist/index.js', import.meta.url))
 
 before(() => {
@@ -23,6 +26,8 @@ before(() => {
 
 async function assertWorkingRoot(pkg: Record<string, unknown>): Promise<void> {
   assert.strictEqual(typeof pkg.createRedisMock, 'function')
+  assert.strictEqual(typeof pkg.createValkeyMock, 'function')
+  assert.strictEqual(pkg.createValkeyMock, pkg.createRedisMock)
   assert.strictEqual(typeof pkg.createRedisServer, 'function')
   assert.strictEqual(typeof pkg.createRedisCluster, 'function')
   assert.strictEqual(typeof pkg.createInMemoryClient, 'function')
@@ -61,25 +66,25 @@ function assertCore(core: Record<string, unknown>): void {
 
 describe('package CJS entry (require)', () => {
   test('root works through the require condition', async () => {
-    await assertWorkingRoot(require('js-redis-server'))
+    await assertWorkingRoot(require(packageName))
   })
 
-  test('js-redis-server/core exposes internals only', () => {
-    assertCore(require('js-redis-server/core'))
+  test(`${packageName}/core exposes internals only`, () => {
+    assertCore(require(`${packageName}/core`))
   })
 })
 
 describe('package ESM entry (import)', () => {
   test('root works through the import condition', async () => {
-    const pkg = (await import('js-redis-server')) as unknown as Record<
+    const pkg = (await import(packageName)) as unknown as Record<
       string,
       unknown
     >
     await assertWorkingRoot(pkg)
   })
 
-  test('js-redis-server/core exposes internals only', async () => {
-    const core = (await import('js-redis-server/core')) as unknown as Record<
+  test(`${packageName}/core exposes internals only`, async () => {
+    const core = (await import(`${packageName}/core`)) as unknown as Record<
       string,
       unknown
     >


### PR DESCRIPTION
## Summary

Replaces the cancelled rename approach (#355) with two supported npm package names from the existing repository: `js-redis-server` and `js-valkey-server`.

- Same source, version (next release: 0.3.0), exports, compatibility defaults, repository and demo.
- Both names export `createRedisMock` and its identical `createValkeyMock` alias.
- CI tests both package identities and their CommonJS/ESM root and `/core` exports.
- The existing tag-triggered release workflow publishes both names, each with its matching CLI, after checking that the tag matches the version.
- No repository rename, old-package deprecation, or native `valkey-server` executable collision.

## Verification

- Red/green check: package tests initially failed because `createValkeyMock` was missing, then passed after the alias/export was added.
- 320 unit tests, lint, formatting and build passed locally using Node 24 for the project toolchain.
- Four package tests passed under each npm identity.
- Built actual tarballs for both names, installed them into a clean consumer directory, and verified CJS/ESM, `/core`, identical aliases, listening mock servers, SET/GET, type declarations, matching 0.3.0 versions, and both CLI entry points.
- Independent read-only review: no blocking findings.

## Release note

This PR does not publish packages or create a release tag. The first shared release requires `NPM_TOKEN` permission for both names. npm publication is not atomic across names; if one publish job fails, resolve its failure and rerun only that job. Neither package is deprecated.
